### PR TITLE
fix: correct project URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,9 @@ dev = [
 kagura = "kagura_memory.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/kagura-ai/memory-cloud"
-Documentation = "https://github.com/kagura-ai/memory-cloud#readme"
-Repository = "https://github.com/kagura-ai/kagura-memory-sdk"
-Issues = "https://github.com/kagura-ai/kagura-memory-sdk/issues"
+Homepage = "https://github.com/kagura-ai/kagura-memory-python-sdk"
+Repository = "https://github.com/kagura-ai/kagura-memory-python-sdk"
+Issues = "https://github.com/kagura-ai/kagura-memory-python-sdk/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Fix Repository URL: `kagura-memory-sdk` → `kagura-memory-python-sdk`
- Fix Homepage/Issues URLs to point to this repo
- Remove dead Documentation link

## Test plan
- [ ] CI passes
- [ ] `uv build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)