### PR TITLE
fix(auth): use actual memory-cloud OAuth endpoint paths

### DIFF
--- a/src/kagura_memory/auth/device_flow.py
+++ b/src/kagura_memory/auth/device_flow.py
@@ -31,10 +31,12 @@ from ..exceptions import (
     KaguraConnectionError,
 )
 
-# OAuth2 endpoint paths under {server}
-_PATH_DEVICE_AUTHORIZE = "/api/v1/oauth2/device/authorize"
-_PATH_TOKEN = "/api/v1/oauth2/token"
-_PATH_REVOKE = "/api/v1/oauth2/revoke"
+# OAuth2 endpoint paths under {server}.
+# The path prefix is /api/v1/oauth/ (NOT /oauth2/) per memory-cloud's
+# actual mount point; the token endpoint requires the trailing slash.
+_PATH_DEVICE_AUTHORIZE = "/api/v1/oauth/device/authorize"
+_PATH_TOKEN = "/api/v1/oauth/token/"
+_PATH_REVOKE = "/api/v1/oauth/revoke"
 
 # RFC 8628 §3.5 — "slow_down" requires the client to add 5 seconds.
 _SLOW_DOWN_INCREMENT_SEC = 5
@@ -113,10 +115,13 @@ async def authorize_device(
 ) -> DeviceAuthorizationResponse:
     """POST ``/api/v1/oauth2/device/authorize`` and parse the response."""
     url = f"{server.rstrip('/')}{_PATH_DEVICE_AUTHORIZE}"
-    data = {"client_id": client_id, "scope": scope}
+    # memory-cloud's device/authorize accepts JSON (DeviceAuthorizationRequest
+    # pydantic model), unlike the /oauth/token/ + /oauth/revoke endpoints
+    # which take application/x-www-form-urlencoded.
+    body = {"client_id": client_id, "scope": scope}
 
     try:
-        response = await client.post(url, data=data)
+        response = await client.post(url, json=body)
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         detail = extract_detail(e.response) or e.response.text

--- a/src/kagura_memory/auth/device_flow.py
+++ b/src/kagura_memory/auth/device_flow.py
@@ -8,7 +8,7 @@ state — that lives in :mod:`auth.cli` and :mod:`auth.credentials`.
 The transport client is intentionally separate from
 :class:`KaguraClient`'s own ``httpx.AsyncClient`` so the SDK's
 ``Authorization: Bearer`` header (for normal MCP calls) cannot leak
