### PR TITLE
feat: bump MIN_SERVER_VERSION to 0.14.0 and expose remember/recall pass-through params (#86)

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -220,6 +220,9 @@ class KaguraClient:
         type: str = "note",
         importance: float = 0.5,
         tags: list[str] | None = None,
+        source_uri: str | None = None,
+        linked_memory_ids: list[str] | None = None,
+        linked_source_uris: list[str] | None = None,
     ) -> dict[str, Any]:
         """
         Call remember MCP tool.
@@ -231,11 +234,16 @@ class KaguraClient:
             type: Memory type
             importance: Importance score (0.0-1.0)
             tags: Optional tags
+            source_uri: Origin URI for this memory (e.g. ``file://``,
+                ``https://``, ``vault://``).
+            linked_memory_ids: Existing memory UUIDs to declare as graph
+                edges from this memory.
+            linked_source_uris: Source URIs to resolve into linked memories.
 
         Returns:
             API response with memory_id
         """
-        arguments = {
+        arguments: dict[str, Any] = {
             "context_id": context_id,
             "summary": summary,
             "content": content,
@@ -244,6 +252,12 @@ class KaguraClient:
         }
         if tags:
             arguments["tags"] = tags
+        if source_uri is not None:
+            arguments["source_uri"] = source_uri
+        if linked_memory_ids is not None:
+            arguments["linked_memory_ids"] = linked_memory_ids
+        if linked_source_uris is not None:
+            arguments["linked_source_uris"] = linked_source_uris
 
         return await self._call_tool("remember", arguments)
 

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -253,7 +253,7 @@ class KaguraClient:
             "type": type,
             "importance": importance,
         }
-        if tags:
+        if tags is not None:
             arguments["tags"] = tags
         if source_uri is not None:
             arguments["source_uri"] = source_uri
@@ -724,11 +724,12 @@ class KaguraClient:
         return await self._rest_get("/api/v1/system/info", ServerInfo)
 
     async def check_server_version(self) -> ServerInfo:
-        """Check server version against SDK's minimum requirement.
+        """Check the connected server's version against the SDK's tested minimum.
 
