### PR TITLE
feat: add update_memory() method and CLI command (#69)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -238,6 +238,50 @@ def reference(context_id, memory_id):
     )
 
 
+@main.command(name="update-memory")
+@click.option("--context-id", "-c", help="Context ID (or set in .kagura.json)")
+@click.option("--memory-id", "-m", help="Memory UUID to update in-place")
+@click.option("--external-id", help="External ID for upsert lookup")
+@click.option("--summary", "-s", help="Updated summary")
+@click.option("--content", help="Updated content")
+@click.option("--type", "-t", "memory_type", help="Updated memory type")
+@click.option("--importance", "-i", type=float, help="Updated importance 0.0-1.0")
+@click.option("--tags", help="Comma-separated tags")
+def update_memory(
+    context_id, memory_id, external_id, summary, content, memory_type, importance, tags
+):
+    """
+    Update an existing memory or upsert by external ID.
+
+    Use --memory-id for in-place update, or --external-id for upsert.
+
+    Examples:
+      kagura update-memory -m MEM_UUID -s "updated summary"
+      kagura update-memory --external-id ext-key -s "summary" --content "..." -t note
+    """
+    if not memory_id and not external_id:
+        raise click.ClickException("Either --memory-id or --external-id is required")
+    if memory_id and external_id:
+        raise click.ClickException("Provide only one of --memory-id or --external-id")
+
+    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
+    tag_list = tag_list or None
+
+    _run_client_command(
+        lambda client, ctx: client.update_memory(
+            context_id=ctx,
+            memory_id=memory_id,
+            external_id=external_id,
+            summary=summary,
+            content=content,
+            type=memory_type,
+            importance=importance,
+            tags=tag_list,
+        ),
+        context_id,
+    )
+
+
 @main.command()
 @click.option("--context-id", "-c", help="Context ID (or set in .kagura.json)")
 @click.option("--memory-id", "-m", help="Memory ID to delete (specific deletion)")

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -20,6 +20,14 @@ from .setup_claude import run_setup_claude
 # =============================================================================
 
 
