### PR TITLE
feat(files): add FilesClient with R2 sha256 binding (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: uv sync --dev --python ${{ matrix.python-version }}
 
       - name: Test with coverage
-        run: uv run pytest tests/ -v --cov=src/kagura_memory --cov-report=xml --cov-report=term
+        run: uv run pytest tests/ -v -m "not integration" --cov=src/kagura_memory --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,11 @@
 
 ## Overview
 
-Python SDK for Kagura Memory Cloud. Three clients:
+Python SDK for Kagura Memory Cloud. Four clients:
 - `KaguraClient` — MCP client for memory and context operations
 - `KaguraAgent` — LLM-powered session analysis with hooks/skills API
 - `ResourceClient` — REST client for resource token management and data ingestion
+- `FilesClient` — REST + presigned PUT client for file uploads with sha256 integrity binding (server v0.15.1+)
 
 ## Development Workflow
 
@@ -30,9 +31,10 @@ uv run pyright src/              # Type check
 - Search tuning: `update_search_config` (semantic/bm25 weights, reranking)
 - Resource ingestion: `setup_resource`, `ingest_event`, `ingest_events`
 - Resource stats/schema: `get_resource_impact`, `get_resource_schema`
+- **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs
-- CLI: `kagura setup claude`, `kagura resource setup/import/stats/schema`, `kagura context search-config`
+- CLI: `kagura setup claude`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura context search-config`
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## What is this?
 
-This SDK connects your Python code to [Kagura Memory Cloud](https://github.com/kagura-ai/memory-cloud), giving AI assistants the ability to **remember, search, and learn** from past interactions. It provides three clients for different use cases:
+This SDK connects your Python code to [Kagura Memory Cloud](https://github.com/kagura-ai/memory-cloud), giving AI assistants the ability to **remember, search, and learn** from past interactions. It provides four clients for different use cases:
 
 | Client | Protocol | Use Case |
 |--------|----------|----------|

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ from pathlib import Path
 from kagura_memory import FilesClient
 
 async with FilesClient.from_mcp_url(api_key="kagura_...", mcp_url="https://memory.kagura-ai.com/mcp") as client:
-    # Upload from a Path (streams sha256, no full-load for large files)
+    # Upload from a Path (read fully into memory; server caps file size at 100 MiB)
     f = await client.upload(context_id="ctx-uuid", source=Path("./report.pdf"))
     print(f"Uploaded {f.id}, sha256={f.sha256}, size={f.size_bytes}")
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Re-uploading bytes whose sha256 already exists in the workspace returns the **ex
 
 When pointing the SDK at a backend with `R2_CHECKSUM_BINDING_ENABLED=true`, the SDK must be v0.14.0+ — older versions don't send the signed checksum header and uploads fail with `HTTP 403 SignatureDoesNotMatch`.
 
+> The `0.14.0` row above describes the next minor release; `__version__` is bumped from `0.13.0` to `0.14.0` by `/release minor` (see `.claude/rules/versioning.md`) at tag time, not in this feature branch.
+
 ## CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This SDK connects your Python code to [Kagura Memory Cloud](https://github.com/k
 | **`KaguraAgent`** | MCP + LLM | AI-powered — auto-decides what to remember/recall from conversations |
 | **`KaguraClient`** | MCP (JSON-RPC) | Direct memory ops — remember, recall, explore, reference, forget |
 | **`ResourceClient`** | REST API | External data ingestion — push data from Slack, CI/CD, CRM into Kagura |
+| **`FilesClient`** | REST + presigned PUT | File uploads with sha256 integrity binding (R2) |
 
 ## Installation
 
@@ -182,6 +183,41 @@ async with ResourceClient.from_mcp_url(api_key="kagura_...", mcp_url="http://loc
 
 See [`examples/`](examples/) for complete working examples.
 
+### FilesClient — File Uploads with Checksum Binding
+
+Upload files to the workspace's object store via short-lived presigned PUT URLs. The SDK binds the body's sha256 into the PUT signature so the server (memory-cloud v0.15.1+, `R2_CHECKSUM_BINDING_ENABLED=true`) can reject tampered uploads with `400 BadDigest`:
+
+```python
+from pathlib import Path
+from kagura_memory import FilesClient
+
+async with FilesClient.from_mcp_url(api_key="kagura_...", mcp_url="https://memory.kagura-ai.com/mcp") as client:
+    # Upload from a Path (streams sha256, no full-load for large files)
+    f = await client.upload(context_id="ctx-uuid", source=Path("./report.pdf"))
+    print(f"Uploaded {f.id}, sha256={f.sha256}, size={f.size_bytes}")
+
+    # Upload from bytes — filename is required (server enforces non-empty)
+    f2 = await client.upload(context_id="ctx-uuid", source=b"...", filename="payload.bin")
+
+    # Short-lived presigned GET URL
+    url = await client.download_url(f.id)
+
+    # List & delete
+    page = await client.list(context_id="ctx-uuid", limit=50)
+    await client.delete(f.id)
+```
+
+Re-uploading bytes whose sha256 already exists in the workspace returns the **existing `FileObject`** (idempotent dedup happy-path) — no exception.
+
+## SDK ↔ memory-cloud Compatibility
+
+| SDK | Min memory-cloud | Notes |
+|---|---|---|
+| 0.14.0 | 0.15.1 | `FilesClient` + R2 checksum binding (`x-amz-checksum-sha256` on PUT) |
+| 0.13.x | 0.13.0 | Pre-`FilesClient` |
+
+When pointing the SDK at a backend with `R2_CHECKSUM_BINDING_ENABLED=true`, the SDK must be v0.14.0+ — older versions don't send the signed checksum header and uploads fail with `HTTP 403 SignatureDoesNotMatch`.
+
 ## CLI
 
 ```bash
@@ -206,6 +242,12 @@ kagura resource schema -r products
 kagura sleep history <context-id> --limit 5
 kagura sleep report <context-id> <report-id>
 kagura sleep rollback <context-id> <report-id> -y    # destructive: prompts unless --yes / -y is set
+
+# File uploads (R2 checksum binding)
+kagura files upload ./report.pdf -c <context-id>
+kagura files list -c <context-id> --limit 50
+kagura files download-url <file-id>
+kagura files delete <file-id>
 
 # Config
 kagura config show
@@ -243,6 +285,7 @@ kagura process -m "今日の学び：FastAPIのDIはDepends()を使う"
 | Resource Event ingestion | `ResourceClient` | REST API | Resource Token |
 | Resource Impact (stats) | `ResourceClient` | REST API | API Key |
 | Resource Schema | `ResourceClient` | REST API | API Key |
+| File upload / download-url / delete / list | `FilesClient` | REST + presigned PUT | API Key |
 | Account erasure (GDPR Art.17 / APPI) | — | Web UI only | Session |
 
 Context deletion and account erasure are intentionally Web UI only — destructive operations require session authentication and confirmation. `kagura sleep rollback` runs over the MCP API Key but is itself destructive (reverses edge creation, merges, importance updates, promotions, and archives) and the CLI requires `--yes` to skip the interactive confirmation. The server commits per-action without a Saga, so a 5xx response after partial success means SOME actions may have been reversed before the error surfaced — re-run `kagura sleep report` to inspect the post-failure state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+markers = [
+    "integration: requires a live memory-cloud backend (gated by KAGURA_INTEGRATION_URL env var)",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 markers = [
-    "integration: requires a live memory-cloud backend (gated by KAGURA_INTEGRATION_URL env var)",
+    "integration: requires a live memory-cloud backend (gated by KAGURA_INTEGRATION_URL, KAGURA_API_KEY, and KAGURA_INTEGRATION_CONTEXT_ID env vars)",
 ]
 
 [tool.ruff]

--- a/src/kagura_memory/__init__.py
+++ b/src/kagura_memory/__init__.py
@@ -7,11 +7,13 @@ from .exceptions import (
     KaguraConnectionError,
     KaguraContextError,
     KaguraError,
+    KaguraIntegrityError,
     KaguraLLMError,
     KaguraNotFoundError,
     KaguraQuotaError,
     KaguraRateLimitError,
 )
+from .files_client import FilesClient
 from .models import (
     Artifact,
     ContextDetail,
@@ -27,6 +29,8 @@ from .models import (
     ExploredMemory,
     FailedMemoryInfo,
     FieldDefinition,
+    FileListResponse,
+    FileObject,
     IndexerJobStatus,
     IndexerSkippedReason,
     IndexerState,
@@ -80,6 +84,7 @@ __all__ = [
     "KaguraAgent",
     "KaguraClient",
     "ResourceClient",
+    "FilesClient",
     "MIN_SERVER_VERSION",
     # Embedding models
     "EmbeddingModel",
@@ -142,6 +147,9 @@ __all__ = [
     "IndexerState",
     "ResourceEventItem",
     "IndexerStatusResponse",
+    # File objects (server v0.15.1+)
+    "FileObject",
+    "FileListResponse",
     # Sleep Maintenance (server v0.8+)
     "SleepRunStatus",
     "SleepReport",
@@ -158,4 +166,5 @@ __all__ = [
     "KaguraQuotaError",
     "KaguraLLMError",
     "KaguraContextError",
+    "KaguraIntegrityError",
 ]

--- a/src/kagura_memory/_http.py
+++ b/src/kagura_memory/_http.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from importlib.metadata import version as _pkg_version
 
+import httpx
+
 SDK_VERSION: str = _pkg_version("kagura-memory")
 """Package version string, shared across client modules."""
 
@@ -22,6 +24,23 @@ def base_url_from_mcp(mcp_url: str) -> str:
     """
     m = re.search(r"/mcp(?=/|$)", mcp_url)
     return mcp_url[: m.start()] if m else mcp_url
+
+
+def extract_detail(response: httpx.Response) -> str:
+    """Return the JSON ``detail`` field from an httpx response if parseable.
+
+    Returns an empty string when the body is not JSON, not a dict, or
+    has no ``detail`` field. Used by REST clients to surface a useful
+    server-supplied message in chained exception text.
+    """
+    try:
+        body = response.json()
+    except (ValueError, UnicodeDecodeError):
+        return ""
+    if isinstance(body, dict):
+        detail = body.get("detail", "")
+        return detail if isinstance(detail, str) else ""
+    return ""
 
 
 def validate_https_url(url: str, *, label: str = "URL") -> None:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1296,5 +1296,5 @@ def files_list(context_id: str | None, limit: int, cursor: str | None):
     _run_files_command(op, context_id)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -72,7 +72,7 @@ def _run_client_command(
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(f"Error: {e}") from e
+        raise click.ClickException(str(e)) from e
 
 
 @click.group()
@@ -132,7 +132,7 @@ def process(message, file, deep, verbose):
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(f"Error: {e}") from e
+        raise click.ClickException(str(e)) from e
 
 
 @main.group()
@@ -692,7 +692,7 @@ def sleep_rollback(context_id, report_id, yes):
     except (click.Abort, click.ClickException):
         raise
     except Exception as e:
-        raise click.ClickException(f"Error: {e}") from e
+        raise click.ClickException(str(e)) from e
 
 
 # =============================================================================
@@ -781,7 +781,7 @@ def _run_resource_command(
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(f"Error: {e}") from e
+        raise click.ClickException(str(e)) from e
 
 
 @main.group()
@@ -1218,7 +1218,7 @@ def _run_files_command(
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(f"Error: {e}") from e
+        raise click.ClickException(str(e)) from e
 
 
 @main.group()

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1285,7 +1285,13 @@ def files_delete(file_id: str):
 
 @files.command(name="list")
 @click.option("--context-id", "-c", help="Context (workspace) UUID to list")
-@click.option("--limit", "-l", type=int, default=50, help="Max results (1-500)")
+@click.option(
+    "--limit",
+    "-l",
+    type=click.IntRange(1, 500),
+    default=50,
+    help="Max results (1-500)",
+)
 @click.option("--cursor", help="Forward-compat cursor (server v0.16+)")
 def files_list(context_id: str | None, limit: int, cursor: str | None):
     """

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import sys
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 
 import click
@@ -11,6 +12,7 @@ import click
 from .agent import KaguraAgent
 from .client import KaguraClient
 from .config import load_config
+from .files_client import FilesClient
 from .models import Message, ProcessResult, ResourceEventRequest, Session
 from .resource_client import ResourceClient
 from .setup_claude import run_setup_claude
@@ -1160,6 +1162,138 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version):
         return json.dumps(output, indent=2)
 
     _run_resource_command(op)
+
+
+# =============================================================================
+# Files (`kagura files ...`) — server v0.15.1+
+# =============================================================================
+
+
+def _build_files_client(config: dict[str, Any]) -> FilesClient:
+    """Build a FilesClient from an already-loaded config dict."""
+    if not config.get("api_key"):
+        raise click.ClickException("No API key found. Set KAGURA_API_KEY or create .kagura.json")
+    return FilesClient.from_mcp_url(
+        api_key=config.get("api_key", ""),
+        mcp_url=config.get("mcp_url", "https://memory.kagura-ai.com/mcp"),
+    )
+
+
+def _run_files_command(
+    operation: Callable[[FilesClient, str], Awaitable[Any]],
+    context_id: str | None,
+    *,
+    needs_context: bool = True,
+) -> None:
+    """Execute a FilesClient operation with standard boilerplate.
+
+    Loads config exactly once, resolves api_key + context_id together
+    so the operator sees a single, consistent error path.
+    """
+    try:
+        config = load_config()
+        ctx_id = ""
+        if needs_context:
+            ctx_id = context_id or config.get("context_id") or ""
+            if not ctx_id:
+                raise click.ClickException(
+                    "context_id required. Use --context-id or set in .kagura.json"
+                )
+
+        client = _build_files_client(config)
+
+        async def _run() -> Any:
+            async with client:
+                return await operation(client, ctx_id)
+
+        result = asyncio.run(_run())
+        if result is not None:
+            click.echo(result)
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(f"Error: {e}") from e
+
+
+@main.group()
+def files():
+    """Upload, list, and manage files in Kagura Memory Cloud."""
+    pass
+
+
+@files.command(name="upload")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--context-id", "-c", help="Target context (workspace) UUID")
+@click.option("--content-type", "-t", help="MIME type override (default: sniffed)")
+def files_upload(path: Path, context_id: str | None, content_type: str | None):
+    """
+    Upload a file to Kagura Memory Cloud.
+
+    Example:
+      kagura files upload ./report.pdf --context-id ctx-uuid
+    """
+
+    async def op(client: FilesClient, ctx: str) -> str:
+        result = await client.upload(
+            context_id=ctx,
+            source=path,
+            content_type=content_type,
+        )
+        return result.model_dump_json(indent=2)
+
+    _run_files_command(op, context_id)
+
+
+@files.command(name="download-url")
+@click.argument("file_id")
+def files_download_url(file_id: str):
+    """
+    Print a short-lived presigned GET URL for a file.
+
+    Example:
+      kagura files download-url <file_id>
+    """
+
+    async def op(client: FilesClient, _ctx: str) -> str:
+        return await client.download_url(file_id)
+
+    _run_files_command(op, None, needs_context=False)
+
+
+@files.command(name="delete")
+@click.argument("file_id")
+def files_delete(file_id: str):
+    """
+    Soft-delete a file by id.
+
+    Example:
+      kagura files delete <file_id>
+    """
+
+    async def op(client: FilesClient, _ctx: str) -> str:
+        await client.delete(file_id)
+        return f"Deleted {file_id}"
+
+    _run_files_command(op, None, needs_context=False)
+
+
+@files.command(name="list")
+@click.option("--context-id", "-c", help="Context (workspace) UUID to list")
+@click.option("--limit", "-l", type=int, default=50, help="Max results (1-500)")
+@click.option("--cursor", help="Forward-compat cursor (server v0.16+)")
+def files_list(context_id: str | None, limit: int, cursor: str | None):
+    """
+    List uploaded files in a context, newest first.
+
+    Example:
+      kagura files list --context-id ctx-uuid
+    """
+
+    async def op(client: FilesClient, ctx: str) -> str:
+        result = await client.list(context_id=ctx, limit=limit, cursor=cursor)
+        return result.model_dump_json(indent=2)
+
+    _run_files_command(op, context_id)
 
 
 if __name__ == "__main__":

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1187,11 +1187,17 @@ def _run_files_command(
 ) -> None:
     """Execute a FilesClient operation with standard boilerplate.
 
-    Loads config exactly once, resolves api_key + context_id together
-    so the operator sees a single, consistent error path.
+    Validates api_key first (matching ``_run_client_command``'s order)
+    so the operator sees a consistent error when both api_key and
+    context_id are missing.
     """
     try:
         config = load_config()
+        if not config.get("api_key"):
+            raise click.ClickException(
+                "No API key found. Set KAGURA_API_KEY or create .kagura.json"
+            )
+
         ctx_id = ""
         if needs_context:
             ctx_id = context_id or config.get("context_id") or ""

--- a/src/kagura_memory/exceptions.py
+++ b/src/kagura_memory/exceptions.py
@@ -42,9 +42,15 @@ class KaguraQuotaError(KaguraError):
 
 
 class KaguraIntegrityError(KaguraError):
-    """File integrity check failed.
+    """Object store rejected an upload with HTTP 400.
 
-    Raised when R2 rejects an upload with ``400 BadDigest`` because the
-    body's sha256 does not match the value bound into the presigned PUT
-    URL (`x-amz-checksum-sha256` header / `ChecksumSHA256` parameter).
+    Raised for any ``HTTP 400`` response from the object store on a
+    presigned PUT — most commonly R2 ``BadDigest`` (the body's sha256
+    did not match the value bound into the presigned PUT URL via the
+    ``x-amz-checksum-sha256`` header / ``ChecksumSHA256`` parameter),
+    but also covers other 400 causes such as a malformed presigned
+    URL or a ``Content-Length`` mismatch. The exception message
+    documents the most likely cause; callers should not assume a
+    specific S3-XML error code without inspecting the underlying
+    ``__cause__`` response body.
     """

--- a/src/kagura_memory/exceptions.py
+++ b/src/kagura_memory/exceptions.py
@@ -39,3 +39,12 @@ class KaguraQuotaError(KaguraError):
     def __init__(self, message: str, retry_after: int | None = None):
         super().__init__(message)
         self.retry_after = retry_after
+
+
+class KaguraIntegrityError(KaguraError):
+    """File integrity check failed.
+
+    Raised when R2 rejects an upload with ``400 BadDigest`` because the
+    body's sha256 does not match the value bound into the presigned PUT
+    URL (`x-amz-checksum-sha256` header / `ChecksumSHA256` parameter).
+    """

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -1,0 +1,426 @@
+"""REST client for Kagura Memory Cloud file uploads.
+
+Drives the 3-step file upload flow against memory-cloud:
+
+1. ``POST /api/v1/files/reserve`` — server returns a presigned PUT URL.
+2. ``PUT`` to R2 with body bytes and the ``x-amz-checksum-sha256``
+   header (base64 of the raw sha256 digest). Required when the
+   backend has ``R2_CHECKSUM_BINDING_ENABLED=true`` (memory-cloud
+   v0.15.1+).
+3. ``POST /api/v1/files/{file_id}/confirm`` — finalize the row.
+
+Plus ``download_url()``, ``delete()`` and ``list()`` for additional
+file operations.
+
+The R2 PUT is sent via a separate :class:`httpx.AsyncClient` so the
+SDK's ``Authorization: Bearer`` header cannot leak to the object
+store, regardless of what other methods are added to this class.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import mimetypes
+from pathlib import Path
+from typing import Any, Literal
+
+import httpx
+
+from ._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
+from .exceptions import (
+    KaguraAuthError,
+    KaguraConnectionError,
+    KaguraIntegrityError,
+    KaguraNotFoundError,
+    KaguraQuotaError,
+)
+from .models import (
+    FileDownloadUrlResponse,
+    FileListResponse,
+    FileObject,
+    FileReserveResponse,
+)
+
+
+class FilesClient:
+    """REST API client for Kagura Memory Cloud file objects.
+
+    Authentication: ``Authorization: Bearer <api_key>`` (set once in
+    constructor). The R2 PUT step is unauthenticated by design — the
+    presigned URL carries its own short-lived SigV4 signature.
+
+    All methods may raise:
+        KaguraAuthError: Authentication failed (401)
+        KaguraNotFoundError: File not found (404)
+        KaguraIntegrityError: Body sha256 did not match the presigned PUT
+            binding (R2 returned 400 BadDigest)
+        KaguraConnectionError: Connection or other HTTP error
+        KaguraQuotaError: Quota exceeded (429)
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://memory.kagura-ai.com",
+        timeout: float = 30.0,
+        upload_timeout: float = 300.0,
+    ) -> None:
+        """Initialize FilesClient.
+
+        Args:
+            api_key: Kagura API key (Bearer token for API operations).
+            base_url: REST API base URL (without path).
+            timeout: API request timeout in seconds.
+            upload_timeout: R2 PUT timeout in seconds (defaults to 5
+                minutes to accommodate large files on slow networks).
+        """
+        stripped_url = base_url.rstrip("/")
+        validate_https_url(stripped_url, label="Base URL")
+
+        self.base_url = stripped_url
+        self._client = httpx.AsyncClient(
+            timeout=timeout,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "User-Agent": f"kagura-memory-sdk/{SDK_VERSION}",
+            },
+        )
+        # Separate client for outbound PUT to the object store. Carries
+        # no Bearer header so a future contributor cannot accidentally
+        # leak the API key by adding another method that reuses it.
+        self._upload_client = httpx.AsyncClient(
+            timeout=upload_timeout,
+            headers={"User-Agent": f"kagura-memory-sdk/{SDK_VERSION}"},
+        )
+
+    @classmethod
+    def from_mcp_url(
+        cls,
+        api_key: str,
+        mcp_url: str = "https://memory.kagura-ai.com/mcp",
+        timeout: float = 30.0,
+        upload_timeout: float = 300.0,
+    ) -> FilesClient:
+        """Create FilesClient by deriving the REST base URL from an MCP URL.
+
+        Strips ``/mcp`` and everything after it. Handles both
+        ``/mcp`` and ``/mcp/w/{workspace_id}`` formats.
+        """
+        url = mcp_url.rstrip("/")
+        base_url = base_url_from_mcp(url)
+        return cls(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+            upload_timeout=upload_timeout,
+        )
+
+    # -------------------------------------------------------------------
+    # Internal HTTP helpers
+    # -------------------------------------------------------------------
+
+    async def _request(
+        self,
+        method: Literal["GET", "POST", "DELETE"],
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Make an authenticated request with standard error mapping."""
+        url = f"{self.base_url}{path}"
+        try:
+            response = await self._client.request(method, url, json=json, params=params)
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 401:
+                raise KaguraAuthError("Authentication failed. Check your API key.") from e
+            if status == 404:
+                raise KaguraNotFoundError(extract_detail(e.response) or "Not found") from e
+            if status == 429:
+                retry_after = e.response.headers.get("Retry-After")
+                raise KaguraQuotaError(
+                    "Quota exceeded. Try again later.",
+                    retry_after=int(retry_after) if retry_after else None,
+                ) from e
+            detail = extract_detail(e.response)
+            msg = f"HTTP {status}: {detail}" if detail else f"HTTP {status}"
+            raise KaguraConnectionError(msg) from e
+        except httpx.RequestError as e:
+            raise KaguraConnectionError(f"Connection failed: {e}") from e
+
+    async def _put_to_object_store(
+        self,
+        upload_url: str,
+        body: bytes,
+        sha256_hex: str,
+        content_type: str,
+    ) -> None:
+        """PUT ``body`` to the presigned R2 URL with checksum binding.
+
+        Sends ``x-amz-checksum-sha256`` as base64 of the raw 32-byte
+        digest (NOT base64 of the hex string). When the backend has
+        ``R2_CHECKSUM_BINDING_ENABLED=true`` and the body's actual
+        sha256 differs from this header, R2 returns 400 BadDigest and
+        we raise :class:`KaguraIntegrityError`.
+
+        Note: any other 400 response from R2 (e.g. a malformed
+        presigned URL or unexpected ``Content-Length`` mismatch) is
+        also surfaced as :class:`KaguraIntegrityError`. BadDigest is
+        the documented and observed common cause; parsing the
+        S3-XML error body for finer discrimination is out of scope
+        for v0.14.0.
+        """
+        checksum_b64 = base64.b64encode(bytes.fromhex(sha256_hex)).decode()
+        try:
+            response = await self._upload_client.put(
+                upload_url,
+                content=body,
+                headers={
+                    "Content-Type": content_type,
+                    "x-amz-checksum-sha256": checksum_b64,
+                },
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 400:
+                raise KaguraIntegrityError(
+                    "Object store rejected upload with HTTP 400 — most "
+                    "commonly R2 BadDigest (body sha256 did not match the "
+                    "presigned PUT binding). Verify that the SDK is "
+                    "computing sha256 over the exact bytes being PUT."
+                ) from e
+            raise KaguraConnectionError(
+                f"Object store PUT failed: HTTP {e.response.status_code}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise KaguraConnectionError(f"Object store PUT timed out: {e}") from e
+        except httpx.RequestError as e:
+            raise KaguraConnectionError(f"Object store PUT failed: {e}") from e
+
+    # -------------------------------------------------------------------
+    # Public API
+    # -------------------------------------------------------------------
+
+    async def upload(
+        self,
+        *,
+        context_id: str,
+        source: Path | bytes,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> FileObject:
+        """Upload a file to Kagura Memory Cloud.
+
+        Drives the full 3-step flow: reserve → presigned PUT →
+        confirm. Returns the finalized :class:`FileObject` on success.
+
+        Args:
+            context_id: Target context (workspace) UUID. The SDK uses
+                ``context_id`` consistently across clients; this is
+                mapped to the backend's ``workspace_id`` field on the
+                wire.
+            source: File contents. ``Path`` reads the file fully
+                into memory; ``bytes`` uses the buffer directly.
+                Chunked / streaming PUT is out of scope for v0.14.0
+                (the server caps file size at 100 MiB by default).
+            filename: Required when ``source`` is ``bytes`` (the
+                server requires a filename). Defaults to ``path.name``
+                when ``source`` is a ``Path``.
+            content_type: MIME type. When omitted, falls back to
+                :func:`mimetypes.guess_type` and then to
+                ``application/octet-stream``.
+
+        Returns:
+            FileObject with the finalized file metadata. When the file
+            already exists with the same sha256 in the workspace the
+            server returns 409 and the SDK surfaces the existing
+            FileObject (dedup happy-path) rather than raising.
+
+        Raises:
+            ValueError: If ``source`` is ``bytes`` and ``filename`` is
+                not provided.
+            KaguraIntegrityError: If R2 rejected the body sha256
+                binding.
+            KaguraAuthError, KaguraNotFoundError, KaguraQuotaError,
+            KaguraConnectionError: see class docstring.
+        """
+        resolved_filename, body, sha256_hex = _prepare_source(source, filename)
+        size_bytes = len(body)
+        resolved_content_type = _resolve_content_type(content_type, resolved_filename)
+
+        reserve_body = {
+            "workspace_id": context_id,
+            "filename": resolved_filename,
+            "content_type": resolved_content_type,
+            "size_bytes": size_bytes,
+            "sha256": sha256_hex,
+        }
+
+        try:
+            reserve_resp = await self._request("POST", "/api/v1/files/reserve", json=reserve_body)
+        except KaguraConnectionError as e:
+            # 409 dedup happy-path: server reports the existing file
+            # in the error detail; surface it as a FileObject so the
+            # caller does not have to special-case duplicates.
+            existing = _extract_existing_file(e)
+            if existing is not None:
+                return existing
+            raise
+
+        reserve = FileReserveResponse.model_validate(reserve_resp.json())
+
+        await self._put_to_object_store(
+            upload_url=reserve.upload_url,
+            body=body,
+            sha256_hex=sha256_hex,
+            content_type=resolved_content_type,
+        )
+
+        confirm_resp = await self._request(
+            "POST",
+            f"/api/v1/files/{reserve.file_id}/confirm",
+            json={"sha256": sha256_hex},
+        )
+        return FileObject.model_validate(confirm_resp.json())
+
+    async def download_url(self, file_id: str) -> str:
+        """Return a short-lived presigned GET URL for ``file_id``."""
+        response = await self._request("GET", f"/api/v1/files/{file_id}/download-url")
+        return FileDownloadUrlResponse.model_validate(response.json()).download_url
+
+    async def delete(self, file_id: str) -> None:
+        """Soft-delete a file by id (server hard-deletes after retention)."""
+        await self._request("DELETE", f"/api/v1/files/{file_id}")
+
+    async def list(
+        self,
+        *,
+        context_id: str,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> FileListResponse:
+        """List uploaded files in a workspace, newest first.
+
+        Args:
+            context_id: Workspace UUID to list files for.
+            limit: Maximum number of files to return (1-500, default
+                50). Server-side cap is 500.
+            cursor: Forward-compatible pagination cursor. The current
+                server (memory-cloud v0.15.x) ignores this field and
+                always returns at most ``limit`` items; a future
+                server version is expected to populate
+                :attr:`FileListResponse.next_cursor`.
+
+        Returns:
+            FileListResponse with the page of files and an optional
+            ``next_cursor`` (always ``None`` against the current
+            server).
+        """
+        params: dict[str, Any] = {"workspace_id": context_id, "limit": limit}
+        if cursor is not None:
+            params["cursor"] = cursor
+        response = await self._request("GET", "/api/v1/files", params=params)
+        raw = response.json()
+        # Current server returns a bare ``list[FileObjectOut]``;
+        # future server versions may return ``{files, next_cursor}``.
+        if isinstance(raw, list):
+            return FileListResponse(
+                files=[FileObject.model_validate(item) for item in raw],
+                next_cursor=None,
+            )
+        return FileListResponse.model_validate(raw)
+
+    # -------------------------------------------------------------------
+    # Lifecycle
+    # -------------------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close both HTTP clients.
+
+        Uses try/finally so the second client is still closed if the
+        first raises during teardown — otherwise we would leak the
+        upload client's connection pool on a flaky API client close.
+        """
+        try:
+            await self._client.aclose()
+        finally:
+            await self._upload_client.aclose()
+
+    async def __aenter__(self) -> FilesClient:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any,
+    ) -> None:
+        await self.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_existing_file(error: KaguraConnectionError) -> FileObject | None:
+    """Pull an ``existing_file`` payload out of a 409 dedup response.
+
+    The 409 path comes through :meth:`_request` as a
+    :class:`KaguraConnectionError` chained from the underlying
+    :class:`httpx.HTTPStatusError`. We re-inspect the response body
+    (not just the formatted message) to recover the structured
+    ``existing_file`` field the server attaches.
+    """
+    cause = error.__cause__
+    if not isinstance(cause, httpx.HTTPStatusError):
+        return None
+    if cause.response.status_code != 409:
+        return None
+    try:
+        body = cause.response.json()
+    except (ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    existing = body.get("existing_file")
+    if not isinstance(existing, dict):
+        return None
+    return FileObject.model_validate(existing)
+
+
+def _resolve_content_type(content_type: str | None, filename: str) -> str:
+    """Pick a content_type — explicit > mimetypes guess > octet-stream."""
+    if content_type:
+        return content_type
+    guessed, _ = mimetypes.guess_type(filename)
+    return guessed or "application/octet-stream"
+
+
+def _prepare_source(
+    source: Path | bytes,
+    filename: str | None,
+) -> tuple[str, bytes, str]:
+    """Resolve filename, load bytes, compute sha256.
+
+    Returns ``(filename, body, sha256_hex)``. The body is fully
+    materialized in memory — the PUT step needs all bytes and the
+    server caps file size at 100 MiB by default. Chunked PUT is out
+    of scope for v0.14.0.
+    """
+    if isinstance(source, Path):
+        if not source.is_file():
+            raise FileNotFoundError(f"source path does not exist: {source}")
+        resolved_filename = filename or source.name
+        body = source.read_bytes()
+        return resolved_filename, body, hashlib.sha256(body).hexdigest()
+
+    if not filename:
+        raise ValueError(
+            "filename is required when source is bytes (the server requires a non-empty filename)."
+        )
+    return filename, source, hashlib.sha256(source).hexdigest()

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -403,7 +403,17 @@ def _resolve_content_type(content_type: str | None, filename: str) -> str:
 
 
 def _read_and_hash(path: Path) -> tuple[bytes, str]:
-    """Synchronously read a file and compute its sha256 — runs in a thread."""
+    """Synchronously read a file and compute its sha256 — runs in a thread.
+
+    Reads the full file into memory by design. R2 presigned PUT is a
+    single-PUT operation (chunked / streaming PUT is out of scope for
+    v0.14.0 per the issue body's "Out of scope" section), so the body
+    is needed in memory at upload time regardless of how it's hashed.
+    Peak memory is bounded by the server's 100 MiB file size cap; a
+    streaming hash + second file read for PUT would double disk I/O
+    without lowering peak memory. Revisit when chunked PUT lands in
+    a future SDK release.
+    """
     body = path.read_bytes()
     return body, hashlib.sha256(body).hexdigest()
 

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -19,6 +19,7 @@ store, regardless of what other methods are added to this class.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import mimetypes
@@ -248,7 +249,7 @@ class FilesClient:
             KaguraAuthError, KaguraNotFoundError, KaguraQuotaError,
             KaguraConnectionError: see class docstring.
         """
-        resolved_filename, body, sha256_hex = _prepare_source(source, filename)
+        resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
         size_bytes = len(body)
         resolved_content_type = _resolve_content_type(content_type, resolved_filename)
 
@@ -401,7 +402,13 @@ def _resolve_content_type(content_type: str | None, filename: str) -> str:
     return guessed or "application/octet-stream"
 
 
-def _prepare_source(
+def _read_and_hash(path: Path) -> tuple[bytes, str]:
+    """Synchronously read a file and compute its sha256 — runs in a thread."""
+    body = path.read_bytes()
+    return body, hashlib.sha256(body).hexdigest()
+
+
+async def _prepare_source(
     source: Path | bytes,
     filename: str | None,
 ) -> tuple[str, bytes, str]:
@@ -411,13 +418,19 @@ def _prepare_source(
     materialized in memory — the PUT step needs all bytes and the
     server caps file size at 100 MiB by default. Chunked PUT is out
     of scope for v0.14.0.
+
+    For ``Path`` sources the disk read + hash runs in ``asyncio.to_thread``
+    so that ``upload()`` does not block the event loop while waiting on
+    file I/O — important when several concurrent uploads share a runtime.
+    ``bytes`` input stays on the loop because the buffer is already
+    resident in memory.
     """
     if isinstance(source, Path):
         if not source.is_file():
             raise FileNotFoundError(f"source path does not exist: {source}")
         resolved_filename = filename or source.name
-        body = source.read_bytes()
-        return resolved_filename, body, hashlib.sha256(body).hexdigest()
+        body, sha256_hex = await asyncio.to_thread(_read_and_hash, source)
+        return resolved_filename, body, sha256_hex
 
     if not filename:
         raise ValueError(

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -226,8 +226,16 @@ class FilesClient:
                 wire.
             source: File contents. ``Path`` reads the file fully
                 into memory; ``bytes`` uses the buffer directly.
-                Chunked / streaming PUT is out of scope for v0.14.0
-                (the server caps file size at 100 MiB by default).
+                **Memory contract**: peak memory is bounded by the
+                file size. R2 presigned PUT is single-PUT (chunked /
+                streaming PUT is out of scope for v0.14.0), so the
+                body has to be resident at upload time regardless of
+                how it's hashed. The server caps file size at 100 MiB
+                by default; callers uploading anywhere near that bound
+                should size their runtime accordingly. The server
+                rejects oversize uploads at the boundary — the SDK
+                does not enforce a client-side cap so that a future
+                server-side cap bump is non-breaking.
             filename: Required when ``source`` is ``bytes`` (the
                 server requires a filename). Defaults to ``path.name``
                 when ``source`` is a ``Path``.

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -643,3 +643,59 @@ class Edge(BaseModel):
     confidence: float = Field(ge=0.0, le=1.0)
     created_at: datetime | None = None
     last_updated: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# File objects (server v0.15.1+)
+# ---------------------------------------------------------------------------
+
+
+class FileObject(BaseModel):
+    """File metadata returned by upload / list / dedup operations.
+
+    Mirrors the server's ``FileObjectOut``. The ``workspace_id`` field
+    name is preserved on the wire; SDK public methods accept the same
+    value as ``context_id`` for vocabulary consistency with the rest of
+    the SDK.
+
+    ``status`` is typed as ``str`` (not a ``Literal``) because the server
+    may add new lifecycle states over time. Known values today:
+    ``reserved``, ``uploaded``, ``confirmed``.
+    """
+
+    id: str
+    workspace_id: str
+    filename: str
+    content_type: str
+    size_bytes: int
+    sha256: str
+    status: str
+    created_at: datetime
+    uploaded_at: datetime | None = None
+
+
+class FileReserveResponse(BaseModel):
+    """Internal response from ``POST /api/v1/files/reserve``."""
+
+    file_id: str
+    upload_url: str
+    expires_at: datetime
+
+
+class FileDownloadUrlResponse(BaseModel):
+    """Internal response from ``GET /api/v1/files/{file_id}/download-url``."""
+
+    download_url: str
+
+
+class FileListResponse(BaseModel):
+    """Paginated list of files.
+
+    ``next_cursor`` is forward-compatible — the current server
+    (memory-cloud v0.15.x) returns at most ``limit`` items with no
+    cursor field; SDK preserves the field as ``None`` so a future
+    server bump can populate it without breaking callers.
+    """
+
+    files: list[FileObject]
+    next_cursor: str | None = None

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 import httpx
 
-from ._http import SDK_VERSION, base_url_from_mcp, validate_https_url
+from ._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
 from .client import KaguraClient
 from .exceptions import (
     KaguraAuthError,
@@ -138,29 +138,15 @@ class ResourceClient:
             if status == 401:
                 raise KaguraAuthError("Authentication failed. Check your API key.") from e
             if status == 404:
-                detail = ""
-                try:
-                    body = e.response.json()
-                    detail = body.get("detail", "") if isinstance(body, dict) else ""
-                except (ValueError, UnicodeDecodeError):
-                    pass
-                raise KaguraNotFoundError(detail or "Not found") from e
+                raise KaguraNotFoundError(extract_detail(e.response) or "Not found") from e
             if status == 429:
                 retry_after = e.response.headers.get("Retry-After")
                 raise KaguraQuotaError(
                     "Quota exceeded. Try again later.",
                     retry_after=int(retry_after) if retry_after else None,
                 ) from e
-            # Try to extract detail from JSON response
-            detail = ""
-            try:
-                body = e.response.json()
-                detail = body.get("detail", "") if isinstance(body, dict) else ""
-            except (ValueError, UnicodeDecodeError):
-                pass
-            msg = f"HTTP {status}"
-            if detail:
-                msg = f"{msg}: {detail}"
+            detail = extract_detail(e.response)
+            msg = f"HTTP {status}: {detail}" if detail else f"HTTP {status}"
             raise KaguraConnectionError(msg) from e
         except httpx.RequestError as e:
             raise KaguraConnectionError(f"Connection failed: {e}") from e

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -120,6 +120,26 @@ def test_files_delete(mock_client_cls, mock_config):
 
 @patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.FilesClient")
+def test_files_unexpected_exception_wrapped_as_click(mock_client_cls, mock_config, tmp_path):
+    """Non-ClickException raised inside the runner → wrapped as 'Error: ...'."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_client_cls.from_mcp_url.side_effect = RuntimeError("boom from factory")
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p)])
+
+    assert result.exit_code != 0
+    assert "Error: boom from factory" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
 def test_files_list(mock_client_cls, mock_config):
     mock_config.return_value = {
         "api_key": "key",

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -1,0 +1,143 @@
+"""Tests for `kagura files ...` CLI commands."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from kagura_memory.cli import main
+from kagura_memory.models import FileListResponse, FileObject
+
+SAMPLE_CTX_ID = "00000000-0000-0000-0000-000000000001"
+SAMPLE_FILE_ID = "10000000-0000-0000-0000-000000000002"
+
+
+def _file_object() -> FileObject:
+    return FileObject(
+        id=SAMPLE_FILE_ID,
+        workspace_id=SAMPLE_CTX_ID,
+        filename="hello.txt",
+        content_type="text/plain",
+        size_bytes=18,
+        sha256="a" * 64,
+        status="uploaded",
+        created_at=datetime(2026, 5, 11, tzinfo=UTC),
+        uploaded_at=datetime(2026, 5, 11, 0, 0, 1, tzinfo=UTC),
+    )
+
+
+def _mock_files_client(method_name: str, return_value) -> MagicMock:
+    """Build a FilesClient mock with one method stubbed."""
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    getattr(client, method_name).return_value = return_value
+    return client
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload(mock_client_cls, mock_config, tmp_path):
+    """`kagura files upload` calls FilesClient.upload and prints the FileObject."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_client = _mock_files_client("upload", _file_object())
+    # FilesClient.from_mcp_url is a classmethod — patch it too
+    mock_client_cls.from_mcp_url.return_value = mock_client
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hello kagura files")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p)])
+
+    assert result.exit_code == 0, result.output
+    assert SAMPLE_FILE_ID in result.output
+    assert "uploaded" in result.output
+
+    mock_client.upload.assert_awaited_once()
+    call = mock_client.upload.call_args
+    assert call.kwargs["context_id"] == SAMPLE_CTX_ID
+    assert call.kwargs["source"] == p
+
+
+@patch("kagura_memory.cli.load_config")
+def test_files_upload_missing_api_key(mock_config, tmp_path):
+    """upload with context-id provided but no api_key → No API key error."""
+    mock_config.return_value = {"api_key": "", "context_id": SAMPLE_CTX_ID}
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p)])
+    assert result.exit_code != 0
+    assert "No API key" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+def test_files_upload_missing_context(mock_config, tmp_path):
+    """upload without --context-id and without .kagura.json default → error."""
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p)])
+    assert result.exit_code != 0
+    assert "context_id required" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_download_url(mock_client_cls, mock_config):
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+    mock_client = _mock_files_client("download_url", "https://r2.example.com/get/key?sig=...")
+    mock_client_cls.from_mcp_url.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "download-url", SAMPLE_FILE_ID])
+
+    assert result.exit_code == 0, result.output
+    assert "https://r2.example.com/get/key" in result.output
+    mock_client.download_url.assert_awaited_once_with(SAMPLE_FILE_ID)
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_delete(mock_client_cls, mock_config):
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+    mock_client = _mock_files_client("delete", None)
+    mock_client_cls.from_mcp_url.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "delete", SAMPLE_FILE_ID])
+
+    assert result.exit_code == 0, result.output
+    assert f"Deleted {SAMPLE_FILE_ID}" in result.output
+    mock_client.delete.assert_awaited_once_with(SAMPLE_FILE_ID)
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_list(mock_client_cls, mock_config):
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_client = _mock_files_client(
+        "list",
+        FileListResponse(files=[_file_object()], next_cursor=None),
+    )
+    mock_client_cls.from_mcp_url.return_value = mock_client
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert SAMPLE_FILE_ID in result.output
+
+    call = mock_client.list.call_args
+    assert call.kwargs["context_id"] == SAMPLE_CTX_ID
+    assert call.kwargs["limit"] == 50

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -1,0 +1,617 @@
+"""Tests for FilesClient."""
+
+import base64
+import hashlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from kagura_memory import (
+    FileListResponse,
+    FileObject,
+    FilesClient,
+    KaguraAuthError,
+    KaguraConnectionError,
+    KaguraIntegrityError,
+    KaguraNotFoundError,
+    KaguraQuotaError,
+)
+
+# ============================================================================
+# Test fixtures and helpers
+# ============================================================================
+
+SAMPLE_BODY = b"hello kagura files"
+SAMPLE_SHA256_HEX = hashlib.sha256(SAMPLE_BODY).hexdigest()
+SAMPLE_SHA256_B64 = base64.b64encode(hashlib.sha256(SAMPLE_BODY).digest()).decode()
+SAMPLE_CTX_ID = "00000000-0000-0000-0000-000000000001"
+SAMPLE_FILE_ID = "10000000-0000-0000-0000-000000000002"
+
+
+def _ok_response(
+    status_code: int = 200,
+    json_data: dict | list | None = None,
+) -> MagicMock:
+    """Build a MagicMock response with no error side-effect."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = {} if json_data is None else json_data
+    resp.raise_for_status = MagicMock()
+    resp.headers = {}
+    return resp
+
+
+def _error_response(status_code: int, json_data: dict | None = None) -> MagicMock:
+    """Build a MagicMock response that raises HTTPStatusError on raise_for_status."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = {}
+    resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status_code}", request=MagicMock(), response=resp
+    )
+    return resp
+
+
+def _file_object_dict(file_id: str = SAMPLE_FILE_ID, status: str = "uploaded") -> dict:
+    """Build a FileObject-shaped dict matching server's FileObjectOut."""
+    return {
+        "id": file_id,
+        "workspace_id": SAMPLE_CTX_ID,
+        "filename": "hello.txt",
+        "content_type": "text/plain",
+        "size_bytes": len(SAMPLE_BODY),
+        "sha256": SAMPLE_SHA256_HEX,
+        "status": status,
+        "created_at": "2026-05-11T00:00:00Z",
+        "uploaded_at": "2026-05-11T00:00:01Z",
+    }
+
+
+def _reserve_response_dict(
+    file_id: str = SAMPLE_FILE_ID,
+    upload_url: str = "https://r2.example.com/bucket/key",
+) -> dict:
+    return {
+        "file_id": file_id,
+        "upload_url": upload_url,
+        "expires_at": "2026-05-11T00:05:00Z",
+    }
+
+
+# ============================================================================
+# Construction / HTTPS enforcement
+# ============================================================================
+
+
+def test_rejects_http_url():
+    """HTTP URLs (non-localhost) should raise ValueError."""
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        FilesClient(api_key="test", base_url="http://evil.com")
+
+
+def test_allows_https_url():
+    client = FilesClient(api_key="test", base_url="https://memory.kagura-ai.com")
+    assert client.base_url == "https://memory.kagura-ai.com"
+
+
+def test_allows_localhost_http():
+    client = FilesClient(api_key="test", base_url="http://localhost:8080")
+    assert client.base_url == "http://localhost:8080"
+
+
+def test_strips_trailing_slash():
+    client = FilesClient(api_key="test", base_url="https://example.com/")
+    assert client.base_url == "https://example.com"
+
+
+def test_from_mcp_url_strips_mcp_path():
+    client = FilesClient.from_mcp_url(api_key="test", mcp_url="https://memory.kagura-ai.com/mcp")
+    assert client.base_url == "https://memory.kagura-ai.com"
+
+
+def test_from_mcp_url_strips_workspace_segment():
+    client = FilesClient.from_mcp_url(
+        api_key="test", mcp_url="https://memory.kagura-ai.com/mcp/w/abc"
+    )
+    assert client.base_url == "https://memory.kagura-ai.com"
+
+
+def test_api_key_not_stored_as_attribute():
+    """API key must live only in the httpx headers, never as an instance attribute."""
+    client = FilesClient(api_key="kagura_secret", base_url="https://example.com")
+    public_attrs = {k: v for k, v in vars(client).items() if not k.startswith("_")}
+    for value in public_attrs.values():
+        assert "kagura_secret" not in str(value)
+
+
+def test_upload_client_has_no_authorization_header():
+    """The R2-bound client must NOT carry the Bearer token by construction."""
+    client = FilesClient(api_key="kagura_secret", base_url="https://example.com")
+    assert "Authorization" not in client._upload_client.headers
+    # Sanity: the API client still has it.
+    assert client._client.headers.get("Authorization") == "Bearer kagura_secret"
+
+
+# ============================================================================
+# upload() — happy path
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_upload_bytes_happy_path():
+    """reserve → PUT → confirm; returns finalized FileObject."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict(status="uploaded"))
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        result = await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="hello.txt",
+        )
+
+    assert isinstance(result, FileObject)
+    assert result.id == SAMPLE_FILE_ID
+    assert result.status == "uploaded"
+
+    # reserve call inspection
+    reserve_call = mock_req.call_args_list[0]
+    assert reserve_call[0][0] == "POST"
+    assert reserve_call[0][1].endswith("/api/v1/files/reserve")
+    body = reserve_call[1]["json"]
+    assert body["workspace_id"] == SAMPLE_CTX_ID
+    assert body["filename"] == "hello.txt"
+    assert body["size_bytes"] == len(SAMPLE_BODY)
+    assert body["sha256"] == SAMPLE_SHA256_HEX
+
+    # confirm call inspection
+    confirm_call = mock_req.call_args_list[1]
+    assert confirm_call[0][0] == "POST"
+    assert f"/api/v1/files/{SAMPLE_FILE_ID}/confirm" in confirm_call[0][1]
+    assert confirm_call[1]["json"] == {"sha256": SAMPLE_SHA256_HEX}
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_sends_base64_raw_digest_header():
+    """x-amz-checksum-sha256 must be base64 of the raw 32-byte digest, NOT hex.
+
+    This is the canonical footgun: base64-encoding the hex string yields a
+    64-char value; base64-encoding the raw digest yields a 44-char value.
+    R2 enforces the raw-digest form.
+    """
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="hello.txt",
+        )
+
+    # PUT was called with the correct base64-of-raw-digest header
+    put_kwargs = mock_put.call_args.kwargs
+    sent = put_kwargs["headers"]["x-amz-checksum-sha256"]
+    assert sent == SAMPLE_SHA256_B64
+    assert len(sent) == 44  # base64(32 raw bytes) — never 64 (which would be hex-encoded)
+    # And NOT the wrong hex-then-base64 form
+    wrong = base64.b64encode(SAMPLE_SHA256_HEX.encode()).decode()
+    assert sent != wrong
+    assert len(wrong) == 88  # sanity: the wrong form has different length
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_from_path(tmp_path: Path):
+    """Path source streams sha256 from disk and uses path.name as filename."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    p = tmp_path / "report.pdf"
+    p.write_bytes(SAMPLE_BODY)
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(context_id=SAMPLE_CTX_ID, source=p)
+
+    body = mock_req.call_args_list[0][1]["json"]
+    assert body["filename"] == "report.pdf"
+    assert body["sha256"] == SAMPLE_SHA256_HEX
+    # mimetypes guess for .pdf
+    assert body["content_type"] == "application/pdf"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_content_type_defaults_to_octet_stream_for_bytes():
+    """bytes input without filename hint → application/octet-stream."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="payload",  # no extension → unguessable
+        )
+
+    body = mock_req.call_args_list[0][1]["json"]
+    assert body["content_type"] == "application/octet-stream"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_path_not_found_raises():
+    """source=Path pointing at a missing file → FileNotFoundError, no HTTP call."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    missing = Path("/tmp/__kagura_does_not_exist_xyz__.bin")
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            await client.upload(context_id=SAMPLE_CTX_ID, source=missing)
+    mock_req.assert_not_called()
+    mock_put.assert_not_called()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_bytes_requires_filename():
+    """source=bytes without filename → ValueError before any HTTP call."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        with pytest.raises(ValueError, match="filename is required"):
+            await client.upload(context_id=SAMPLE_CTX_ID, source=SAMPLE_BODY)
+
+    mock_req.assert_not_called()
+    mock_put.assert_not_called()
+    await client.close()
+
+
+# ============================================================================
+# upload() — error and dedup paths
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_upload_409_dedup_returns_existing_file():
+    """reserve 409 with existing_file payload → return FileObject, no PUT/confirm."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    existing = _file_object_dict(file_id="existing-uuid", status="uploaded")
+    dup_resp = _error_response(
+        409,
+        {"detail": "file with this sha256 already exists", "existing_file": existing},
+    )
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.return_value = dup_resp
+
+        result = await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="hello.txt",
+        )
+
+    assert result.id == "existing-uuid"
+    assert result.status == "uploaded"
+    # No PUT, no confirm — dedup short-circuited the flow.
+    assert mock_req.call_count == 1
+    mock_put.assert_not_called()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_409_without_existing_file_raises():
+    """409 without an existing_file payload is just a normal connection error."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    dup_resp = _error_response(409, {"detail": "conflict, but no payload"})
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = dup_resp
+
+        with pytest.raises(KaguraConnectionError, match="HTTP 409"):
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+            )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_r2_bad_digest_raises_integrity_error():
+    """R2 returning 400 → KaguraIntegrityError (not a generic connection error)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    r2_error = _error_response(400, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.return_value = reserve_resp
+        mock_put.return_value = r2_error
+
+        with pytest.raises(KaguraIntegrityError, match="BadDigest"):
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+            )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_r2_network_error_raises_connection_error():
+    """Non-timeout httpx.RequestError on PUT → KaguraConnectionError."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.return_value = reserve_resp
+        mock_put.side_effect = httpx.ConnectError("connection refused")
+
+        with pytest.raises(KaguraConnectionError, match="Object store PUT failed"):
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+            )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_r2_timeout_raises_connection_error():
+    """R2 PUT timeout → KaguraConnectionError with 'timed out' in message."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.return_value = reserve_resp
+        mock_put.side_effect = httpx.TimeoutException("timeout")
+
+        with pytest.raises(KaguraConnectionError, match="timed out"):
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+            )
+
+    await client.close()
+
+
+# ============================================================================
+# Error mapping on _request (mirrors ResourceClient contract)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_request_401_raises_auth_error():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    err_resp = _error_response(401, {"detail": "bad key"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraAuthError):
+            await client.delete("some-file-id")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_request_404_raises_not_found():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    err_resp = _error_response(404, {"detail": "file gone"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraNotFoundError, match="file gone"):
+            await client.download_url("some-file-id")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_request_429_raises_quota_error_with_retry_after():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    err_resp = _error_response(429, {})
+    err_resp.headers = {"Retry-After": "60"}
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraQuotaError) as exc_info:
+            await client.delete("some-file-id")
+        assert exc_info.value.retry_after == 60
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_request_network_error_raises_connection_error():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.side_effect = httpx.ConnectError("refused")
+        with pytest.raises(KaguraConnectionError, match="Connection failed"):
+            await client.delete("some-file-id")
+    await client.close()
+
+
+# ============================================================================
+# download_url / delete / list
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_download_url_returns_string():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    resp = _ok_response(200, {"download_url": "https://r2.example.com/get/key?sig=..."})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = resp
+        url = await client.download_url(SAMPLE_FILE_ID)
+    assert url == "https://r2.example.com/get/key?sig=..."
+    call = mock_req.call_args
+    assert call[0][0] == "GET"
+    assert f"/api/v1/files/{SAMPLE_FILE_ID}/download-url" in call[0][1]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_none():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    resp = _ok_response(204, {})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = resp
+        result = await client.delete(SAMPLE_FILE_ID)
+    assert result is None
+    call = mock_req.call_args
+    assert call[0][0] == "DELETE"
+    assert f"/api/v1/files/{SAMPLE_FILE_ID}" in call[0][1]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_with_legacy_bare_array_response():
+    """Server v0.15.x returns bare list[FileObjectOut]; SDK wraps it."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    resp = _ok_response(200, [_file_object_dict(), _file_object_dict(file_id="another")])
+    # Mocked response returns the list when .json() is called
+    resp.json.return_value = [_file_object_dict(), _file_object_dict(file_id="another")]
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = resp
+        result = await client.list(context_id=SAMPLE_CTX_ID, limit=10)
+
+    assert isinstance(result, FileListResponse)
+    assert len(result.files) == 2
+    assert result.next_cursor is None  # current server has no cursor
+
+    call = mock_req.call_args
+    assert call[0][0] == "GET"
+    assert "/api/v1/files" in call[0][1]
+    assert call[1]["params"]["workspace_id"] == SAMPLE_CTX_ID
+    assert call[1]["params"]["limit"] == 10
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_forwards_cursor_when_provided():
+    """When cursor is given, it is forwarded as a query param (forward-compat)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    resp = _ok_response(200, [])
+    resp.json.return_value = []
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = resp
+        await client.list(context_id=SAMPLE_CTX_ID, limit=20, cursor="opaque-token")
+
+    call = mock_req.call_args
+    assert call[1]["params"]["cursor"] == "opaque-token"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_with_future_dict_response():
+    """A future server returning {files, next_cursor} is parsed natively."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    resp = _ok_response(
+        200,
+        {"files": [_file_object_dict()], "next_cursor": "page-2-token"},
+    )
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = resp
+        result = await client.list(context_id=SAMPLE_CTX_ID)
+
+    assert len(result.files) == 1
+    assert result.next_cursor == "page-2-token"
+    await client.close()
+
+
+# ============================================================================
+# Lifecycle
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_close_closes_both_clients():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with (
+        patch.object(client._client, "aclose", new_callable=AsyncMock) as api_close,
+        patch.object(client._upload_client, "aclose", new_callable=AsyncMock) as upload_close,
+    ):
+        await client.close()
+    api_close.assert_awaited_once()
+    upload_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_on_exit():
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with (
+        patch.object(client._client, "aclose", new_callable=AsyncMock) as api_close,
+        patch.object(client._upload_client, "aclose", new_callable=AsyncMock) as upload_close,
+    ):
+        async with client:
+            pass
+    api_close.assert_awaited_once()
+    upload_close.assert_awaited_once()

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -227,7 +227,7 @@ async def test_upload_sends_base64_raw_digest_header():
 
 @pytest.mark.asyncio
 async def test_upload_from_path(tmp_path: Path):
-    """Path source streams sha256 from disk and uses path.name as filename."""
+    """Path source reads bytes from disk and uses path.name as filename."""
     client = FilesClient(api_key="test", base_url="https://example.com")
 
     p = tmp_path / "report.pdf"

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -313,10 +313,10 @@ async def test_upload_content_type_defaults_to_octet_stream_for_bytes():
 
 
 @pytest.mark.asyncio
-async def test_upload_path_not_found_raises():
+async def test_upload_path_not_found_raises(tmp_path: Path):
     """source=Path pointing at a missing file → FileNotFoundError, no HTTP call."""
     client = FilesClient(api_key="test", base_url="https://example.com")
-    missing = Path("/tmp/__kagura_does_not_exist_xyz__.bin")
+    missing = tmp_path / "missing.bin"  # tmp_path guarantees this doesn't exist
     with (
         patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
         patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -256,6 +256,35 @@ async def test_upload_from_path(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_upload_explicit_content_type_overrides_sniff():
+    """User-supplied content_type is passed through verbatim."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="hello.txt",
+            content_type="application/x-custom",
+        )
+
+    body = mock_req.call_args_list[0][1]["json"]
+    assert body["content_type"] == "application/x-custom"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_upload_content_type_defaults_to_octet_stream_for_bytes():
     """bytes input without filename hint → application/octet-stream."""
     client = FilesClient(api_key="test", base_url="https://example.com")
