### PR TITLE
feat: add create_context and update_context

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -257,14 +257,90 @@ def forget(context_id, memory_id, query, k):
     )
 
 
-@main.command()
-def contexts():
+@main.group()
+def context():
+    """Manage contexts (list, create, update)."""
+    pass
+
+
+@context.command(name="list")
+def context_list():
     """
     List available contexts.
 
     Examples:
-      kagura contexts
+      kagura context list
     """
+    _run_client_command(
+        lambda client, _: client.list_contexts(),
+        context_id=None,
+        needs_context=False,
+    )
+
+
+@context.command(name="create")
+@click.option("--name", "-n", required=True, help="Context name (lowercase, hyphens, underscores)")
+@click.option("--display-name", help="Human-readable display name")
+@click.option("--description", "-d", help="Context description")
+@click.option("--summary", "-s", help="LLM-oriented summary (200-500 chars)")
+@click.option("--usage-guide", help="LLM-oriented usage guidelines")
+@click.option("--public", is_flag=True, default=False, help="Accessible to workspace members")
+def context_create(name, display_name, description, summary, usage_guide, public):
+    """
+    Create a new context.
+
+    Examples:
+      kagura context create -n my-project
+      kagura context create -n dev -d "Development notes" -s "Project dev context"
+    """
+    _run_client_command(
+        lambda client, _: client.create_context(
+            name=name,
+            display_name=display_name,
+            description=description,
+            summary=summary,
+            usage_guide=usage_guide,
+            is_private=not public,
+        ),
+        context_id=None,
+        needs_context=False,
+    )
+
+
+@context.command(name="update")
+@click.argument("context_id")
+@click.option("--display-name", help="Updated display name")
+@click.option("--description", "-d", help="Updated description")
+@click.option("--summary", "-s", help="Updated LLM-oriented summary")
+@click.option("--usage-guide", help="Updated LLM-oriented usage guidelines")
+def context_update(context_id, display_name, description, summary, usage_guide):
+    """
+    Update a context's settings.
+
+    Examples:
+      kagura context update CTX_UUID -s "Updated summary"
+      kagura context update CTX_UUID --usage-guide "Store only code snippets"
+    """
+    if all(v is None for v in (display_name, description, summary, usage_guide)):
+        raise click.ClickException("At least one update option is required")
+
+    _run_client_command(
+        lambda client, _: client.update_context(
+            context_id=context_id,
+            display_name=display_name,
+            description=description,
+            summary=summary,
+            usage_guide=usage_guide,
+        ),
+        context_id=None,
+        needs_context=False,
+    )
+
+
+# Keep backward compat: kagura contexts → kagura context list
+@main.command()
+def contexts():
+    """List available contexts (alias for 'context list')."""
     _run_client_command(
         lambda client, _: client.list_contexts(),
         context_id=None,

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -328,6 +328,70 @@ class KaguraClient:
             arguments["k"] = k
         return await self._call_tool("forget", arguments)
 
+    async def create_context(
+        self,
+        name: str,
+        display_name: str | None = None,
+        description: str | None = None,
+        summary: str | None = None,
+        usage_guide: str | None = None,
+        is_private: bool = True,
+    ) -> dict[str, Any]:
+        """Create a new context in the current workspace.
+
+        Args:
+            name: Context name (lowercase alphanumeric + hyphen/underscore).
+            display_name: Human-readable display name.
+            description: Context description.
+            summary: LLM-oriented summary (200-500 chars).
+            usage_guide: LLM-oriented memory usage guidelines.
+            is_private: Privacy flag (default: True).
+
+        Returns:
+            Created context dict with id, name, and metadata.
+        """
+        arguments: dict[str, Any] = {"name": name, "is_private": is_private}
+        if display_name is not None:
+            arguments["display_name"] = display_name
+        if description is not None:
+            arguments["description"] = description
+        if summary is not None:
+            arguments["summary"] = summary
+        if usage_guide is not None:
+            arguments["usage_guide"] = usage_guide
+        return await self._call_tool("create_context", arguments)
+
+    async def update_context(
+        self,
+        context_id: str,
+        display_name: str | None = None,
+        description: str | None = None,
+        summary: str | None = None,
+        usage_guide: str | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing context's settings.
+
+        Args:
+            context_id: Context UUID to update.
+            display_name: Updated human-readable display name.
+            description: Updated context description.
+            summary: Updated LLM-oriented summary (max 500 chars).
+            usage_guide: Updated LLM-oriented usage guidelines (max 2000 chars).
+
+        Returns:
+            Updated context dict.
+        """
+        arguments: dict[str, Any] = {"context_id": context_id}
+        if display_name is not None:
+            arguments["display_name"] = display_name
+        if description is not None:
+            arguments["description"] = description
+        if summary is not None:
+            arguments["summary"] = summary
+        if usage_guide is not None:
+            arguments["usage_guide"] = usage_guide
+        return await self._call_tool("update_context", arguments)
+
     async def close(self) -> None:
         """Close the HTTP client."""
         await self._client.aclose()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,3 +97,65 @@ def test_forget_requires_memory_id_or_query():
     result = runner.invoke(main, ["forget", "-c", "ctx"])
     assert result.exit_code != 0
     assert "Either --memory-id or --query" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_context_list(mock_client_cls, mock_config):
+    """context list should work."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.list_contexts.return_value = {"contexts": [{"id": "c1"}]}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "list"])
+    assert result.exit_code == 0
+    assert "c1" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_context_create(mock_client_cls, mock_config):
+    """context create should call create_context."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.create_context.return_value = {"id": "new-uuid", "name": "dev"}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "create", "-n", "dev", "-s", "Dev context"])
+    assert result.exit_code == 0
+    assert "new-uuid" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_context_update(mock_client_cls, mock_config):
+    """context update should call update_context."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.update_context.return_value = {"id": "uuid-1", "summary": "updated"}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "update", "uuid-1", "-s", "updated"])
+    assert result.exit_code == 0
+    assert "updated" in result.output
+
+
+def test_context_update_requires_option():
+    """context update should fail without any update option."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "update", "uuid-1"])
+    assert result.exit_code != 0
+    assert "At least one update option" in result.output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -340,6 +340,75 @@ async def test_session_already_initialized():
     await client.close()
 
 
+# ============================================================================
+# Context management
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_context():
+    """create_context() should call tool with correct arguments."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"id": "uuid-1", "name": "new-ctx"}
+        result = await client.create_context(
+            name="new-ctx",
+            summary="A test context",
+            is_private=False,
+        )
+        assert result["name"] == "new-ctx"
+        tool_name = mock.call_args[0][0]
+        args = mock.call_args[0][1]
+        assert tool_name == "create_context"
+        assert args["name"] == "new-ctx"
+        assert args["summary"] == "A test context"
+        assert args["is_private"] is False
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_context_minimal():
+    """create_context() with only name should not send optional fields."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"id": "uuid-1", "name": "minimal"}
+        await client.create_context(name="minimal")
+        args = mock.call_args[0][1]
+        assert args["name"] == "minimal"
+        assert args["is_private"] is True
+        assert "summary" not in args
+        assert "display_name" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_context():
+    """update_context() should call tool with correct arguments."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"id": "uuid-1", "summary": "updated"}
+        result = await client.update_context(
+            context_id="uuid-1",
+            summary="updated",
+            usage_guide="Store code only",
+        )
+        assert result["summary"] == "updated"
+        tool_name = mock.call_args[0][0]
+        args = mock.call_args[0][1]
+        assert tool_name == "update_context"
+        assert args["context_id"] == "uuid-1"
+        assert args["summary"] == "updated"
+        assert args["usage_guide"] == "Store code only"
+        assert "display_name" not in args
+
+    await client.close()
+
+
 @pytest.mark.asyncio
 async def test_context_manager():
     """async with should return client and close on exit."""


### PR DESCRIPTION
## Summary

- `KaguraClient.create_context(name, display_name?, description?, summary?, usage_guide?, is_private?)` — create via MCP tool
- `KaguraClient.update_context(context_id, display_name?, description?, summary?, usage_guide?)` — update via MCP tool
- CLI: `kagura context create/update/list` command group
- Backward compat: `kagura contexts` alias preserved

Closes #16

## Verified against localhost

| Operation | SDK | CLI |
|-----------|-----|-----|
| create_context | OK | OK |
| update_context | OK | OK |
| list (via context list) | OK | OK |
| contexts (backward compat) | — | OK |

## Test plan

- [x] 92 tests passing (7 new)
- [x] ruff lint clean
- [x] Integration test against localhost:8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)