### PR TITLE
fix(resource): use atomic MCP setup_resource for v0.14 compat (#89)

### DIFF
--- a/src/kagura_memory/__init__.py
+++ b/src/kagura_memory/__init__.py
@@ -42,6 +42,7 @@ from .models import (
     ResourceEventResponse,
     ResourceImpactResponse,
     ResourceSchemaResponse,
+    ResourceSetupResponse,
     ResourceTokenCreate,
     ResourceTokenCreateResponse,
     ResourceTokenResponse,
@@ -113,6 +114,7 @@ __all__ = [
     "ResourceImpactResponse",
     "FieldDefinition",
     "ResourceSchemaResponse",
+    "ResourceSetupResponse",
     # Exceptions
     "KaguraError",
     "KaguraAuthError",

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -608,6 +608,49 @@ class KaguraClient:
             arguments["is_locked"] = is_locked
         return await self._call_tool("update_context", arguments)
 
+    async def setup_resource(
+        self,
+        resource_id: str,
+        name: str | None = None,
+        summary: str | None = None,
+        description: str | None = None,
+        quota_events_per_hour: int = 1000,
+    ) -> dict[str, Any]:
+        """Atomically create Context + Resource entity + ingestion token.
+
+        Wraps the v0.14 server-side ``setup_resource`` MCP tool, which performs
+        Context creation, Resource entity binding, and token issuance in a
+        single transaction. On failure, no orphan rows are left on the server.
+
+        Args:
+            resource_id: Resource identifier for data ingestion.
+            name: Context name (defaults to ``resource_id`` server-side).
+            summary: Context summary.
+            description: Token description.
+            quota_events_per_hour: Token quota (1-10000).
+
+        Returns:
+            Server response dict with keys: ``context_id``, ``context_name``,
+            ``resource_id``, ``token`` (plaintext, shown once), ``token_id``,
+            ``warning``. Server may include additional fields (e.g. ``status``,
+            ``message``) which callers can ignore.
+
+        Note:
+            Idempotency for repeated calls with the same ``resource_id`` is
+            not guaranteed by this SDK; server-side behavior may evolve.
+        """
+        arguments: dict[str, Any] = {
+            "resource_id": resource_id,
+            "quota_events_per_hour": quota_events_per_hour,
+        }
+        if name is not None:
+            arguments["name"] = name
+        if summary is not None:
+            arguments["summary"] = summary
+        if description is not None:
+            arguments["description"] = description
+        return await self._call_tool("setup_resource", arguments)
+
     async def merge_contexts(
         self,
         source_id: str,

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -353,6 +353,23 @@ class PaginatedResourceTokensResponse(BaseModel):
     offset: int
 
 
+class ResourceSetupResponse(BaseModel):
+    """Atomic resource setup response (server v0.14+).
+
+    Returned by ``ResourceClient.setup_resource()`` and
+    ``KaguraClient.setup_resource()``, which create a Context, Resource entity,
+    and ingestion token in a single transaction. The plaintext ``token`` is
+    shown only once — save it immediately.
+    """
+
+    context_id: str
+    context_name: str
+    resource_id: str
+    token: str
+    token_id: int
+    warning: str | None = None
+
+
 class ResourceEventRequest(BaseModel):
     """Request model for resource event ingestion."""
 

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -22,6 +22,7 @@ from .models import (
     ResourceEventResponse,
     ResourceImpactResponse,
     ResourceSchemaResponse,
+    ResourceSetupResponse,
     ResourceTokenCreate,
     ResourceTokenCreateResponse,
     ResourceTokenResponse,
@@ -257,11 +258,13 @@ class ResourceClient:
         summary: str | None = None,
         description: str | None = None,
         quota_events_per_hour: int = 1000,
-    ) -> ResourceTokenCreateResponse:
-        """Set up a resource for data ingestion in one call.
+    ) -> ResourceSetupResponse:
+        """Atomically set up a resource for data ingestion (server v0.14+).
 
-        Creates a public context, sets its resource_id, and creates a
-        resource token. Requires the client to be created via ``from_mcp_url()``.
+        Calls the server-side atomic ``setup_resource`` MCP tool which creates
+        Context + Resource entity + token in a single transaction. On failure,
+        no orphan Context rows are left on the server. Requires the client to
+        be created via ``from_mcp_url()``.
 
         Args:
             resource_id: Resource identifier for data ingestion.
@@ -271,10 +274,16 @@ class ResourceClient:
             quota_events_per_hour: Token quota (1-10000).
 
         Returns:
-            ResourceTokenCreateResponse with token (shown only once).
+            ResourceSetupResponse with plaintext token (shown only once).
 
         Raises:
             RuntimeError: If client was not created via ``from_mcp_url()``.
+            KaguraAuthError: If the stored Authorization header is missing or malformed.
+
+        Note:
+            Idempotency for repeated calls with the same ``resource_id`` is
+            not guaranteed; server-side behavior may evolve. Avoid retrying
+            setup for an existing ``resource_id`` without first verifying state.
         """
         if not self._mcp_url:
             raise RuntimeError(
@@ -282,24 +291,20 @@ class ResourceClient:
                 "Create client via ResourceClient.from_mcp_url()."
             )
 
-        # Extract API key from httpx Authorization header
         auth = self._client.headers.get("authorization", "")
         if not auth.startswith("Bearer "):
-            raise ValueError("Authorization header missing or invalid")
+            raise KaguraAuthError("Authorization header missing or invalid")
         api_key = auth[7:]
 
-        name = context_name or resource_id
-
         async with KaguraClient(api_key=api_key, mcp_url=self._mcp_url) as mcp:
-            ctx = await mcp.create_context(name=name, summary=summary, is_private=False)
-            ctx_id = ctx["context_id"]
-            await mcp.update_context(context_id=ctx_id, resource_id=resource_id)
-
-        return await self.create_token(
-            resource_id=resource_id,
-            description=description,
-            quota_events_per_hour=quota_events_per_hour,
-        )
+            response = await mcp.setup_resource(
+                resource_id=resource_id,
+                name=context_name,
+                summary=summary,
+                description=description,
+                quota_events_per_hour=quota_events_per_hour,
+            )
+        return ResourceSetupResponse.model_validate(response)
 
     # -------------------------------------------------------------------
     # Resource Stats (Bearer auth)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -745,6 +745,57 @@ async def test_update_context_with_resource_id_and_is_public():
 
 
 @pytest.mark.asyncio
+async def test_setup_resource_basic():
+    """Optional fields must be omitted when None so the server applies its own defaults."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "context_id": "ctx-uuid",
+            "context_name": "products",
+            "resource_id": "products",
+            "token": "kagura_resource_xyz",
+            "token_id": 1,
+        }
+        result = await client.setup_resource(resource_id="products")
+        tool_name = mock.call_args[0][0]
+        args = mock.call_args[0][1]
+        assert tool_name == "setup_resource"
+        assert args["resource_id"] == "products"
+        assert args["quota_events_per_hour"] == 1000
+        assert "name" not in args
+        assert "summary" not in args
+        assert "description" not in args
+        assert result["token"] == "kagura_resource_xyz"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_setup_resource_with_all_args():
+    """setup_resource() should forward all optional args when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {}
+        await client.setup_resource(
+            resource_id="products",
+            name="Product Catalog",
+            summary="All product data",
+            description="Catalog ingestion token",
+            quota_events_per_hour=5000,
+        )
+        args = mock.call_args[0][1]
+        assert args["resource_id"] == "products"
+        assert args["name"] == "Product Catalog"
+        assert args["summary"] == "All product data"
+        assert args["description"] == "Catalog ingestion token"
+        assert args["quota_events_per_hour"] == 5000
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_create_context_minimal():
     """create_context() with only name should not send optional fields."""
     client = _make_initialized_client()

--- a/tests/test_resource_client.py
+++ b/tests/test_resource_client.py
@@ -599,46 +599,83 @@ async def test_connection_error_non_json_body():
 # ============================================================================
 
 
+def _make_mcp_mock(server_response: dict) -> AsyncMock:
+    """Emulate ``async with KaguraClient(...) as mcp`` with a stubbed setup_resource."""
+    mock_mcp = AsyncMock()
+    mock_mcp.setup_resource.return_value = server_response
+    mock_mcp.__aenter__ = AsyncMock(return_value=mock_mcp)
+    mock_mcp.__aexit__ = AsyncMock(return_value=None)
+    return mock_mcp
+
+
 @pytest.mark.asyncio
 async def test_setup_resource():
-    """setup_resource() should create context, set resource_id, and create token."""
+    """All caller-provided args propagate to the atomic MCP tool; response is type-validated."""
     client = ResourceClient.from_mcp_url(api_key="test", mcp_url="http://localhost:8080/mcp")
 
-    token_response = {
-        "id": 1,
+    server_response = {
+        "status": "success",
+        "message": "Resource 'my-res' set up successfully.",
+        "context_id": "ctx-uuid",
+        "context_name": "my-res",
         "resource_id": "my-res",
-        "quota_events_per_hour": 1000,
-        "created_at": "2026-03-29T00:00:00Z",
-        "is_active": True,
-        "status": "active",
         "token": "kagura_resource_abc",
+        "token_id": 42,
+        "warning": "Save this token — it will not be shown again.",
     }
-    mock_resp = _mock_response(201, token_response)
+    mock_mcp = _make_mcp_mock(server_response)
 
-    with (
-        patch("kagura_memory.resource_client.KaguraClient") as mock_mcp_cls,
-        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
-    ):
-        mock_mcp = AsyncMock()
-        mock_mcp.create_context.return_value = {"context_id": "ctx-1"}
-        mock_mcp.update_context.return_value = {"status": "success"}
-        mock_mcp.__aenter__ = AsyncMock(return_value=mock_mcp)
-        mock_mcp.__aexit__ = AsyncMock(return_value=None)
-        mock_mcp_cls.return_value = mock_mcp
-        mock_req.return_value = mock_resp
-
+    with patch("kagura_memory.resource_client.KaguraClient", return_value=mock_mcp):
         result = await client.setup_resource(
             resource_id="my-res",
+            context_name="my-res",
             summary="Test setup",
             description="Setup test token",
+            quota_events_per_hour=2000,
         )
 
-        assert result.token == "kagura_resource_abc"
-        mock_mcp.create_context.assert_called_once()
-        create_kwargs = mock_mcp.create_context.call_args[1]
-        assert create_kwargs["name"] == "my-res"
-        assert create_kwargs["is_private"] is False
-        mock_mcp.update_context.assert_called_once()
+    assert result.token == "kagura_resource_abc"
+    assert result.token_id == 42
+    assert result.context_id == "ctx-uuid"
+    assert result.resource_id == "my-res"
+    assert result.warning == "Save this token — it will not be shown again."
+
+    mock_mcp.setup_resource.assert_called_once_with(
+        resource_id="my-res",
+        name="my-res",
+        summary="Test setup",
+        description="Setup test token",
+        quota_events_per_hour=2000,
+    )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_setup_resource_passes_none_context_name():
+    """Omitting context_name must surface as name=None so the server applies its own default."""
+    client = ResourceClient.from_mcp_url(api_key="test", mcp_url="http://localhost:8080/mcp")
+
+    server_response = {
+        "context_id": "ctx-uuid",
+        "context_name": "auto-named",
+        "resource_id": "auto-named",
+        "token": "kagura_resource_xyz",
+        "token_id": 7,
+    }
+    mock_mcp = _make_mcp_mock(server_response)
+
+    with patch("kagura_memory.resource_client.KaguraClient", return_value=mock_mcp):
+        result = await client.setup_resource(resource_id="auto-named")
+
+    assert result.warning is None
+    mock_mcp.setup_resource.assert_called_once_with(
+        resource_id="auto-named",
+        name=None,
+        summary=None,
+        description=None,
+        quota_events_per_hour=1000,
+    )
 
     await client.close()
 
@@ -656,12 +693,12 @@ async def test_setup_resource_requires_mcp_url():
 
 @pytest.mark.asyncio
 async def test_setup_resource_validates_auth_header():
-    """setup_resource() should raise ValueError if auth header is malformed."""
+    """setup_resource() should raise KaguraAuthError if auth header is malformed."""
     client = ResourceClient.from_mcp_url(api_key="test", mcp_url="http://localhost:8080/mcp")
     # Corrupt the Authorization header
     client._client.headers["authorization"] = "BadFormat"
 
-    with pytest.raises(ValueError, match="Authorization header"):
+    with pytest.raises(KaguraAuthError, match="Authorization header"):
         await client.setup_resource(resource_id="test")
 
     await client.close()


### PR DESCRIPTION
Closes #89

## Summary
- Replace broken 3-step orchestration in `ResourceClient.setup_resource()` (create_context → update_context → create_token) with a single call to the server-side atomic MCP `setup_resource` tool added in memory-cloud v0.14
- Eliminates HTTP 409 errors and orphan Context rows that occurred when the previous flow ran against v0.14+ (the server now requires a Resource entity row that `update_context` did not create)
- Adds `KaguraClient.setup_resource()` as a public MCP method (used internally by `ResourceClient`) for layering consistency with `create_context`/`update_context`
- Adds `ResourceSetupResponse` Pydantic model that maps the server's atomic response shape directly (no field-gap hack)

## Implementation notes
- `ResourceClient.setup_resource()` return type: `ResourceTokenCreateResponse` → `ResourceSetupResponse` (technically breaking, but the only existing caller is the CLI which uses `model_dump_json()` and works unchanged)
- Auth header validation: `ValueError` → `KaguraAuthError` (per python.md "use KaguraError hierarchy" rule)
- 4 round-trips → 1 atomic round-trip (3 SDK + 1 internal `list_contexts` quota check eliminated)
- Idempotency for repeated `resource_id` calls is not guaranteed by this SDK (documented in docstring)
- MCP-only constraint preserved (no REST fallback — server has no atomic REST equivalent)
- Tests: rewrote the existing 3-step REST mock for `setup_resource` to a single MCP `_call_tool` mock, added 3 new tests, extracted `_make_mcp_mock()` helper to deduplicate `__aenter__`/`__aexit__` boilerplate

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/89-fix-fix-resource-resourceclient-setup-resour.gate1.md
- ~/.claude/cache/gh-issue-driven/89-fix-fix-resource-resourceclient-setup-resour.gate2.md

🤖 Generated via /gh-issue-driven:ship
