### PR TITLE
feat(client): add Edge CRUD methods and CLI commands (#84)

### DIFF
--- a/src/kagura_memory/__init__.py
+++ b/src/kagura_memory/__init__.py
@@ -20,6 +20,7 @@ from .models import (
     DuplicateMemoryInfo,
     DuplicatePair,
     DuplicatesResponse,
+    Edge,
     EmbeddingModel,
     EmbeddingModelsResponse,
     EmbeddingStatus,
@@ -115,6 +116,8 @@ __all__ = [
     "DuplicateMemoryInfo",
     "DuplicatePair",
     "DuplicatesResponse",
+    # Edge model
+    "Edge",
     # Resource Token models
     "ResourceTokenCreate",
     "ResourceTokenUpdate",

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -472,6 +472,146 @@ def contexts():
 
 
 # =============================================================================
+# Edge Commands
+# =============================================================================
+
+
+@main.group()
+def edge():
+    """Manage neural memory edges (list, create, update, delete)."""
+    pass
+
+
+@edge.command(name="list")
+@click.argument("context_id")
+@click.argument("memory_id")
+@click.option("--min-weight", type=float, default=0.0, help="Minimum edge weight (0.0-3.0)")
+@click.option(
+    "--type",
+    "edge_types",
+    help="Comma-separated edge types to filter (e.g. 'related_to,depends_on')",
+)
+@click.option(
+    "--limit", type=int, help="Max edges per direction (effective max: 2x limit, dedup'd)"
+)
+def edge_list(context_id, memory_id, min_weight, edge_types, limit):
+    """
+    List edges connected to a memory.
+
+    Examples:
+      kagura edge list CTX_UUID MEM_UUID
+      kagura edge list CTX_UUID MEM_UUID --min-weight 0.5 --type related_to
+    """
+
+    async def op(client: KaguraClient, _ctx: str) -> dict[str, Any]:
+        edges = await client.list_edges(
+            context_id=context_id,
+            memory_id=memory_id,
+            min_weight=min_weight,
+            edge_types=_parse_tags(edge_types),
+            limit=limit,
+        )
+        return {"edges": [e.model_dump() for e in edges], "count": len(edges)}
+
+    _run_client_command(op, context_id=None, needs_context=False)
+
+
+@edge.command(name="create")
+@click.argument("context_id")
+@click.argument("source_id")
+@click.argument("target_id")
+@click.option("--type", "edge_type", default="related_to", help="Edge type (default: related_to)")
+@click.option("--weight", type=float, default=0.5, help="Edge weight 0.0-3.0 (default: 0.5)")
+@click.option(
+    "--confidence", type=float, default=1.0, help="Edge confidence 0.0-1.0 (default: 1.0)"
+)
+def edge_create(context_id, source_id, target_id, edge_type, weight, confidence):
+    """
+    Create or upsert an edge from SOURCE_ID to TARGET_ID.
+
+    If an edge already exists for the same pair, the server applies max-weight
+    UPSERT semantics (existing weight is replaced only when the new weight is
+    higher). Self-loops are rejected.
+
+    Examples:
+      kagura edge create CTX_UUID SRC_UUID TGT_UUID
+      kagura edge create CTX_UUID SRC_UUID TGT_UUID --type depends_on --weight 0.8
+    """
+
+    async def op(client: KaguraClient, _ctx: str) -> dict[str, Any]:
+        result = await client.create_edge(
+            context_id=context_id,
+            source_id=source_id,
+            target_id=target_id,
+            edge_type=edge_type,
+            weight=weight,
+            confidence=confidence,
+        )
+        return result.model_dump()
+
+    _run_client_command(op, context_id=None, needs_context=False)
+
+
+@edge.command(name="update")
+@click.argument("context_id")
+@click.argument("source_id")
+@click.argument("target_id")
+@click.option("--weight", type=float, help="New edge weight 0.0-3.0")
+@click.option("--type", "edge_type", help="New edge type")
+def edge_update(context_id, source_id, target_id, weight, edge_type):
+    """
+    Update an existing edge's weight and/or type.
+
+    At least one of --weight or --type must be provided.
+
+    Examples:
+      kagura edge update CTX_UUID SRC_UUID TGT_UUID --weight 0.9
+      kagura edge update CTX_UUID SRC_UUID TGT_UUID --type related_to --weight 0.7
+    """
+    if weight is None and edge_type is None:
+        raise click.ClickException("At least one of --weight or --type must be provided")
+
+    async def op(client: KaguraClient, _ctx: str) -> dict[str, Any]:
+        result = await client.update_edge(
+            context_id=context_id,
+            source_id=source_id,
+            target_id=target_id,
+            weight=weight,
+            edge_type=edge_type,
+        )
+        return result.model_dump()
+
+    _run_client_command(op, context_id=None, needs_context=False)
+
+
+@edge.command(name="delete")
+@click.argument("context_id")
+@click.argument("source_id")
+@click.argument("target_id")
+@click.option("--yes", "-y", is_flag=True, help="Skip confirmation prompt")
+def edge_delete(context_id, source_id, target_id, yes):
+    """
+    Delete the edge between SOURCE_ID and TARGET_ID.
+
+    Examples:
+      kagura edge delete CTX_UUID SRC_UUID TGT_UUID
+      kagura edge delete CTX_UUID SRC_UUID TGT_UUID -y
+    """
+    if not yes:
+        click.confirm(f"Delete edge {source_id} -> {target_id}?", abort=True)
+
+    async def op(client: KaguraClient, _ctx: str) -> dict[str, Any]:
+        deleted = await client.delete_edge(
+            context_id=context_id,
+            source_id=source_id,
+            target_id=target_id,
+        )
+        return {"deleted": deleted}
+
+    _run_client_command(op, context_id=None, needs_context=False)
+
+
+# =============================================================================
 # Sleep Maintenance Commands (issue #85)
 # =============================================================================
 

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -511,7 +511,7 @@ def edge_list(context_id, memory_id, min_weight, edge_types, limit):
             edge_types=_parse_tags(edge_types),
             limit=limit,
         )
-        return {"edges": [e.model_dump() for e in edges], "count": len(edges)}
+        return {"edges": [e.model_dump(mode="json") for e in edges], "count": len(edges)}
 
     _run_client_command(op, context_id=None, needs_context=False)
 
@@ -547,7 +547,7 @@ def edge_create(context_id, source_id, target_id, edge_type, weight, confidence)
             weight=weight,
             confidence=confidence,
         )
-        return result.model_dump()
+        return result.model_dump(mode="json")
 
     _run_client_command(op, context_id=None, needs_context=False)
 
@@ -579,7 +579,7 @@ def edge_update(context_id, source_id, target_id, weight, edge_type):
             weight=weight,
             edge_type=edge_type,
         )
