### PR TITLE
fix(cli): keep non-ASCII output readable in json.dumps (#106)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -67,7 +67,7 @@ def _run_client_command(
                 return await operation(client, ctx_id)
 
         result = asyncio.run(_run())
-        click.echo(json.dumps(result, indent=2))
+        click.echo(json.dumps(result, indent=2, ensure_ascii=False))
 
     except click.ClickException:
         raise
@@ -135,7 +135,7 @@ def process(message, file, deep, verbose):
                 return await agent.process(session, deep=deep, verbose=verbose)
 
         result = asyncio.run(_run_agent())
-        click.echo(json.dumps(result.model_dump(), indent=2))
+        click.echo(json.dumps(result.model_dump(), indent=2, ensure_ascii=False))
 
     except click.ClickException:
         raise
@@ -157,7 +157,7 @@ def config_show():
         # Mask API key
         if "api_key" in cfg and cfg["api_key"]:
             cfg["api_key"] = cfg["api_key"][:8] + "..." + cfg["api_key"][-4:]
-        click.echo(json.dumps(cfg, indent=2))
+        click.echo(json.dumps(cfg, indent=2, ensure_ascii=False))
     except Exception as e:
         click.echo(f"Error loading config: {e}", err=True)
         sys.exit(1)
@@ -696,7 +696,7 @@ def sleep_rollback(context_id, report_id, yes):
 
     try:
         result = asyncio.run(_run())
-        click.echo(json.dumps(result, indent=2))
+        click.echo(json.dumps(result, indent=2, ensure_ascii=False))
     except (click.Abort, click.ClickException):
         raise
     except Exception as e:
@@ -1178,7 +1178,7 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version):
         output: dict = {"created": total_created, "failed": total_failed, "total": len(events)}
         if all_errors:
             output["errors"] = all_errors[:10]  # Show first 10 errors total
-        return json.dumps(output, indent=2)
+        return json.dumps(output, indent=2, ensure_ascii=False)
 
     _run_resource_command(op)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -382,6 +382,42 @@ def test_process_no_input_on_tty_exits_with_usage_hint(mock_sys, mock_config):
 
 @patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.KaguraAgent")
+def test_process_output_keeps_non_ascii_readable(mock_agent_cls, mock_config):
+    """`kagura process` JSON output must keep non-ASCII characters (CJK, emoji,
+    accented Latin) readable — i.e. `ensure_ascii=False` on json.dumps. Regression
+    guard for issue #106: agent action strings like "recall: こんにちは" were being
+    serialised as "recall: \\u3053\\u3093..." which is unreadable in a terminal.
+    """
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+
+    mock_agent = AsyncMock()
+    mock_agent.process.return_value = MagicMock(
+        model_dump=lambda: {
+            "remembered": [],
+            "recalled": [],
+            "context_used": "ctx",
+            "actions": ["recall: こんにちは 挨拶 日本語"],
+        }
+    )
+    mock_agent.__aenter__ = AsyncMock(return_value=mock_agent)
+    mock_agent.__aexit__ = AsyncMock(return_value=None)
+    mock_agent_cls.return_value = mock_agent
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["process", "-m", "hi"])
+
+    assert result.exit_code == 0
+    assert "こんにちは" in result.output
+    assert "挨拶" in result.output
+    assert "\\u3053" not in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraAgent")
 def test_process_reads_piped_json_when_not_tty(mock_agent_cls, mock_config):
     """`echo '{...}' | kagura process` must still read session JSON from stdin —
     the TTY check only blocks the interactive case, not pipe / redirect input.


### PR DESCRIPTION
Closes #106

## Summary

- `json.dumps()` defaults to `ensure_ascii=True`, escaping non-ASCII (CJK, accented Latin, emoji) into `\uXXXX` sequences — unreadable in a terminal.
- Add `ensure_ascii=False` to all five `json.dumps(...)` call sites in `src/kagura_memory/cli.py` (process, config_show, sleep_rollback, resource_import, the shared `_run_client_command` helper).
- Output stays valid JSON (RFC 8259, UTF-8 is the modern default); `jq` and other consumers handle it correctly.
- One regression test added: `test_process_output_keeps_non_ascii_readable` mocks an agent returning Japanese action strings and asserts they appear literally (not escaped) in stdout.

## Implementation notes

- 5-line change in `cli.py` (one keyword arg per call site).
- 30-line regression test in `tests/test_cli.py` reusing the existing `test_process_command` mock pattern.
- Unaffected: `model_dump_json(indent=2)` calls used by `resource_*` / `files_*` / `edge_*` commands. pydantic-core emits UTF-8 directly; only the stdlib `json.dumps` path needed the flag.

## Test plan

- [x] `uv run pytest tests/` — 458 passed (was 457; +1 new regression test), 1 skipped
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — 33 files already formatted
- [x] `uv run pyright src/` — 0 errors / 0 warnings
- [ ] Manual: `uv run kagura process -m "こんにちは"` prints `recall: こんにちは ...` literally, not `こん...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)