-into ``/oauth2/*`` requests, which use ``client_id`` body parameter
+into ``/oauth/*`` requests, which use ``client_id`` body parameter
 authentication (RFC 8628 §3.1 ``token_endpoint_auth_method='none'``).
 This mirrors :class:`FilesClient._upload_client`'s "isolate secrets to
 a dedicated client" idiom.
@@ -90,7 +90,7 @@ class TokenResponse:
 
 
 def make_oauth_client(timeout: float = 30.0) -> httpx.AsyncClient:
-    """Construct an unauthenticated ``httpx.AsyncClient`` for ``/oauth2/*``.
+    """Construct an unauthenticated ``httpx.AsyncClient`` for ``/oauth/*``.
 
     No ``Authorization`` header is set — device-flow uses ``client_id``
     in the form body for client authentication, not a bearer token.
@@ -113,7 +113,7 @@ async def authorize_device(
     client_id: str = DEFAULT_CLIENT_ID,
     scope: str = "memory:read",
 ) -> DeviceAuthorizationResponse:
-    """POST ``/api/v1/oauth2/device/authorize`` and parse the response."""
+    """POST ``/api/v1/oauth/device/authorize`` and parse the response."""
     url = f"{server.rstrip('/')}{_PATH_DEVICE_AUTHORIZE}"
     # memory-cloud's device/authorize accepts JSON (DeviceAuthorizationRequest
     # pydantic model), unlike the /oauth/token/ + /oauth/revoke endpoints
@@ -163,7 +163,7 @@ async def poll_for_token(
     expires_at: datetime,
     sleep: Any = asyncio.sleep,
 ) -> TokenResponse:
-    """Poll ``/api/v1/oauth2/token`` until the user approves or denies.
+    """Poll ``/api/v1/oauth/token/`` until the user approves or denies.
 
     The ``sleep`` parameter is injectable so tests can supply a no-op
     or counter-based stub without waiting real seconds.
@@ -257,7 +257,7 @@ async def refresh_access_token(
     refresh_token: str,
     scope: str | None = None,
 ) -> TokenResponse:
-    """POST ``/api/v1/oauth2/token`` with ``grant_type=refresh_token``.
+    """POST ``/api/v1/oauth/token/`` with ``grant_type=refresh_token``.
 
     When ``scope`` is supplied, the server may reject the call with
     ``insufficient_scope`` / ``invalid_scope`` if the grant doesn't
@@ -316,7 +316,7 @@ async def revoke_token(
     token: str,
     client_id: str = DEFAULT_CLIENT_ID,
 ) -> bool:
-    """POST ``/api/v1/oauth2/revoke``. Best-effort — never raises.
+    """POST ``/api/v1/oauth/revoke``. Best-effort — never raises.
 
     Returns ``True`` on success, ``False`` on any failure. The caller
     (``kagura auth logout``) deletes the local profile regardless of
@@ -364,7 +364,7 @@ def _safe_json_object(response: httpx.Response, endpoint: str) -> dict[str, Any]
 
 
 def _token_response_from_response(response: httpx.Response) -> TokenResponse:
-    """Build a :class:`TokenResponse` from a 200 ``/oauth2/token`` response.
+    """Build a :class:`TokenResponse` from a 200 ``/oauth/token/`` response.
 
     ``expires_at`` is computed from ``expires_in`` at receipt time so
     laptop sleep / clock skew won't yield a negative TTL after wake.

--- a/tests/test_auth_device_flow.py
+++ b/tests/test_auth_device_flow.py
@@ -78,11 +78,11 @@ async def test_authorize_device_happy_path():
     assert da.user_code == "ABCD-1234"
     assert da.device_code == "dc-1"
     assert da.interval == 5
-    # The POST body uses application/x-www-form-urlencoded data.
+    # device/authorize uses application/json body (server-side pydantic model).
     client.post.assert_called_once()
     posted = client.post.call_args
-    assert posted.kwargs["data"]["client_id"] == DEFAULT_CLIENT_ID
-    assert posted.kwargs["data"]["scope"] == "memory:read"
+    assert posted.kwargs["json"]["client_id"] == DEFAULT_CLIENT_ID
+    assert posted.kwargs["json"]["scope"] == "memory:read"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
End-to-end smoke test against memory.kagura-ai.com (with the public `kagura-cli` client newly seeded server-side via kagura-ai/memory-cloud#624) revealed that the SDK's OAuth endpoint paths and the device/authorize request body shape don't match what the server actually exposes.

## Path mismatches found

| SDK had | Server has |
|---|---|
| `/api/v1/oauth2/device/authorize` | `/api/v1/oauth/device/authorize` |
| `/api/v1/oauth2/token` | `/api/v1/oauth/token/` (trailing slash required) |
| `/api/v1/oauth2/revoke` | `/api/v1/oauth/revoke` |

No `2` in the path segment, and FastAPI's `/oauth/token/` route returns 404 without the trailing slash.

## Body shape mismatch

`device/authorize` accepts `application/json` (server-side pydantic `DeviceAuthorizationRequest` model), not `application/x-www-form-urlencoded`. The SDK was sending `data={...}` which httpx encodes as urlencoded form body.

`/oauth/token/` and `/oauth/revoke` remain urlencoded per RFC 6749.

## End-to-end verification

After this fix, `kagura auth login --no-browser --server https://memory.kagura-ai.com` against the live server:

1. POSTs to `/oauth/device/authorize` with JSON body → receives `device_code` + `user_code`
2. Prints the URL + code for browser approval
3. Polls `/oauth/token/` with form body + grant_type `urn:ietf:params:oauth:grant-type:device_code` → receives `authorization_pending` (400) until user approves
4. After approval (manual smoke test pending end-to-end completion) the SDK should receive the token and write `~/.kagura/credentials.json`

## Test plan

- [x] `tests/test_auth_device_flow.py::test_authorize_device_happy_path` updated to assert JSON body shape
- [x] All 455 tests pass
- [x] Smoke test against memory.kagura-ai.com: device/authorize returns 200, token/ polling returns 400 + `authorization_pending` as expected

## Related

- Parent: #100 (closed by #102)
- Server companion: kagura-ai/memory-cloud#624 (seeds the `kagura-cli` OAuth2 client)

🤖 Generated via end-to-end smoke test discovery