### PR TITLE
security: pin litellm <1.82.7 due to supply chain compromise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "litellm>=1.50,<2.0",
+    "litellm>=1.50,<1.82.7",
     "pydantic>=2.0.0",
     "httpx>=0.25.0",
     "click>=8.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ wheels = [
 
 [[package]]
 name = "kagura-memory"
-version = "0.2.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -849,7 +849,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
-    { name = "litellm", specifier = ">=1.50,<2.0" },
+    { name = "litellm", specifier = ">=1.50,<1.82.7" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },


### PR DESCRIPTION
## Summary

- Pin `litellm>=1.50,<1.82.7` to exclude compromised versions (1.82.7, 1.82.8)
- LiteLLM PyPI was compromised on 2026-03-24 by TeamPCP supply chain attack
- Current SDK uses 1.82.6 (safe), but previous `<2.0` bound could allow upgrade to compromised versions

## Test plan

- [x] `pip show litellm` confirms 1.82.6
- [x] No backdoor artifacts found on system
- [x] `uv lock` resolves successfully
- [x] 144 tests pass

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)