### PR TITLE
docs: add CHANGELOG.md linking to GitHub Releases

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -103,6 +103,10 @@ Rules:
 - Omit empty sections (e.g., skip "Bug fixes" if there are none)
 - Keep descriptions concise — one line per item, details go in code examples
 - Reference issue/PR numbers with `#N`
+- **Breaking changes check**: If any commit contains breaking API/MCP changes (field renames, tool removals, endpoint changes), add a `## Migration` section at the top of the release notes with:
+  - What changed (before → after)
+  - What clients/users need to update
+  - Example of the new usage
 
 ### 10. Report
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/releases) for all release notes.


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` that points to GitHub Releases page
- Helps PyPI users find release notes without searching

## Test plan
- [x] File exists and link is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)