-        Calls ``get_server_info()`` and emits a warning via
-        :mod:`logging` if the server version is below
-        :data:`MIN_SERVER_VERSION`.
+        Advisory only — calls ``get_server_info()`` and logs a warning
+        via :mod:`logging` when the server version is below
+        :data:`MIN_SERVER_VERSION`. Does not raise. Older servers may
+        silently ignore unknown parameters.
 
         Returns:
             ServerInfo from the server.

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -23,8 +23,13 @@ from .models import (
 _T = TypeVar("_T", bound=_BaseModel)
 
 
-MIN_SERVER_VERSION = "0.6.1"
-"""Minimum memory-cloud server version required by this SDK."""
+MIN_SERVER_VERSION = "0.14.0"
+"""Minimum memory-cloud server version this SDK was tested against.
+
+This is the lowest server version where every parameter the SDK exposes
+(remember/recall pass-through fields, resource APIs) is fully supported.
+Connecting to an older server logs a warning but does not raise — older
+servers may silently ignore unknown parameters."""
 
 _MIN_SERVER_VERSION_TUPLE = tuple(int(x) for x in MIN_SERVER_VERSION.split(".")[:3])
 

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -270,6 +270,7 @@ class KaguraClient:
         filters: dict[str, Any] | None = None,
         search_mode: str | None = None,
         context_ids: list[str] | None = None,
+        include_explore_hints: bool = False,
     ) -> dict[str, Any]:
         """
         Call recall MCP tool.
@@ -288,6 +289,10 @@ class KaguraClient:
             search_mode: Search strategy — "hybrid" (default), "semantic", or "keyword"
             context_ids: Search across multiple contexts (2–20 IDs).
                 When provided, ``context_id`` is not required.
+            include_explore_hints: When True, the server includes up to 3
+                graph discovery hints in the response under the
+                ``explore_hints`` key — useful as seeds for a follow-up
+                :meth:`explore` call.
 
         Returns:
             API response with results list
@@ -319,6 +324,8 @@ class KaguraClient:
             if search_mode not in ("hybrid", "semantic", "keyword"):
                 raise ValueError(f"Invalid search_mode: {search_mode!r}")
             arguments["search_mode"] = search_mode
+        if include_explore_hints:
+            arguments["include_explore_hints"] = True
         return await self._call_tool("recall", arguments)
 
     async def list_contexts(self) -> dict[str, Any]:

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -28,8 +28,11 @@ MIN_SERVER_VERSION = "0.14.0"
 
 This is the lowest server version where every parameter the SDK exposes
 (remember/recall pass-through fields, resource APIs) is fully supported.
-Connecting to an older server logs a warning but does not raise — older
-servers may silently ignore unknown parameters."""
+The check is opt-in: callers must explicitly invoke
+:meth:`KaguraClient.check_server_version` to log an advisory warning when
+the connected server is older. Plain ``KaguraClient`` instantiation and
+tool calls never raise on version mismatch, and older servers may
+silently ignore unknown parameters."""
 
 _MIN_SERVER_VERSION_TUPLE = tuple(int(x) for x in MIN_SERVER_VERSION.split(".")[:3])
 
@@ -737,8 +740,9 @@ class KaguraClient:
             return info
         if server_ver < _MIN_SERVER_VERSION_TUPLE:
             logging.getLogger("kagura_memory").warning(
-                "Server version %s is below minimum %s required by this SDK. "
-                "Some features may not work.",
+                "Server version %s is below the SDK's tested minimum %s. "
+                "Some features may not work; older servers may silently "
+                "ignore unknown parameters.",
                 info.version,
                 MIN_SERVER_VERSION,
             )

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -393,6 +393,7 @@ class ResourceEventBatchResponse(BaseModel):
 class ResourceImpactResponse(BaseModel):
     """Resource impact statistics per resource_id."""
 
+    resource_id: str
     token_count: int
     memory_count: int
     current_schema_version: int | None = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -215,6 +215,90 @@ async def test_remember_with_tags():
 
 
 @pytest.mark.asyncio
+async def test_remember_with_source_uri():
+    """remember() should include source_uri when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx", summary="s", content="c", source_uri="file:///foo.txt"
+        )
+        args = mock.call_args[0][1]
+        assert args["source_uri"] == "file:///foo.txt"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_pass_through_keys_absent_when_none():
+    """remember() should not send source_uri / linked_* keys when None."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(context_id="ctx", summary="s", content="c")
+        args = mock.call_args[0][1]
+        assert "source_uri" not in args
+        assert "linked_memory_ids" not in args
+        assert "linked_source_uris" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_linked_memory_ids():
+    """remember() should include linked_memory_ids when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx",
+            summary="s",
+            content="c",
+            linked_memory_ids=["mem-1", "mem-2"],
+        )
+        args = mock.call_args[0][1]
+        assert args["linked_memory_ids"] == ["mem-1", "mem-2"]
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_linked_source_uris():
+    """remember() should include linked_source_uris when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx",
+            summary="s",
+            content="c",
+            linked_source_uris=["vault://x", "vault://y"],
+        )
+        args = mock.call_args[0][1]
+        assert args["linked_source_uris"] == ["vault://x", "vault://y"]
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_empty_linked_memory_ids():
+    """remember() should send linked_memory_ids even when empty list (not None)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(context_id="ctx", summary="s", content="c", linked_memory_ids=[])
+        args = mock.call_args[0][1]
+        assert args["linked_memory_ids"] == []
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_recall_with_rerank():
     """recall() should pass use_rerank when True."""
     client = _make_initialized_client()
@@ -266,6 +350,34 @@ async def test_recall_search_mode_not_sent_when_none():
         await client.recall(context_id="ctx", query="test")
         args = mock.call_args[0][1]
         assert "search_mode" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_recall_with_include_explore_hints():
