### PR TITLE
feat: add is_locked support for context lock/unlock (#71)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -390,15 +390,17 @@ def context_delete(context_id, yes):
 @click.option("--description", "-d", help="Updated description")
 @click.option("--summary", "-s", help="Updated LLM-oriented summary")
 @click.option("--usage-guide", help="Updated LLM-oriented usage guidelines")
-def context_update(context_id, display_name, description, summary, usage_guide):
+@click.option("--lock/--unlock", default=None, help="Lock or unlock the context")
+def context_update(context_id, display_name, description, summary, usage_guide, lock):
     """
     Update a context's settings.
 
     Examples:
       kagura context update CTX_UUID -s "Updated summary"
-      kagura context update CTX_UUID --usage-guide "Store only code snippets"
+      kagura context update CTX_UUID --lock
+      kagura context update CTX_UUID --unlock
     """
-    if all(v is None for v in (display_name, description, summary, usage_guide)):
+    if all(v is None for v in (display_name, description, summary, usage_guide, lock)):
         raise click.ClickException("At least one update option is required")
 
     _run_client_command(
@@ -408,6 +410,7 @@ def context_update(context_id, display_name, description, summary, usage_guide):
             description=description,
             summary=summary,
             usage_guide=usage_guide,
+            is_locked=lock,
         ),
         context_id=None,
         needs_context=False,

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -475,6 +475,7 @@ class KaguraClient:
         usage_guide: str | None = None,
         resource_id: str | None = None,
         is_public: bool | None = None,
+        is_locked: bool | None = None,
     ) -> dict[str, Any]:
         """Update an existing context's settings.
 
@@ -486,6 +487,7 @@ class KaguraClient:
             usage_guide: Updated LLM-oriented usage guidelines (max 2000 chars).
             resource_id: Updated resource identifier for external data ingestion.
             is_public: Updated public visibility (required for resource tokens).
+            is_locked: Lock/unlock context. Locked contexts cannot be deleted.
 
         Returns:
             Updated context dict.
@@ -503,6 +505,8 @@ class KaguraClient:
             arguments["resource_id"] = resource_id
         if is_public is not None:
             arguments["is_public"] = is_public
+        if is_locked is not None:
+            arguments["is_locked"] = is_locked
         return await self._call_tool("update_context", arguments)
 
     async def update_search_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,6 +182,25 @@ def test_context_update_lock(mock_client_cls, mock_config):
     assert call_kwargs["is_locked"] is True
 
 
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_context_update_unlock(mock_client_cls, mock_config):
+    """context update --unlock should pass is_locked=False."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.update_context.return_value = {"id": "uuid-1", "is_locked": False}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "update", "uuid-1", "--unlock"])
+    assert result.exit_code == 0
+    call_kwargs = mock_client.update_context.call_args[1]
+    assert call_kwargs["is_locked"] is False
+
+
 def test_context_update_requires_option():
     """context update should fail without any update option."""
     runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,25 @@ def test_context_update(mock_client_cls, mock_config):
     assert "updated" in result.output
 
 
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_context_update_lock(mock_client_cls, mock_config):
+    """context update --lock should pass is_locked=True."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.update_context.return_value = {"id": "uuid-1", "is_locked": True}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["context", "update", "uuid-1", "--lock"])
+    assert result.exit_code == 0
+    call_kwargs = mock_client.update_context.call_args[1]
+    assert call_kwargs["is_locked"] is True
+
+
 def test_context_update_requires_option():
     """context update should fail without any update option."""
     runner = CliRunner()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -608,6 +608,24 @@ async def test_update_context():
     await client.close()
 
 
+@pytest.mark.asyncio
+async def test_update_context_is_locked():
+    """update_context() should pass is_locked when specified."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"id": "uuid-1", "is_locked": True}
+        await client.update_context(context_id="uuid-1", is_locked=True)
+        args = mock.call_args[0][1]
+        assert args["is_locked"] is True
+
+        await client.update_context(context_id="uuid-1", is_locked=False)
+        args = mock.call_args[0][1]
+        assert args["is_locked"] is False
+
+    await client.close()
+
+
 # ============================================================================
 # Search config
 # ============================================================================


### PR DESCRIPTION
## Summary
- Add `is_locked` parameter to `KaguraClient.update_context()`
- Add `--lock` / `--unlock` flags to `kagura context update` CLI
- Locked contexts cannot be deleted (server returns 409 Conflict)

## Test plan
- [x] `test_update_context_is_locked` — client passes is_locked True/False
- [x] `test_context_update_lock` — CLI --lock passes is_locked=True
- [x] 211/211 tests passing
- [x] Lint/format/pyright clean

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)