### PR TITLE
feat: add bulk_remember() method and CLI command (#67)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -181,6 +181,37 @@ def remember(context_id, summary, content, memory_type, importance, tags):
     _run_client_command(op, context_id)
 
 
+@main.command(name="bulk-remember")
+@click.option("--context-id", "-c", help="Context ID (or set in .kagura.json)")
+@click.option(
+    "--file",
+    "-f",
+    "file_",
+    required=True,
+    type=click.File("r"),
+    help="JSON file with memories array",
+)
+def bulk_remember(context_id, file_):
+    """
+    Store multiple memories from a JSON file (max 100).
+
+    The file should contain a JSON array of memory objects:
+    [{"summary": "...", "content": "...", "type": "note"}, ...]
+
+    Examples:
+      kagura bulk-remember -f memories.json
+      kagura bulk-remember -c dev -f memories.json
+    """
+    memories = json.load(file_)
+    if not isinstance(memories, list):
+        raise click.ClickException("File must contain a JSON array of memories")
+
+    _run_client_command(
+        lambda client, ctx: client.bulk_remember(context_id=ctx, memories=memories),
+        context_id,
+    )
+
+
 @main.command()
 @click.argument("query")
 @click.option("--context-id", "-c", help="Context ID (or set in .kagura.json)")

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -84,13 +84,19 @@ class KaguraClient:
         except httpx.RequestError as e:
             raise KaguraConnectionError(f"Connection failed: {e}") from e
 
-    async def _make_jsonrpc_request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    async def _make_jsonrpc_request(
+        self,
+        method: str,
+        params: dict[str, Any],
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         """
         Make a JSON-RPC 2.0 request to MCP server (DRY: common logic).
 
         Args:
             method: JSON-RPC method name (e.g., "tools/call", "tools/list")
             params: Method parameters
+            timeout: Optional per-request timeout override in seconds
 
         Returns:
             Result dict from JSON-RPC response
@@ -111,7 +117,9 @@ class KaguraClient:
         headers = {"mcp-session-id": self._session_id} if self._session_id else {}
 
         try:
-            response = await self._client.post(self.mcp_url, json=body, headers=headers)
+            response = await self._client.post(
+                self.mcp_url, json=body, headers=headers, timeout=timeout
+            )
             response.raise_for_status()
 
             data = response.json() or {}
@@ -128,13 +136,19 @@ class KaguraClient:
         except httpx.RequestError as e:
             raise KaguraConnectionError(f"Connection failed: {e}") from e
 
-    async def _call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async def _call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
         """
         Call MCP tool via JSON-RPC.
 
         Args:
             tool_name: Tool name (e.g., "remember", "recall")
             arguments: Tool arguments
+            timeout: Optional per-request timeout override in seconds
 
         Returns:
             Tool result parsed from content[0].text
@@ -144,7 +158,9 @@ class KaguraClient:
             KaguraConnectionError: Connection failed
         """
         result = await self._make_jsonrpc_request(
-            method="tools/call", params={"name": tool_name, "arguments": arguments}
+            method="tools/call",
+            params={"name": tool_name, "arguments": arguments},
+            timeout=timeout,
         )
 
         # Parse MCP tool response format
@@ -193,6 +209,31 @@ class KaguraClient:
             arguments["tags"] = tags
 
         return await self._call_tool("remember", arguments)
+
+    async def bulk_remember(
+        self,
+        context_id: str,
+        memories: list[dict[str, Any]],
+        timeout: float = 300.0,
+    ) -> dict[str, Any]:
+        """Store multiple memories in a single call (max 100).
+
+        Args:
+            context_id: Context UUID.
+            memories: List of memory dicts, each with summary, content, type,
+                and optional importance, tags, context_summary.
+            timeout: Request timeout in seconds (default 300s for bulk operations).
+
+        Returns:
+            API response with created_count, failed_count, created, failed.
+        """
+        if len(memories) > 100:
+            raise ValueError(f"Max 100 memories per batch, got {len(memories)}")
+        return await self._call_tool(
+            "bulk_remember",
+            {"context_id": context_id, "memories": memories},
+            timeout=timeout,
+        )
 
     async def recall(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,6 +288,35 @@ def test_remember_with_empty_tags(mock_client_cls, mock_config):
 
 
 @patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_bulk_remember_cli(mock_client_cls, mock_config, tmp_path):
+    """bulk-remember should load file and call bulk_remember."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.bulk_remember.return_value = {
+        "status": "success",
+        "created_count": 2,
+        "failed_count": 0,
+    }
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    f = tmp_path / "memories.json"
+    f.write_text('[{"summary": "a", "content": "b", "type": "note"}]')
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["bulk-remember", "-f", str(f)])
+    assert result.exit_code == 0
+    mock_client.bulk_remember.assert_called_once()
+
+
+@patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.ResourceClient")
 def test_resource_stats(mock_rc_cls, mock_config):
     """resource stats should call get_resource_impact."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -502,6 +502,49 @@ async def test_create_context_minimal():
 
 
 @pytest.mark.asyncio
+async def test_bulk_remember():
+    """bulk_remember() should call tool with memories list and extended timeout."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "success",
+            "created_count": 2,
+            "failed_count": 0,
+            "created": [
+                {"memory_id": "m1", "summary": "first"},
+                {"memory_id": "m2", "summary": "second"},
+            ],
+            "failed": [],
+        }
+        memories = [
+            {"summary": "first", "content": "content 1", "type": "note"},
+            {"summary": "second", "content": "content 2", "type": "decision"},
+        ]
+        result = await client.bulk_remember(context_id="ctx", memories=memories)
+        mock.assert_called_once_with(
+            "bulk_remember",
+            {"context_id": "ctx", "memories": memories},
+            timeout=300.0,
+        )
+        assert result["created_count"] == 2
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_bulk_remember_max_100():
+    """bulk_remember() should reject more than 100 memories."""
+    client = _make_initialized_client()
+
+    memories = [{"summary": f"m{i}", "content": "c", "type": "note"} for i in range(101)]
+    with pytest.raises(ValueError, match="Max 100"):
+        await client.bulk_remember(context_id="ctx", memories=memories)
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_delete_context():
     """delete_context() should call tool with context_id."""
     client = _make_initialized_client()


### PR DESCRIPTION
## Summary
- Add `KaguraClient.bulk_remember(context_id, memories)` — store up to 100 memories in a single MCP call
- Add `kagura bulk-remember -f memories.json` CLI command
- Add per-request timeout override to `_call_tool` / `_make_jsonrpc_request` (300s default for bulk ops)
- Client-side validation rejects >100 memories

## Key design decisions
- **300s timeout**: bulk_remember triggers embedding generation for each memory. With Ollama local models, 100 memories can take several minutes
- **Timeout propagation**: `_make_jsonrpc_request` and `_call_tool` now accept optional `timeout` parameter, passed to `httpx.post(timeout=...)`. Other methods are unaffected (use client default)

## Test plan
- [x] `test_bulk_remember` — verifies correct MCP tool call with timeout
- [x] `test_bulk_remember_max_100` — validates >100 rejection
- [x] `test_bulk_remember_cli` — CLI loads file and calls method
- [x] 205/205 tests passing
- [x] Lint/format/pyright clean

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)