+def _parse_tags(tags: str | None) -> list[str] | None:
+    """Parse comma-separated tags string into a list, or None if empty."""
+    if not tags:
+        return None
+    parsed = [t.strip() for t in tags.split(",") if t.strip()]
+    return parsed or None
+
+
 def _run_client_command(
     operation: Callable[[KaguraClient, str], Awaitable[dict[str, Any]]],
     context_id: str | None,
@@ -165,8 +173,7 @@ def remember(context_id, summary, content, memory_type, importance, tags):
       kagura remember -s "FastAPI DI pattern" --content "Use Depends()..."
       kagura remember -c dev -s "OAuth2 setup" --content "..." --tags "auth,oauth"
     """
-    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
-    tag_list = tag_list or None
+    tag_list = _parse_tags(tags)
 
     async def op(client: KaguraClient, ctx: str) -> dict[str, Any]:
         return await client.remember(
@@ -264,8 +271,7 @@ def update_memory(
     if memory_id and external_id:
         raise click.ClickException("Provide only one of --memory-id or --external-id")
 
-    tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else None
-    tag_list = tag_list or None
+    tag_list = _parse_tags(tags)
 
     _run_client_command(
         lambda client, ctx: client.update_memory(

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -310,6 +310,66 @@ class KaguraClient:
         }
         return await self._call_tool("reference", arguments)
 
+    async def update_memory(
+        self,
+        context_id: str,
+        memory_id: str | None = None,
+        external_id: str | None = None,
+        summary: str | None = None,
+        content: str | None = None,
+        type: str | None = None,
+        importance: float | None = None,
+        tags: list[str] | None = None,
+        context_summary: str | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing memory in-place or upsert by external ID.
+
+        Two modes (provide exactly one of memory_id or external_id):
+
+        1. In-place update (memory_id): Modifies specific fields while
+           preserving memory ID, graph edges, and creation timestamp.
+        2. Upsert (external_id): Finds by external resource ID within context.
+           If found, replaces. If not found, creates new.
+           Requires summary, content, and type.
+
+        Args:
+            context_id: Context UUID.
+            memory_id: UUID of memory to update in-place.
+            external_id: External resource ID for upsert lookup.
+            summary: Updated summary (10-500 chars).
+            content: Updated content.
+            type: Updated memory type.
+            importance: Updated importance (0.0-1.0).
+            tags: Updated tags.
+            context_summary: Updated context summary (max 2000 chars).
+
+        Returns:
+            API response with updated memory info.
+        """
+        if not memory_id and not external_id:
+            raise ValueError("Provide exactly one of memory_id or external_id")
+        if memory_id and external_id:
+            raise ValueError("Provide exactly one of memory_id or external_id")
+
+        arguments: dict[str, Any] = {"context_id": context_id}
+        if memory_id is not None:
+            arguments["memory_id"] = memory_id
+        if external_id is not None:
+            arguments["external_id"] = external_id
+        if summary is not None:
+            arguments["summary"] = summary
+        if content is not None:
+            arguments["content"] = content
+        if type is not None:
+            arguments["type"] = type
+        if importance is not None:
+            arguments["importance"] = importance
+        if tags is not None:
+            arguments["tags"] = tags
+        if context_summary is not None:
+            arguments["context_summary"] = context_summary
+        return await self._call_tool("update_memory", arguments)
+
     async def forget(
         self,
         context_id: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,9 +204,7 @@ def test_update_memory_requires_id():
 def test_update_memory_rejects_both_ids():
     """update-memory with both --memory-id and --external-id should fail."""
     runner = CliRunner()
-    result = runner.invoke(
-        main, ["update-memory", "-m", "mem-1", "--external-id", "ext-1"]
-    )
+    result = runner.invoke(main, ["update-memory", "-m", "mem-1", "--external-id", "ext-1"])
     assert result.exit_code != 0
     assert "only one" in result.output.lower()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,6 +201,16 @@ def test_update_memory_requires_id():
     assert "Either --memory-id or --external-id" in result.output
 
 
+def test_update_memory_rejects_both_ids():
+    """update-memory with both --memory-id and --external-id should fail."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["update-memory", "-m", "mem-1", "--external-id", "ext-1"]
+    )
+    assert result.exit_code != 0
+    assert "only one" in result.output.lower()
+
+
 @patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.KaguraClient")
 def test_context_delete(mock_client_cls, mock_config):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,36 @@ def test_context_update_requires_option():
 
 @patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.KaguraClient")
+def test_update_memory_by_id(mock_client_cls, mock_config):
+    """update-memory with --memory-id should call update_memory."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.update_memory.return_value = {"status": "success"}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["update-memory", "-m", "mem-1", "-s", "updated summary"])
+    assert result.exit_code == 0
+    mock_client.update_memory.assert_called_once()
+
+
+def test_update_memory_requires_id():
+    """update-memory without --memory-id or --external-id should fail."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["update-memory", "-s", "test"])
+    assert result.exit_code != 0
+    assert "Either --memory-id or --external-id" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
 def test_context_delete(mock_client_cls, mock_config):
     """context delete should call delete_context with -y flag."""
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from click.testing import CliRunner
 
-from kagura_memory.cli import main
+from kagura_memory.cli import _parse_tags, main
+
+
+def test_parse_tags():
+    """_parse_tags should handle various inputs."""
+    assert _parse_tags(None) is None
+    assert _parse_tags("") is None
+    assert _parse_tags(",,,") is None
+    assert _parse_tags("a, b, c") == ["a", "b", "c"]
+    assert _parse_tags("single") == ["single"]
+    assert _parse_tags(" spaced , tags ") == ["spaced", "tags"]
 
 
 @patch("kagura_memory.cli.load_config")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -514,6 +514,7 @@ async def test_update_memory_by_id():
             summary="updated",
             importance=0.9,
             tags=["new-tag"],
+            context_summary="why this matters",
         )
         args = mock.call_args[0][1]
         assert args["context_id"] == "ctx"
@@ -521,6 +522,7 @@ async def test_update_memory_by_id():
         assert args["summary"] == "updated"
         assert args["importance"] == 0.9
         assert args["tags"] == ["new-tag"]
+        assert args["context_summary"] == "why this matters"
         assert "external_id" not in args
         assert result["status"] == "success"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -502,6 +502,68 @@ async def test_create_context_minimal():
 
 
 @pytest.mark.asyncio
+async def test_update_memory_by_id():
+    """update_memory() with memory_id should pass correct arguments."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"status": "success", "memory_id": "mem-1"}
+        result = await client.update_memory(
+            context_id="ctx",
+            memory_id="mem-1",
+            summary="updated",
+            importance=0.9,
+            tags=["new-tag"],
+        )
+        args = mock.call_args[0][1]
+        assert args["context_id"] == "ctx"
+        assert args["memory_id"] == "mem-1"
+        assert args["summary"] == "updated"
+        assert args["importance"] == 0.9
+        assert args["tags"] == ["new-tag"]
+        assert "external_id" not in args
+        assert result["status"] == "success"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_upsert():
+    """update_memory() with external_id should pass correct arguments."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"status": "success", "memory_id": "mem-new"}
+        await client.update_memory(
+            context_id="ctx",
+            external_id="ext-key",
+            summary="upserted",
+            content="content",
+            type="note",
+        )
+        args = mock.call_args[0][1]
+        assert args["external_id"] == "ext-key"
+        assert args["summary"] == "upserted"
+        assert "memory_id" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_requires_one_id():
+    """update_memory() should reject when neither or both IDs provided."""
+    client = _make_initialized_client()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        await client.update_memory(context_id="ctx")
+
+    with pytest.raises(ValueError, match="exactly one"):
+        await client.update_memory(context_id="ctx", memory_id="m1", external_id="e1")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_delete_context():
     """delete_context() should call tool with context_id."""
     client = _make_initialized_client()


### PR DESCRIPTION
## Summary
- Add `KaguraClient.update_memory()` — two modes:
  - **In-place update** (`memory_id`): partial field update, preserves ID/edges/created_at
  - **Upsert** (`external_id`): find by external resource ID, replace or create
- Add `kagura update-memory` CLI command with `--memory-id` and `--external-id` modes
- Client-side validation: exactly one of memory_id/external_id required

## Verified
- MCP `update_memory` confirmed working: updated tags and importance on existing memory
- `re_embedded: false` when summary/content unchanged (correct behavior)

## Test plan
- [x] `test_update_memory_by_id` — in-place update with correct arguments
- [x] `test_update_memory_upsert` — external_id mode
- [x] `test_update_memory_requires_one_id` — validates neither/both rejection
- [x] `test_update_memory_by_id` (CLI) — CLI calls method correctly
- [x] `test_update_memory_requires_id` (CLI) — CLI rejects missing IDs
- [x] 207/207 tests passing
- [x] Lint/format/pyright clean

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)