### PR TITLE
fix(cli): refuse to block on stdin when no input on TTY (#103)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -111,6 +111,11 @@ def process(message, file, deep, verbose):
         elif file:
             session = Session(**json.load(file))
         else:
+            if sys.stdin.isatty():
+                raise click.UsageError(
+                    "No input given. Use -m / -f, or pipe a session JSON to stdin. "
+                    "Run `kagura process --help` for examples."
+                )
             session = Session(**json.load(sys.stdin))
 
         # KaguraAgent / KaguraClient run the full credential resolution

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -360,6 +360,58 @@ def test_process_command(mock_agent_cls, mock_config):
 
 
 @patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.sys")
+def test_process_no_input_on_tty_exits_with_usage_hint(mock_sys, mock_config):
+    """`kagura process` (no -m / -f) on an interactive TTY must refuse to block
+    on stdin and surface a Click UsageError with the recovery hint instead.
+
+    CliRunner replaces the real sys.stdin with a BytesIO at invoke-time, so we
+    patch the cli module's `sys` reference itself to force isatty()=True and
+    exercise the TTY-detection branch deterministically.
+    """
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+    mock_sys.stdin.isatty.return_value = True
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["process"])
+
+    assert result.exit_code == 2
+    assert "No input given" in result.output
+    assert "kagura process --help" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraAgent")
+def test_process_reads_piped_json_when_not_tty(mock_agent_cls, mock_config):
+    """`echo '{...}' | kagura process` must still read session JSON from stdin —
+    the TTY check only blocks the interactive case, not pipe / redirect input.
+    """
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+
+    mock_agent = AsyncMock()
+    mock_agent.process.return_value = MagicMock(
+        model_dump=lambda: {"remembered": [], "recalled": [], "context_used": "ctx"}
+    )
+    mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+    mock_agent.__aexit__ = AsyncMock(return_value=None)
+    mock_agent_cls.return_value = mock_agent
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["process"],
+        input='{"messages":[{"role":"user","content":"piped"}]}',
+    )
+
+    assert result.exit_code == 0
+    assert "ctx" in result.output
+
+
+@patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.KaguraClient")
 def test_remember_with_empty_tags(mock_client_cls, mock_config):
     """remember with empty tags should not pass empty strings."""


### PR DESCRIPTION
Closes #103

## Summary

- `kagura process` (no `-m` / `-f`, interactive TTY) refuses to block on `json.load(sys.stdin)` and raises `click.UsageError` with the recovery hint instead — exit code 2, Click's standard `Usage: ...` + `Try '--help'` lines.
- Pipe / redirect input (`echo '{...}' | kagura process`) is unaffected — the TTY check only blocks the interactive case.
- Two regression tests added in `tests/test_cli.py` covering both branches (TTY=True via `@patch("kagura_memory.cli.sys")` since CliRunner swaps `sys.stdin` to a BytesIO; TTY=False via the standard `CliRunner.invoke(input=...)`).

## Implementation notes

- 5-line change in `src/kagura_memory/cli.py:113-118` — `sys.stdin.isatty()` guard inside the existing `else` branch (`-m` and `-f` paths are untouched).
- Chose `click.UsageError` over `click.ClickException` deliberately (gate1-confirmed): `UsageError` is a `ClickException` subclass that Click formats with the `Usage:` line + `Try '... --help'` suggestion, which is exactly the recovery affordance the operator needs.
- No new dependencies; `sys` was already imported.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/103-feat-fix-cli-kagura-process-hangs-silently-on.gate1.md
- ~/.claude/cache/gh-issue-driven/103-feat-fix-cli-kagura-process-hangs-silently-on.gate2.md

🤖 Generated via /gh-issue-driven:ship