@@ -412,6 +441,31 @@ async def test_upload_r2_network_error_raises_connection_error():
         mock_put.side_effect = httpx.ConnectError("connection refused")
 
         with pytest.raises(KaguraConnectionError, match="Object store PUT failed"):
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+            )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_r2_5xx_raises_connection_error():
+    """Non-400 R2 HTTP error (e.g. 500) → KaguraConnectionError, not IntegrityError."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    r2_500 = _error_response(500, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.return_value = reserve_resp
+        mock_put.return_value = r2_500
+
+        with pytest.raises(KaguraConnectionError, match="Object store PUT failed: HTTP 500"):
             await client.upload(
                 context_id=SAMPLE_CTX_ID,
                 source=SAMPLE_BODY,
@@ -584,6 +638,87 @@ async def test_list_with_future_dict_response():
 
     assert len(result.files) == 1
     assert result.next_cursor == "page-2-token"
+    await client.close()
+
+
+# ============================================================================
+# Lifecycle
+# ============================================================================
+
+
+# ============================================================================
+# _extract_existing_file defensive branches (module-level helper)
+# ============================================================================
+
+
+def _make_dedup_error(response_mock: MagicMock) -> KaguraConnectionError:
+    """Build a KaguraConnectionError chained from an HTTPStatusError, mirroring
+    what `_request` raises for non-{401, 404, 429} HTTP errors."""
+    status_err = httpx.HTTPStatusError(
+        f"{response_mock.status_code}",
+        request=MagicMock(),
+        response=response_mock,
+    )
+    err = KaguraConnectionError(f"HTTP {response_mock.status_code}")
+    err.__cause__ = status_err
+    return err
+
+
+def test_extract_existing_file_returns_none_when_cause_not_httpstatus():
+    """KaguraConnectionError without an HTTPStatusError cause → None."""
+    from kagura_memory.files_client import _extract_existing_file
+
+    err = KaguraConnectionError("plain network failure")
+    err.__cause__ = httpx.ConnectError("refused")
+    assert _extract_existing_file(err) is None
+
+
+def test_extract_existing_file_returns_none_for_non_409_status():
+    """Cause is HTTPStatusError but status != 409 → None."""
+    from kagura_memory.files_client import _extract_existing_file
+
+    resp = _error_response(500)
+    err = _make_dedup_error(resp)
+    assert _extract_existing_file(err) is None
+
+
+def test_extract_existing_file_returns_none_when_body_not_parseable():
+    """409 body that fails to decode as JSON → None (defensive)."""
+    from kagura_memory.files_client import _extract_existing_file
+
+    resp = _error_response(409)
+    resp.json.side_effect = ValueError("not json")
+    err = _make_dedup_error(resp)
+    assert _extract_existing_file(err) is None
+
+
+def test_extract_existing_file_returns_none_when_body_is_not_dict():
+    """409 body that's a bare list/string → None (defensive)."""
+    from kagura_memory.files_client import _extract_existing_file
+
+    resp = _error_response(409)
+    resp.json.return_value = ["not", "a", "dict"]
+    err = _make_dedup_error(resp)
+    assert _extract_existing_file(err) is None
+
+
+# ============================================================================
+# extract_detail (_http.py) — non-dict body fallthrough
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_request_500_with_non_dict_body_message():
+    """5xx with a bare-string JSON body → HTTP 500 message (no ': detail' suffix)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    err_resp = _error_response(500)
+    err_resp.json.return_value = "just a string, not a dict"
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            await client.delete("some-id")
+    # extract_detail returns "" for non-dict bodies; the message has no suffix.
+    assert str(exc_info.value) == "HTTP 500"
     await client.close()
 
 

--- a/tests/test_files_integration.py
+++ b/tests/test_files_integration.py
@@ -1,0 +1,64 @@
+"""Integration tests for FilesClient — gated by environment.
+
+Skipped unless ``KAGURA_INTEGRATION_URL`` is set (and the matching API
+key + context UUID are available). Runs a single round-trip against a
+local memory-cloud configured with ``R2_CHECKSUM_BINDING_ENABLED=true``
+so the SDK's ``x-amz-checksum-sha256`` header is actually validated by
+R2 on the wire.
+
+Local run:
+
+    export KAGURA_INTEGRATION_URL=http://localhost:8080
+    export KAGURA_API_KEY=kagura_...
+    export KAGURA_INTEGRATION_CONTEXT_ID=<workspace_uuid>
+    uv run pytest -m integration -v
+"""
+
+import hashlib
+import os
+import uuid
+
+import pytest
+
+from kagura_memory import FilesClient
+
+INTEGRATION_URL = os.environ.get("KAGURA_INTEGRATION_URL", "")
+INTEGRATION_API_KEY = os.environ.get("KAGURA_API_KEY", "")
+INTEGRATION_CONTEXT_ID = os.environ.get("KAGURA_INTEGRATION_CONTEXT_ID", "")
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not (INTEGRATION_URL and INTEGRATION_API_KEY and INTEGRATION_CONTEXT_ID),
+    reason=(
+        "KAGURA_INTEGRATION_URL, KAGURA_API_KEY, and KAGURA_INTEGRATION_CONTEXT_ID must all be set"
+    ),
+)
+@pytest.mark.asyncio
+async def test_upload_round_trip_against_live_backend():
+    """upload → download_url → list → delete against a live backend."""
+    body = f"kagura integration test {uuid.uuid4()}".encode()
+    sha256_hex = hashlib.sha256(body).hexdigest()
+
+    async with FilesClient(api_key=INTEGRATION_API_KEY, base_url=INTEGRATION_URL) as client:
+        # Upload
+        file_obj = await client.upload(
+            context_id=INTEGRATION_CONTEXT_ID,
+            source=body,
+            filename=f"integration_{uuid.uuid4().hex[:8]}.txt",
+            content_type="text/plain",
+        )
+        assert file_obj.sha256 == sha256_hex
+        assert file_obj.size_bytes == len(body)
+        assert file_obj.status in ("uploaded", "confirmed")
+
+        # Download URL
+        url = await client.download_url(file_obj.id)
+        assert url.startswith("http")
+
+        # List — uploaded file should appear in the workspace
+        page = await client.list(context_id=INTEGRATION_CONTEXT_ID, limit=50)
+        assert any(f.id == file_obj.id for f in page.files)
+
+        # Clean up
+        await client.delete(file_obj.id)


### PR DESCRIPTION
Closes #97

## Summary

- New `FilesClient` (REST + presigned PUT) drives the 3-step file upload flow: reserve → R2 PUT with `x-amz-checksum-sha256` (base64 of raw digest) → confirm. Plus `download_url()`, `delete()`, `list()`.
- A separate `httpx.AsyncClient` is used for the R2 PUT step — it carries no `Authorization` header, so the SDK's Bearer token cannot leak to the object store regardless of what other methods are added later.
- Ships unblocks memory-cloud#577 (default-flip of `R2_CHECKSUM_BINDING_ENABLED`): once this SDK release is tagged, the backend can pin SDK >= 0.14.0 as the criteria for flipping the gate to on-by-default.

## Implementation notes

- **SDK ↔ wire naming**: SDK surface uses `context_id` everywhere for consistency with `KaguraClient` / `ResourceClient`; mapped to backend's `workspace_id` field on the wire only.
- **`source: Path | bytes`** with mutual-exclusion enforced at the type level. `bytes` requires `filename`; `Path` defaults to `path.name`.
- **409 dedup happy-path**: server returns 409 with `existing_file` payload when the sha256 already exists in the workspace. SDK surfaces the existing `FileObject` rather than raising — caller does not have to special-case duplicates.
- **R2 400 → `KaguraIntegrityError`** (most commonly BadDigest); other PUT failures → `KaguraConnectionError`. `KaguraIntegrityError` is a new exception in the `KaguraError` hierarchy.
- **Forward-compat pagination**: `list()` accepts `limit` (1-500, server-side cap) and `cursor` (currently ignored by server v0.15.x). `FileListResponse` parses both bare-list and `{files, next_cursor}` wire shapes so a future server bump is non-breaking.
- **Memory**: body is fully materialized in memory — server caps file size at 100 MiB by default. Chunked / streaming PUT is out of scope for v0.14.0.
- **CLI**: `kagura files {upload, download-url, delete, list}` shipped alongside the SDK.
- **Refactor**: `extract_detail` extracted to `_http.py`; `ResourceClient._request` now uses the same helper, consolidating three inline detail-extraction blocks into one shared utility.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped (binary_gate=null per config)
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (DX Lead) — operator confirmed with resolutions; 10 design decisions documented in gate1 cache
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/97-feat-feat-files-add-filesclient-r2-presigned.gate1.md
- ~/.claude/cache/gh-issue-driven/97-feat-feat-files-add-filesclient-r2-presigned.gate2.md

## Test plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 25 files already formatted
- [x] `pyright src/` — 0 errors, 0 warnings, 0 informations
- [x] `pytest tests/ -m "not integration"` — 339 passed (added 30 unit + 6 CLI; integration test is env-gated)
- [ ] Local integration round-trip against memory-cloud with `R2_CHECKSUM_BINDING_ENABLED=true` (operator-driven, gated by `KAGURA_INTEGRATION_URL`)

🤖 Generated via /gh-issue-driven:ship
