### PR TITLE
feat(client): expose details/context_summary/source_type/context on remember()

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -228,27 +228,44 @@ class KaguraClient:
         importance: float = 0.5,
         tags: list[str] | None = None,
         source_uri: str | None = None,
+        source_type: str | None = None,
+        context_summary: str | None = None,
+        details: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
         linked_memory_ids: list[str] | None = None,
         linked_source_uris: list[str] | None = None,
     ) -> dict[str, Any]:
-        """
-        Call remember MCP tool.
+        """Call remember MCP tool.
 
         Args:
-            context_id: Context ID
-            summary: Memory summary
-            content: Memory content
-            type: Memory type
-            importance: Importance score (0.0-1.0)
-            tags: Optional tags
-            source_uri: Origin URI for this memory (e.g. ``file://``,
-                ``https://``, ``vault://``).
+            context_id: Context ID.
+            summary: Memory summary (10-500 chars).
+            content: Memory content.
+            type: Memory type. Server validates against its own vocabulary;
+                the SDK passes through.
+            importance: Importance score (0.0-1.0).
+            tags: Optional tags.
+            source_uri: Origin URI (e.g. ``file:///``, ``https://``,
+                ``vault://``).
+            source_type: Origin classification. One of
+                ``"file" | "url" | "vault" | "api" | "manual"`` per the MCP
+                tool schema; pairs with ``source_uri`` for downstream filters.
+            context_summary: Brief explanation (max 2000 chars) of why the
+                memory exists and how to use it. Distinct from ``summary``,
+                which is the search-target text.
+            details: Structured details JSON. Use for additional metadata
+                like code locations, parent/child links, or any caller-defined
+                payload that the server should store as-is.
+            context: Open-ended context metadata JSON. Less structured than
+                ``details``; useful for free-form provenance hints.
             linked_memory_ids: Existing memory UUIDs to declare as graph
-                edges from this memory.
+                edges from this memory. Server creates ``declared_link``
+                edges with ``weight=1.0`` atomically.
             linked_source_uris: Source URIs to resolve into linked memories.
+                Unresolved URIs are silently skipped server-side.
 
         Returns:
-            API response with memory_id
+            API response with ``memory_id``.
         """
         arguments: dict[str, Any] = {
             "context_id": context_id,
@@ -261,6 +278,14 @@ class KaguraClient:
             arguments["tags"] = tags
         if source_uri is not None:
             arguments["source_uri"] = source_uri
+        if source_type is not None:
+            arguments["source_type"] = source_type
+        if context_summary is not None:
+            arguments["context_summary"] = context_summary
+        if details is not None:
+            arguments["details"] = details
+        if context is not None:
+            arguments["context"] = context
         if linked_memory_ids is not None:
             arguments["linked_memory_ids"] = linked_memory_ids
         if linked_source_uris is not None:

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -228,12 +228,12 @@ class KaguraClient:
         importance: float = 0.5,
         tags: list[str] | None = None,
         source_uri: str | None = None,
-        source_type: str | None = None,
+        linked_memory_ids: list[str] | None = None,
+        linked_source_uris: list[str] | None = None,
+        source_type: Literal["file", "url", "vault", "api", "manual"] | None = None,
         context_summary: str | None = None,
         details: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
-        linked_memory_ids: list[str] | None = None,
-        linked_source_uris: list[str] | None = None,
     ) -> dict[str, Any]:
         """Call remember MCP tool.
 
@@ -247,8 +247,12 @@ class KaguraClient:
             tags: Optional tags.
             source_uri: Origin URI (e.g. ``file:///``, ``https://``,
                 ``vault://``).
-            source_type: Origin classification. One of
-                ``"file" | "url" | "vault" | "api" | "manual"`` per the MCP
+            linked_memory_ids: Existing memory UUIDs to declare as graph
+                edges from this memory. Server creates ``declared_link``
+                edges with ``weight=1.0`` atomically.
+            linked_source_uris: Source URIs to resolve into linked memories.
+                Unresolved URIs are silently skipped server-side.
+            source_type: Origin classification. Closed enum per the MCP
                 tool schema; pairs with ``source_uri`` for downstream filters.
             context_summary: Brief explanation (max 2000 chars) of why the
                 memory exists and how to use it. Distinct from ``summary``,
@@ -258,11 +262,6 @@ class KaguraClient:
                 payload that the server should store as-is.
             context: Open-ended context metadata JSON. Less structured than
                 ``details``; useful for free-form provenance hints.
-            linked_memory_ids: Existing memory UUIDs to declare as graph
-                edges from this memory. Server creates ``declared_link``
-                edges with ``weight=1.0`` atomically.
-            linked_source_uris: Source URIs to resolve into linked memories.
-                Unresolved URIs are silently skipped server-side.
 
         Returns:
             API response with ``memory_id``.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -239,7 +239,7 @@ async def test_remember_with_source_uri():
 
 @pytest.mark.asyncio
 async def test_remember_pass_through_keys_absent_when_none():
-    """remember() should not send source_uri / linked_* keys when None."""
+    """remember() should not send optional keys when None."""
     client = _make_initialized_client()
 
     with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
@@ -247,8 +247,137 @@ async def test_remember_pass_through_keys_absent_when_none():
         await client.remember(context_id="ctx", summary="s", content="c")
         args = mock.call_args[0][1]
         assert "source_uri" not in args
+        assert "source_type" not in args
+        assert "context_summary" not in args
+        assert "details" not in args
+        assert "context" not in args
         assert "linked_memory_ids" not in args
         assert "linked_source_uris" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_details():
+    """remember() should pass details JSON dict through to MCP arguments."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx",
+            summary="s",
+            content="c",
+            details={
+                "code_location": "src/auth.py:142",
+                "related_issue": "#123",
+                "tags_seen": ["oauth", "jwt"],
+            },
+        )
+        args = mock.call_args[0][1]
+        assert args["details"] == {
+            "code_location": "src/auth.py:142",
+            "related_issue": "#123",
+            "tags_seen": ["oauth", "jwt"],
+        }
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_context_summary():
+    """remember() should pass context_summary when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx",
+            summary="s",
+            content="c",
+            context_summary="Why this memory matters and how to use it.",
+        )
+        args = mock.call_args[0][1]
+        assert args["context_summary"] == "Why this memory matters and how to use it."
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_source_type():
+    """remember() should pass source_type alongside source_uri."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx",
+            summary="s",
+            content="c",
+            source_uri="https://example.com/doc.html",
+            source_type="url",
+        )
+        args = mock.call_args[0][1]
+        assert args["source_type"] == "url"
+        assert args["source_uri"] == "https://example.com/doc.html"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_with_context_dict():
+    """remember() should pass context dict (free-form provenance metadata)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx",
+            summary="s",
+            content="c",
+            context={"issue": 80, "branch": "feat/example", "session_id": "s-1"},
+        )
+        args = mock.call_args[0][1]
+        assert args["context"] == {
+            "issue": 80,
+            "branch": "feat/example",
+            "session_id": "s-1",
+        }
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_combined_pass_through_payload():
+    """remember() with all the new pass-through kwargs together."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "section-uuid"}
+        await client.remember(
+            context_id="ctx",
+            summary="Doc — chapter 0: Intro",
+            content="Chapter text...",
+            type="document_section",
+            importance=0.5,
+            tags=["pdf", "user-recipe"],
+            source_uri="https://example.com/doc.pdf",
+            source_type="url",
+            context_summary="Chapter 0 of doc.pdf",
+            details={
+                "parent_id": "overview-uuid",
+                "role": "section",
+                "section_index": 0,
+            },
+            linked_memory_ids=["overview-uuid"],
+        )
+        args = mock.call_args[0][1]
+        assert args["type"] == "document_section"
+        assert args["details"]["role"] == "section"
+        assert args["details"]["parent_id"] == "overview-uuid"
+        assert args["linked_memory_ids"] == ["overview-uuid"]
+        assert args["source_type"] == "url"
+        assert args["context_summary"] == "Chapter 0 of doc.pdf"
 
     await client.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ wheels = [
 
 [[package]]
 name = "kagura-memory"
-version = "0.9.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Surface four parameters on `KaguraClient.remember()` that the MCP server already accepts but the SDK had not exposed:

- `details: dict[str, Any] | None` — structured JSON metadata (free-form payload, e.g. code locations, parent/child links, custom fields)
- `context_summary: str | None` — brief "why this matters" explanation, distinct from `summary` (which is the search-target text)
- `source_type: Literal["file","url","vault","api","manual"] | None` — origin classification, pairs with `source_uri` for downstream filters
- `context: dict[str, Any] | None` — open-ended free-form provenance metadata

All four are optional kwargs and follow the existing pattern: included in the MCP arguments dict only when not None. Existing callers are unaffected.

## Background

These parameters are present in the MCP `remember` tool's `inputSchema` (`backend/src/mcp_server/tools/_definitions.py` on the memory-cloud side) and have been accepted server-side since the tool was introduced. The SDK was the gap — callers wanting to attach structured metadata had to fall through to `client._call_tool("remember", {...})` and bypass the typed wrapper.

This PR keeps the SDK's primitive-only philosophy intact: it does NOT add any opinionated workflow logic (file fetching, parsing, LLM summarization, etc.). It is a pure pass-through extension that lets users compose those workflows in their own code while still using the typed `remember()` method.

(For the architectural rationale that led to extracting only this slice, see the discussion on closed PR #95 and the comment on issue #80.)

## Tests

- 5 new tests (`test_remember_with_details`, `test_remember_with_context_summary`, `test_remember_with_source_type`, `test_remember_with_context_dict`, `test_remember_combined_pass_through_payload`)
- Existing `test_remember_pass_through_keys_absent_when_none` extended to assert the four new keys also stay absent when `None`

## Quality gates

- `ruff check src/ tests/` — clean
- `ruff format src/ tests/` — clean
- `pyright src/` — 0 errors, 0 warnings, 0 informations
- `pytest tests/` — 303 passed (+5 new) in 9.9 s

## Incidental

`uv.lock` was out of sync with `__init__.py` on `main` (lock had 0.9.0, source had 0.13.0). `uv` re-resolved on first run; included that 1-line sync in the same commit for consistency.

## Test plan

- [x] Lint, type, full test suite all clean locally
- [ ] Reviewer confirms the new kwargs are forwarded to MCP correctly via the unit tests' assertion shape
- [ ] Reviewer verifies backward compatibility (no existing call site needs changes)

🤖 Generated via /gh-issue-driven (extracted from closed PR #95)