-        return result.model_dump()
+        return result.model_dump(mode="json")
 
     _run_client_command(op, context_id=None, needs_context=False)
 

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -13,6 +13,7 @@ from .exceptions import KaguraAuthError, KaguraConnectionError, KaguraError, Kag
 from .models import (
     ContextInfo,
     DuplicatesResponse,
+    Edge,
     EmbeddingModelsResponse,
     EmbeddingStatus,
     MemoryStatsResponse,
@@ -687,6 +688,173 @@ class KaguraClient:
         if delete_source:
             arguments["delete_source"] = True
         return await self._call_tool("merge_contexts", arguments)
+
+    async def list_edges(
+        self,
+        context_id: str,
+        memory_id: str,
+        min_weight: float = 0.0,
+        edge_types: list[str] | None = None,
+        limit: int | None = None,
+    ) -> list[Edge]:
+        """List neural memory edges connected to a memory.
+
+        Returns both outgoing and incoming edges, deduplicated.
+
+        Args:
+            context_id: Context UUID containing the memory.
+            memory_id: Memory UUID whose edges to list.
+            min_weight: Minimum edge weight (0.0-3.0). Edges below this are filtered.
+            edge_types: Restrict to these edge types (e.g. ``["related_to"]``). ``None``
+                returns all types.
+            limit: Maximum edges per direction. **The server applies this to outgoing
+                AND incoming queries independently**, so the practical maximum returned
+                is ``2 * limit`` minus dedup overlap. ``None`` means no limit.
+
+        Returns:
+            List of :class:`Edge` instances ordered as the server returns them.
+
+        Raises:
+            KaguraNotFoundError: Context or memory not found.
+            KaguraError: Other server-side error.
+        """
+        arguments: dict[str, Any] = {
+            "context_id": context_id,
+            "memory_id": memory_id,
+            "min_weight": min_weight,
+        }
+        if edge_types is not None:
+            arguments["edge_types"] = edge_types
+        if limit is not None:
+            arguments["limit"] = limit
+        result = await self._call_tool("list_edges", arguments)
+        self._raise_for_mcp_error(result, "list_edges")
+        return [Edge.model_validate(e) for e in result.get("edges", [])]
+
+    async def create_edge(
+        self,
+        context_id: str,
+        source_id: str,
+        target_id: str,
+        edge_type: str = "related_to",
+        weight: float = 0.5,
+        confidence: float = 1.0,
+    ) -> Edge:
+        """Create or upsert a neural memory edge from ``source_id`` to ``target_id``.
+
+        The server uses ``(user_id, source_id, target_id)`` as a unique key, so if an
+        edge already exists for the same pair the server applies **max-weight UPSERT**
+        semantics: the existing edge's weight is replaced only when the new weight is
+        higher, and the previous ``edge_type`` may be overwritten. This is **not** a
+        pure INSERT — callers expecting INSERT-or-fail semantics should call
+        :meth:`list_edges` first.
+
+        Args:
+            context_id: Context UUID containing both endpoints.
+            source_id: Source memory UUID.
+            target_id: Target memory UUID. Must differ from ``source_id`` (self-loops
+                are rejected client-side and server-side).
+            edge_type: Edge type label. Server validates against its current
+                ``VALID_EDGE_TYPES`` set; ``"related_to"`` is the standard default for
+                manual links.
+            weight: Edge weight in [0.0, 3.0]. Default 0.5 is a sensible mid-range
+                value for manual edges.
+            confidence: Edge confidence in [0.0, 1.0].
+
+        Returns:
+            The created :class:`Edge`.
+
+        Raises:
+            ValueError: If ``source_id == target_id``.
+            KaguraNotFoundError: Context or memory not found.
+            KaguraError: Server-side validation error (e.g. weight out of range,
+                self-loop accepted past the client preflight, edge type rejected).
+        """
+        if source_id == target_id:
+            raise ValueError(
+                "source_id and target_id must be different (self-loops are not allowed)"
+            )
+        arguments: dict[str, Any] = {
+            "context_id": context_id,
+            "source_id": source_id,
+            "target_id": target_id,
+            "edge_type": edge_type,
+            "weight": weight,
+            "confidence": confidence,
+        }
+        result = await self._call_tool("create_edge", arguments)
+        self._raise_for_mcp_error(result, "create_edge")
+        return Edge.model_validate(result.get("edge", result))
+
+    async def update_edge(
+        self,
+        context_id: str,
+        source_id: str,
+        target_id: str,
+        weight: float | None = None,
+        edge_type: str | None = None,
+    ) -> Edge:
+        """Update an existing edge's weight and/or edge type.
+
+        The edge is identified by the ``(source_id, target_id)`` pair (the server's
+        DB unique constraint covers ``(user_id, src, dst)``). Pass ``None`` for
+        either ``weight`` or ``edge_type`` to leave that field unchanged.
+
+        Args:
+            context_id: Context UUID containing both endpoints.
+            source_id: Source memory UUID.
+            target_id: Target memory UUID.
+            weight: New edge weight in [0.0, 3.0]. ``None`` keeps the existing value.
+            edge_type: New edge type label. ``None`` keeps the existing value.
+
+        Returns:
+            The updated :class:`Edge`.
+
+        Raises:
+            KaguraNotFoundError: Edge or context not found.
+            KaguraError: Other server-side error.
+        """
+        arguments: dict[str, Any] = {
+            "context_id": context_id,
+            "source_id": source_id,
+            "target_id": target_id,
+        }
+        if weight is not None:
+            arguments["weight"] = weight
+        if edge_type is not None:
+            arguments["edge_type"] = edge_type
+        result = await self._call_tool("update_edge", arguments)
+        self._raise_for_mcp_error(result, "update_edge")
+        return Edge.model_validate(result.get("edge", result))
+
+    async def delete_edge(
+        self,
+        context_id: str,
+        source_id: str,
+        target_id: str,
+    ) -> bool:
+        """Delete the edge between ``source_id`` and ``target_id``.
+
+        Args:
+            context_id: Context UUID containing both endpoints.
+            source_id: Source memory UUID.
+            target_id: Target memory UUID.
+
+        Returns:
+            ``True`` once the server confirms deletion succeeded.
+
+        Raises:
+            KaguraNotFoundError: Edge or context not found.
+            KaguraError: Other server-side error.
+        """
+        arguments: dict[str, Any] = {
+            "context_id": context_id,
+            "source_id": source_id,
+            "target_id": target_id,
+        }
+        result = await self._call_tool("delete_edge", arguments)
+        self._raise_for_mcp_error(result, "delete_edge")
+        return bool(result.get("deleted", True))
 
     async def get_usage(self) -> UsageInfo:
         """Get workspace usage and quota limits.

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -811,8 +811,8 @@ class KaguraClient:
             The updated :class:`Edge`.
 
         Raises:
-            KaguraNotFoundError: Edge or context not found.
-            KaguraError: Other server-side error.
+            KaguraNotFoundError: Context not found.
+            KaguraError: Edge not found or other server-side error.
         """
         arguments: dict[str, Any] = {
             "context_id": context_id,
@@ -844,8 +844,8 @@ class KaguraClient:
             ``True`` once the server confirms deletion succeeded.
 
         Raises:
-            KaguraNotFoundError: Edge or context not found.
-            KaguraError: Other server-side error.
+            KaguraNotFoundError: Context not found.
+            KaguraError: Edge not found or other server-side error.
         """
         arguments: dict[str, Any] = {
             "context_id": context_id,

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -641,5 +641,5 @@ class Edge(BaseModel):
     edge_type: str
     weight: float = Field(ge=0.0, le=3.0)
     confidence: float = Field(ge=0.0, le=1.0)
-    created_at: str | None = None
-    last_updated: str | None = None
+    created_at: datetime | None = None
+    last_updated: datetime | None = None

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Message(BaseModel):
@@ -610,3 +610,36 @@ class RollbackResult(BaseModel):
     report_id: str
     status: SleepRunStatus
     rollback_summary: RollbackSummary
+
+
+# ---------------------------------------------------------------------------
+# Edge model
+# ---------------------------------------------------------------------------
+
+
+class Edge(BaseModel):
+    """A neural memory edge between two memories.
+
+    Represents a directed link from ``source_id`` to ``target_id`` with a
+    semantic ``edge_type`` and a ``weight``/``confidence`` pair. Edges are
+    created either by users (manual curation) or by server-side processes
+    (Sleep Maintenance, k-NN seeding, declared links, tag co-occurrence).
+
+    Note:
+        ``edge_type`` is intentionally typed as ``str`` (not a ``Literal``)
+        because the server's ``VALID_EDGE_TYPES`` set is open-ended and grows
+        with new auto-discovery processes (currently 7 values:
+        ``neural_association``, ``related_to``, ``depends_on``,
+        ``learned_from``, ``semantic_similarity``, ``declared_link``,
+        ``tag_cooccurrence``). The server is the authority on validation.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    source_id: str
+    target_id: str
+    edge_type: str
+    weight: float = Field(ge=0.0, le=3.0)
+    confidence: float = Field(ge=0.0, le=1.0)
+    created_at: str | None = None
+    last_updated: str | None = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -803,3 +803,224 @@ def test_get_kagura_client_missing_api_key(mock_config):
     result = runner.invoke(main, ["sleep", "rollback", "ctx-1", "rid-9", "-y"])
     assert result.exit_code != 0
     assert "No API key" in result.output
+
+
+# ============================================================================
+# Edge CRUD CLI tests
+# ============================================================================
+
+
+def _edge_obj():
+    """Build an Edge model instance for CLI test mocking."""
+    from kagura_memory import Edge
+
+    return Edge(
+        source_id="src-uuid",
+        target_id="tgt-uuid",
+        edge_type="related_to",
+        weight=0.5,
+        confidence=1.0,
+        created_at="2026-04-29T00:00:00",
+        last_updated="2026-04-29T00:05:00",
+    )
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_list(mock_client_cls, mock_config):
+    """edge list should call list_edges and emit JSON."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.list_edges.return_value = [_edge_obj()]
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["edge", "list", "ctx-1", "mem-1"])
+    assert result.exit_code == 0, result.output
+    assert "src-uuid" in result.output
+    assert "tgt-uuid" in result.output
+
+    mock_client.list_edges.assert_called_once_with(
+        context_id="ctx-1",
+        memory_id="mem-1",
+        min_weight=0.0,
+        edge_types=None,
+        limit=None,
+    )
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_list_with_filters(mock_client_cls, mock_config):
+    """edge list should pass --min-weight, --type, --limit through."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.list_edges.return_value = []
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "edge",
+            "list",
+            "ctx-1",
+            "mem-1",
+            "--min-weight",
+            "0.5",
+            "--type",
+            "related_to,depends_on",
+            "--limit",
+            "10",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_client.list_edges.assert_called_once_with(
+        context_id="ctx-1",
+        memory_id="mem-1",
+        min_weight=0.5,
+        edge_types=["related_to", "depends_on"],
+        limit=10,
+    )
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_create(mock_client_cls, mock_config):
+    """edge create should call create_edge with defaults."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.create_edge.return_value = _edge_obj()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["edge", "create", "ctx-1", "src-uuid", "tgt-uuid"])
+    assert result.exit_code == 0, result.output
+    assert "related_to" in result.output
+
+    mock_client.create_edge.assert_called_once_with(
+        context_id="ctx-1",
+        source_id="src-uuid",
+        target_id="tgt-uuid",
+        edge_type="related_to",
+        weight=0.5,
+        confidence=1.0,
+    )
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_create_with_options(mock_client_cls, mock_config):
+    """edge create should pass --type, --weight, --confidence."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.create_edge.return_value = _edge_obj()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "edge",
+            "create",
+            "ctx-1",
+            "src-uuid",
+            "tgt-uuid",
+            "--type",
+            "depends_on",
+            "--weight",
+            "0.8",
+            "--confidence",
+            "0.9",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_client.create_edge.assert_called_once_with(
+        context_id="ctx-1",
+        source_id="src-uuid",
+        target_id="tgt-uuid",
+        edge_type="depends_on",
+        weight=0.8,
+        confidence=0.9,
+    )
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_update(mock_client_cls, mock_config):
+    """edge update should call update_edge with the provided fields."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.update_edge.return_value = _edge_obj()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["edge", "update", "ctx-1", "src-uuid", "tgt-uuid", "--weight", "0.9"],
+    )
+    assert result.exit_code == 0, result.output
+
+    mock_client.update_edge.assert_called_once_with(
+        context_id="ctx-1",
+        source_id="src-uuid",
+        target_id="tgt-uuid",
+        weight=0.9,
+        edge_type=None,
+    )
+
+
+def test_edge_update_requires_option():
+    """edge update should fail without --weight or --type."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["edge", "update", "ctx-1", "src-uuid", "tgt-uuid"])
+    assert result.exit_code != 0
+    assert "At least one of --weight or --type" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_delete_with_yes_flag(mock_client_cls, mock_config):
+    """edge delete with -y should call delete_edge without prompting."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_client = AsyncMock()
+    mock_client.delete_edge.return_value = True
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["edge", "delete", "ctx-1", "src-uuid", "tgt-uuid", "-y"])
+    assert result.exit_code == 0, result.output
+    assert "true" in result.output.lower()
+
+    mock_client.delete_edge.assert_called_once_with(
+        context_id="ctx-1",
+        source_id="src-uuid",
+        target_id="tgt-uuid",
+    )
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_edge_delete_prompts_confirmation(mock_client_cls, mock_config):
+    """edge delete without -y should prompt and abort on 'n'."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["edge", "delete", "ctx-1", "src-uuid", "tgt-uuid"], input="n\n")
+    assert result.exit_code != 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -812,6 +812,8 @@ def test_get_kagura_client_missing_api_key(mock_config):
 
 def _edge_obj():
     """Build an Edge model instance for CLI test mocking."""
+    from datetime import datetime
+
     from kagura_memory import Edge
 
     return Edge(
@@ -820,8 +822,8 @@ def _edge_obj():
         edge_type="related_to",
         weight=0.5,
         confidence=1.0,
-        created_at="2026-04-29T00:00:00",
-        last_updated="2026-04-29T00:05:00",
+        created_at=datetime(2026, 4, 29, 0, 0, 0),
+        last_updated=datetime(2026, 4, 29, 0, 5, 0),
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1779,3 +1779,445 @@ async def test_get_sleep_history_connection_error_on_5xx():
             await client.get_sleep_history(context_id="ctx-1")
 
     await client.close()
+
+
+# ============================================================================
+# Edge CRUD tests
+# ============================================================================
+
+
+def _edge_dict(
+    source_id: str = "src-uuid",
+    target_id: str = "tgt-uuid",
+    edge_type: str = "related_to",
+    weight: float = 0.5,
+    confidence: float = 1.0,
+) -> dict:
+    """Build a minimal server-shaped edge dict for use as ``_call_tool`` mock returns."""
+    return {
+        "source_id": source_id,
+        "target_id": target_id,
+        "edge_type": edge_type,
+        "weight": weight,
+        "confidence": confidence,
+        "created_at": "2026-04-29T00:00:00",
+        "last_updated": "2026-04-29T00:05:00",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_edges_basic():
+    """list_edges() should call tool and parse edges into Edge models."""
+    from kagura_memory import Edge
+
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "memory_id": "mem-1",
+            "edges": [_edge_dict(), _edge_dict(target_id="tgt-2", weight=0.8)],
+            "count": 2,
+        }
+        edges = await client.list_edges(context_id="ctx-1", memory_id="mem-1")
+
+        assert len(edges) == 2
+        assert all(isinstance(e, Edge) for e in edges)
+        assert edges[0].source_id == "src-uuid"
+        assert edges[1].weight == 0.8
+
+        tool_name = mock.call_args[0][0]
+        args = mock.call_args[0][1]
+        assert tool_name == "list_edges"
+        assert args["context_id"] == "ctx-1"
+        assert args["memory_id"] == "mem-1"
+        assert args["min_weight"] == 0.0
+        assert "edge_types" not in args
+        assert "limit" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_edges_with_filters():
+    """list_edges() should pass min_weight, edge_types, limit when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "mem-1", "edges": [], "count": 0}
+        await client.list_edges(
+            context_id="ctx-1",
+            memory_id="mem-1",
+            min_weight=0.5,
+            edge_types=["related_to", "depends_on"],
+            limit=10,
+        )
+        args = mock.call_args[0][1]
+        assert args["min_weight"] == 0.5
+        assert args["edge_types"] == ["related_to", "depends_on"]
+        assert args["limit"] == 10
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_edges_empty_response():
+    """list_edges() should return [] when server returns no edges field."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "mem-1"}
+        edges = await client.list_edges(context_id="ctx-1", memory_id="mem-1")
+        assert edges == []
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_edge_basic():
+    """create_edge() should call tool and return Edge model."""
+    from kagura_memory import Edge
+
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"edge": _edge_dict()}
+        result = await client.create_edge(
+            context_id="ctx-1",
+            source_id="src-uuid",
+            target_id="tgt-uuid",
+        )
+
+        assert isinstance(result, Edge)
+        assert result.source_id == "src-uuid"
+        assert result.target_id == "tgt-uuid"
+        assert result.edge_type == "related_to"
+        assert result.weight == 0.5
+        assert result.confidence == 1.0
+
+        tool_name = mock.call_args[0][0]
+        args = mock.call_args[0][1]
+        assert tool_name == "create_edge"
+        assert args["context_id"] == "ctx-1"
+        assert args["source_id"] == "src-uuid"
+        assert args["target_id"] == "tgt-uuid"
+        assert args["edge_type"] == "related_to"
+        assert args["weight"] == 0.5
+        assert args["confidence"] == 1.0
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_edge_custom_values():
+    """create_edge() should pass custom edge_type, weight, confidence."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"edge": _edge_dict(edge_type="depends_on", weight=2.5, confidence=0.7)}
+        result = await client.create_edge(
+            context_id="ctx-1",
+            source_id="a",
+            target_id="b",
+            edge_type="depends_on",
+            weight=2.5,
+            confidence=0.7,
+        )
+        assert result.edge_type == "depends_on"
+        assert result.weight == 2.5
+        assert result.confidence == 0.7
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_edge_self_loop_rejected():
+    """create_edge() should raise ValueError when source_id == target_id."""
+    client = _make_initialized_client()
+
+    with pytest.raises(ValueError, match="self-loops are not allowed"):
+        await client.create_edge(
+            context_id="ctx-1",
+            source_id="same-uuid",
+            target_id="same-uuid",
+        )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_create_edge_accepts_unwrapped_response():
+    """create_edge() should also handle the edge dict directly without 'edge' wrapper."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = _edge_dict()
+        result = await client.create_edge(context_id="ctx-1", source_id="a", target_id="b")
+        assert result.source_id == "src-uuid"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_edge_weight_only():
+    """update_edge() should send only weight when edge_type is None."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"edge": _edge_dict(weight=0.9)}
+        result = await client.update_edge(
+            context_id="ctx-1",
+            source_id="a",
+            target_id="b",
+            weight=0.9,
+        )
+        assert result.weight == 0.9
+
+        args = mock.call_args[0][1]
+        assert args["weight"] == 0.9
+        assert "edge_type" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_edge_type_only():
+    """update_edge() should send only edge_type when weight is None."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"edge": _edge_dict(edge_type="depends_on")}
+        await client.update_edge(
+            context_id="ctx-1",
+            source_id="a",
+            target_id="b",
+            edge_type="depends_on",
+        )
+        args = mock.call_args[0][1]
+        assert args["edge_type"] == "depends_on"
+        assert "weight" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_edge_both_fields():
+    """update_edge() should send both weight and edge_type when both given."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"edge": _edge_dict(edge_type="learned_from", weight=1.5)}
+        await client.update_edge(
+            context_id="ctx-1",
+            source_id="a",
+            target_id="b",
+            weight=1.5,
+            edge_type="learned_from",
+        )
+        args = mock.call_args[0][1]
+        assert args["weight"] == 1.5
+        assert args["edge_type"] == "learned_from"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_edge_neither_field():
+    """update_edge() should send only the identifying triple when both are None."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"edge": _edge_dict()}
+        await client.update_edge(
+            context_id="ctx-1",
+            source_id="a",
+            target_id="b",
+        )
+        args = mock.call_args[0][1]
+        assert args == {"context_id": "ctx-1", "source_id": "a", "target_id": "b"}
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_edge_success():
+    """delete_edge() should return True on success."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"deleted": True, "status": "success"}
+        result = await client.delete_edge(context_id="ctx-1", source_id="a", target_id="b")
+        assert result is True
+
+        tool_name = mock.call_args[0][0]
+        args = mock.call_args[0][1]
+        assert tool_name == "delete_edge"
+        assert args == {"context_id": "ctx-1", "source_id": "a", "target_id": "b"}
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_edge_defaults_true_when_no_deleted_key():
+    """delete_edge() should return True when no error and no 'deleted' key in response."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"status": "success"}
+        result = await client.delete_edge(context_id="ctx-1", source_id="a", target_id="b")
+        assert result is True
+
+    await client.close()
+
+
+def test_edge_model_ignores_extra_fields():
+    """Edge model must accept (and silently drop) extra server fields.
+
+    Guards against future server-side provenance additions
+    (e.g. ``created_by``, ``origin``, ``frozen``) breaking older SDKs.
+    """
+    from kagura_memory import Edge
+
+    edge = Edge.model_validate(
+        {
+            **_edge_dict(),
+            "created_by": "user",
+            "origin": "manual",
+            "frozen": True,
+            "future_unknown_field": {"nested": [1, 2, 3]},
+        }
+    )
+
+    assert edge.source_id == "src-uuid"
+    assert edge.weight == 0.5
+    assert not hasattr(edge, "created_by")
+    assert not hasattr(edge, "origin")
+
+
+def test_edge_model_validates_weight_range():
+    """Edge.weight must reject values outside [0.0, 3.0]."""
+    from pydantic import ValidationError
+
+    from kagura_memory import Edge
+
+    # Below range
+    with pytest.raises(ValidationError):
+        Edge.model_validate({**_edge_dict(weight=-0.1)})
+
+    # Above range
+    with pytest.raises(ValidationError):
+        Edge.model_validate({**_edge_dict(weight=3.5)})
+
+    # Boundary values are valid
+    Edge.model_validate({**_edge_dict(weight=0.0)})
+    Edge.model_validate({**_edge_dict(weight=3.0)})
+
+
+def test_edge_model_validates_confidence_range():
+    """Edge.confidence must reject values outside [0.0, 1.0]."""
+    from pydantic import ValidationError
+
+    from kagura_memory import Edge
+
+    with pytest.raises(ValidationError):
+        Edge.model_validate({**_edge_dict(confidence=-0.1)})
+
+    with pytest.raises(ValidationError):
+        Edge.model_validate({**_edge_dict(confidence=1.5)})
+
+
+@pytest.mark.asyncio
+async def test_create_edge_surfaces_server_weight_error():
+    """Server-side validation_error responses must raise KaguraError, not slip past
+    as a Pydantic ValidationError on the error dict."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "validation_error",
+            "message": "weight must be between 0.0 and 3.0.",
+        }
+        with pytest.raises(KaguraError, match="weight must be between"):
+            await client.create_edge(
+                context_id="ctx-1",
+                source_id="a",
+                target_id="b",
+                weight=5.0,
+            )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_edges_surfaces_server_error():
+    """list_edges() must raise on server-side error rather than returning []."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "memory_not_found",
+            "message": "Memory not found.",
+        }
+        with pytest.raises(KaguraNotFoundError, match="list_edges"):
+            await client.list_edges(context_id="ctx-1", memory_id="missing-mem")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_edge_surfaces_server_error():
+    """update_edge() must raise on server-side error rather than running model_validate
+    on the error dict."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "edge_not_found",
+            "message": "Edge does not exist.",
+        }
+        with pytest.raises(KaguraError, match="edge_not_found"):
+            await client.update_edge(
+                context_id="ctx-1",
+                source_id="a",
+                target_id="b",
+                weight=0.7,
+            )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_edge_surfaces_server_error():
+    """delete_edge() must raise on server-side error rather than silently returning
+    False, so callers can distinguish 'edge missing' from 'auth/permission failure'."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "edge_not_found",
+            "message": "Edge does not exist.",
+        }
+        with pytest.raises(KaguraError, match="edge_not_found"):
+            await client.delete_edge(context_id="ctx-1", source_id="a", target_id="b")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_edges_raises_not_found_for_context_not_found():
+    """list_edges() raises KaguraNotFoundError specifically for context_not_found code."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "context_not_found",
+            "message": "Context not found.",
+        }
+        with pytest.raises(KaguraNotFoundError):
+            await client.list_edges(context_id="ctx-missing", memory_id="mem-1")
+
+    await client.close()


### PR DESCRIPTION
Closes #84

## Summary
- New `Edge` Pydantic model and 4 client methods (`list_edges`, `create_edge`, `update_edge`, `delete_edge`) wrapping the server-side MCP tools added in kagura-ai/memory-cloud#163.
- New `kagura edge` CLI subcommand group (list / create / update / delete) mirroring the `kagura context` group.
- 30 new tests (298 total) covering happy paths, sparse-update variations, boundary validation, server-error surfacing via `_raise_for_mcp_error`, and provenance-RFC future-proofing.

## Implementation notes
- `Edge` model uses `model_config = ConfigDict(extra="ignore")` — required so the SDK silently accepts future server-side provenance fields (`created_by`, `origin`, `frozen`) without breaking older clients.
- `edge_type` is typed as `str` (not `Literal[...]`) because the server's `VALID_EDGE_TYPES` set is open-ended (currently 7: `neural_association`, `related_to`, `depends_on`, `learned_from`, `semantic_similarity`, `declared_link`, `tag_cooccurrence`) — SDK defers validation to the server.
- `Edge` has no `edge_id` field — server `_edge_to_dict` doesn't return one; edges are identified by `(source_id, target_id)` per the DB unique constraint.
- All 4 client methods call `self._raise_for_mcp_error(result, "<op>")` after `_call_tool` to surface server-side `{"status": "error", ...}` responses as `KaguraError`/`KaguraNotFoundError` (mirrors the existing pattern in `get_sleep_history`/`get_sleep_report`/`rollback_sleep_run`).
- `create_edge` performs a client-side self-loop preflight (raises `ValueError` when `source_id == target_id`), mirroring the pattern in `merge_contexts`.
- `update_edge` uses sparse-update semantics (None means "keep existing"), mirroring `update_context`.
- `list_edges` docstring documents the server's 2x-limit behaviour: the server applies `limit` to outgoing AND incoming queries independently, so the practical maximum returned is `2 * limit` minus dedup overlap.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (DX Lead lens — minor spec corrections noted, all addressed before commit)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/84-feat-feat-add-edge-crud-methods-and-cli-comma.gate1.md
- ~/.claude/cache/gh-issue-driven/84-feat-feat-add-edge-crud-methods-and-cli-comma.gate2.md

🤖 Generated via /gh-issue-driven:ship