+    """recall() should send include_explore_hints when True."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": []}
+        await client.recall(context_id="ctx", query="test", include_explore_hints=True)
+        args = mock.call_args[0][1]
+        assert args["include_explore_hints"] is True
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_recall_include_explore_hints_not_sent_by_default():
+    """recall() should not send include_explore_hints when False (the default)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": []}
+        await client.recall(context_id="ctx", query="test")
+        args = mock.call_args[0][1]
+        assert "include_explore_hints" not in args
 
     await client.close()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1468,7 +1468,8 @@ async def test_check_server_version_old(caplog):
         with caplog.at_level(logging.WARNING, logger="kagura_memory"):
             result = await client.check_server_version()
             assert result.version == "0.5.0"
-            assert "below minimum" in caplog.text
+            assert "is below" in caplog.text
+            assert "tested minimum" in caplog.text
 
     await client.close()
 

--- a/tests/test_resource_client.py
+++ b/tests/test_resource_client.py
@@ -320,6 +320,7 @@ async def test_get_resource_impact():
     client = ResourceClient(api_key="test", base_url="https://test.com")
 
     response_data = {
+        "resource_id": "products",
         "token_count": 3,
         "memory_count": 150,
         "current_schema_version": 2,
@@ -331,6 +332,7 @@ async def test_get_resource_impact():
 
         result = await client.get_resource_impact("products")
 
+        assert result.resource_id == "products"
         assert result.token_count == 3
         assert result.memory_count == 150
         assert result.current_schema_version == 2


### PR DESCRIPTION
Closes #86

## Summary
- Bump `MIN_SERVER_VERSION` from `0.6.1` to `0.14.0` and clarify in the docstring that the check is advisory.
- Expose three pass-through kwargs on `KaguraClient.remember()`: `source_uri`, `linked_memory_ids`, `linked_source_uris`.
- Expose `include_explore_hints: bool` on `KaguraClient.recall()` so callers can opt into server-side graph discovery hints.
- Add the missing `resource_id: str` field to `ResourceImpactResponse` so the server's response field stops being silently dropped.

## Implementation notes
- All new kwargs follow the existing `if x is not None: arguments[k] = x` pattern (consistent with `update_memory`, `create_context`, etc.). Empty list is sent verbatim, matching the new-params semantics.
- 7 new unit tests in `tests/test_client.py` cover positive, negative (key-absent), and empty-list paths for each new kwarg.
- `tests/test_resource_client.py::test_get_resource_impact` updated to include `resource_id` in the mock response.
- 5 atomic commits for clean history (squash recommended on merge).

## Verified live against memory.kagura-ai.com (production, server v0.14.0)
A standalone end-to-end verification was run before opening this PR (test resources cleaned up afterwards):

```
✓ A. MIN_SERVER_VERSION matches      (server v0.14.0 connection, no warning)
✓ G. ResourceImpactResponse.resource_id round-trips (verify_86_<ts>)
✓ B. remember(source_uri="vault://...")          → memory created
✓ C. remember(linked_memory_ids=[<uuid>])        → memory + edge created
✓ D. remember(linked_source_uris=["vault://..."]) → memory created
✓ E. recall(include_explore_hints=True)          → 3 explore_hints returned
✓ F. recall() default                            → no explore_hints key
```

Side discovery (out of scope for this PR, filed separately as #89): `ResourceClient.setup_resource()` is incompatible with server v0.14 because it does not create the required Resource entity row. The verification used the server-side MCP `setup_resource` tool as a workaround.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (DX Lead lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/86-feat-feat-bump-min-server-version-to-0-14-0-a.gate1.md`
- `~/.claude/cache/gh-issue-driven/86-feat-feat-bump-min-server-version-to-0-14-0-a.gate2.md`

🤖 Generated via /gh-issue-driven:ship
