### PR TITLE
feat(prompts): add wago hiragana variants to tags_rules (#61)

### DIFF
--- a/src/kagura_memory/prompts.py
+++ b/src/kagura_memory/prompts.py
@@ -58,6 +58,7 @@ Include category tags and entity tags for searchability.
 - Entity: key terms with writing variations for recall
 - Japanese: include kanji, katakana, hiragana (e.g., ["鯖", "サバ", "さば"])
 - Okurigana variants (e.g., ["引越し", "引っ越し", "ひっこし"])
+- Wago: include hiragana for kanji terms (e.g., ["働き方", "はたらき方"])
 - Tech: abbreviated and full forms (e.g., ["DB", "データベース", "database"])
 </tags_rules>
 


### PR DESCRIPTION
## Summary
- Add wago (和語) hiragana reading guidance to `<tags_rules>`
- Example: `["働き方", "はたらき方"]`

Fixes NOT FOUND for `はたらき方の改革` → `働き方改革` in Japanese search test.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)