### PR TITLE
feat(http): surface FastAPI 422 validation detail (part 1 of #110)

### DIFF
--- a/src/kagura_memory/_http.py
+++ b/src/kagura_memory/_http.py
@@ -57,15 +57,7 @@ def extract_detail(response: httpx.Response) -> str:
 
 
 def _format_validation_errors(errors: list[Any]) -> str:
-    """Format FastAPI validation-error entries into a one-line string.
-
-    Each entry is expected to be a dict with at least ``msg``; ``loc`` is
-    used when present to produce a dotted path (integer list indices are
-    stringified so ``["body", "items", 0, "name"]`` becomes
-    ``"body.items.0.name"``). Entries missing ``msg``, with an empty
-    ``msg``, or that are not dicts are skipped silently — a single malformed
-    entry should not blank the whole detail line.
-    """
+    # Silent-skip malformed entries so a single bad entry doesn't blank the line.
     parts: list[str] = []
     for entry in errors:
         if not isinstance(entry, dict):

--- a/src/kagura_memory/_http.py
+++ b/src/kagura_memory/_http.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from importlib.metadata import version as _pkg_version
+from typing import Any
 
 import httpx
 
@@ -27,20 +28,58 @@ def base_url_from_mcp(mcp_url: str) -> str:
 
 
 def extract_detail(response: httpx.Response) -> str:
-    """Return the JSON ``detail`` field from an httpx response if parseable.
+    """Return a useful server-supplied error string from an httpx response.
 
-    Returns an empty string when the body is not JSON, not a dict, or
-    has no ``detail`` field. Used by REST clients to surface a useful
-    server-supplied message in chained exception text.
+    Handles three response shapes:
+
+    - ``{"detail": "string"}`` — returned as-is (FastAPI HTTPException default).
+    - ``{"detail": [{"loc": [...], "msg": "...", ...}, ...]}`` — FastAPI's
+      validation-error format (RequestValidationError / Pydantic). Each entry
+      is formatted as ``"<loc.path>: <msg>"`` and joined with ``"; "``. Without
+      this, a 422 surfaces to the caller as a bare ``"HTTP 422"`` with no hint
+      at which field failed validation.
+    - Anything else — non-JSON body, non-dict body, missing ``detail``, or a
+      ``detail`` of unexpected type — returns an empty string so callers can
+      fall back to ``response.text`` or just print the status.
     """
     try:
         body = response.json()
     except (ValueError, UnicodeDecodeError):
         return ""
-    if isinstance(body, dict):
-        detail = body.get("detail", "")
-        return detail if isinstance(detail, str) else ""
+    if not isinstance(body, dict):
+        return ""
+    detail = body.get("detail")
+    if isinstance(detail, str):
+        return detail
+    if isinstance(detail, list):
+        return _format_validation_errors(detail)
     return ""
+
+
+def _format_validation_errors(errors: list[Any]) -> str:
+    """Format FastAPI validation-error entries into a one-line string.
+
+    Each entry is expected to be a dict with at least ``msg``; ``loc`` is
+    used when present to produce a dotted path (integer list indices are
+    stringified so ``["body", "items", 0, "name"]`` becomes
+    ``"body.items.0.name"``). Entries missing ``msg``, with an empty
+    ``msg``, or that are not dicts are skipped silently — a single malformed
+    entry should not blank the whole detail line.
+    """
+    parts: list[str] = []
+    for entry in errors:
+        if not isinstance(entry, dict):
+            continue
+        msg = entry.get("msg")
+        if not isinstance(msg, str) or not msg:
+            continue
+        loc = entry.get("loc")
+        if isinstance(loc, list) and loc:
+            loc_path = ".".join(str(part) for part in loc)
+            parts.append(f"{loc_path}: {msg}")
+        else:
+            parts.append(msg)
+    return "; ".join(parts)
 
 
 def validate_https_url(url: str, *, label: str = "URL") -> None:

--- a/tests/test__http.py
+++ b/tests/test__http.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``kagura_memory._http`` helpers.
+
+Focused on ``extract_detail``'s contract — the FastAPI validation-error
+list path is the new behavior added in #110 so a bare ``HTTP 422`` no
+longer hides which field actually failed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+
+from kagura_memory._http import extract_detail
+
+
+def _response_with_json(payload: object) -> MagicMock:
+    """Build a minimal httpx.Response-shaped mock with ``.json()`` returning ``payload``."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.return_value = payload
+    return resp
+
+
+def _response_with_bad_json() -> MagicMock:
+    """Mock whose ``.json()`` raises — simulates a non-JSON / HTML / empty body."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.side_effect = ValueError("not json")
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# str detail (legacy FastAPI HTTPException shape)
+# ---------------------------------------------------------------------------
+
+
+def test_string_detail_returned_as_is():
+    resp = _response_with_json({"detail": "User not found"})
+    assert extract_detail(resp) == "User not found"
+
+
+def test_empty_string_detail_returns_empty():
+    resp = _response_with_json({"detail": ""})
+    assert extract_detail(resp) == ""
+
+
+# ---------------------------------------------------------------------------
+# list detail (FastAPI validation-error shape — 422)
+# ---------------------------------------------------------------------------
+
+
+def test_single_validation_error_formats_with_loc_path():
+    """The motivating case from #110: a single 422 with ``loc=[body, workspace_id]``."""
+    resp = _response_with_json(
+        {
+            "detail": [
+                {
+                    "type": "uuid_parsing",
+                    "loc": ["body", "workspace_id"],
+                    "msg": "Input should be a valid UUID",
+                    "input": "auto",
+                }
+            ]
+        }
+    )
+    assert extract_detail(resp) == "body.workspace_id: Input should be a valid UUID"
+
+
+def test_multiple_validation_errors_joined_with_semicolon():
+    """Multiple field failures are joined with ``"; "`` so a one-line CLI error stays one line."""
+    resp = _response_with_json(
+        {
+            "detail": [
+                {"loc": ["body", "workspace_id"], "msg": "Input should be a valid UUID"},
+                {"loc": ["body", "size_bytes"], "msg": "Input should be greater than 0"},
+            ]
+        }
+    )
+    assert extract_detail(resp) == (
+        "body.workspace_id: Input should be a valid UUID; "
+        "body.size_bytes: Input should be greater than 0"
+    )
+
+
+def test_loc_with_integer_list_index_stringified():
+    """FastAPI puts list indices in ``loc`` as ints — stringify so the path stays printable."""
+    resp = _response_with_json(
+        {
+            "detail": [
+                {"loc": ["body", "items", 0, "name"], "msg": "Field required"},
+            ]
+        }
+    )
+    assert extract_detail(resp) == "body.items.0.name: Field required"
+
+
+def test_missing_loc_uses_msg_alone():
+    """Entry with ``msg`` but no ``loc`` (e.g. a non-field validator) → return msg alone."""
+    resp = _response_with_json(
+        {
+            "detail": [
+                {"msg": "Internal validation failure"},
+            ]
+        }
+    )
+    assert extract_detail(resp) == "Internal validation failure"
+
+
+def test_empty_loc_list_uses_msg_alone():
+    """``loc: []`` is treated the same as missing ``loc``."""
+    resp = _response_with_json(
+        {
+            "detail": [
+                {"loc": [], "msg": "Top-level validation failure"},
+            ]
+        }
+    )
+    assert extract_detail(resp) == "Top-level validation failure"
+
+
+def test_malformed_entries_skipped_well_formed_kept():
+    """Silent skip on per-entry malformed data: a single bad entry must not blank the line."""
+    resp = _response_with_json(
+        {
+            "detail": [
+                "not a dict",
+                {"loc": ["body", "x"]},
+                {"msg": ""},
+                42,
+                {"loc": ["body", "y"], "msg": "Field required"},
+            ]
+        }
+    )
+    assert extract_detail(resp) == "body.y: Field required"
+
+
+def test_empty_list_detail_returns_empty():
+    resp = _response_with_json({"detail": []})
+    assert extract_detail(resp) == ""
+
+
+def test_list_with_only_malformed_entries_returns_empty():
+    """If nothing in the list can be formatted, caller falls back to ``response.text``."""
+    resp = _response_with_json({"detail": ["junk", 42, {}, {"loc": ["x"]}]})
+    assert extract_detail(resp) == ""
+
+
+# ---------------------------------------------------------------------------
+# Non-JSON / non-dict / unsupported shapes
+# ---------------------------------------------------------------------------
+
+
+def test_non_json_body_returns_empty():
+    resp = _response_with_bad_json()
+    assert extract_detail(resp) == ""
+
+
+def test_non_dict_body_returns_empty():
+    resp = _response_with_json(["not", "a", "dict"])
+    assert extract_detail(resp) == ""
+
+
+def test_missing_detail_field_returns_empty():
+    resp = _response_with_json({"error": "oops"})
+    assert extract_detail(resp) == ""
+
+
+def test_unsupported_detail_type_returns_empty():
+    """``detail`` that is neither str nor list → empty (don't crash, don't guess)."""
+    resp = _response_with_json({"detail": 42})
+    assert extract_detail(resp) == ""
+
+
+def test_unicode_decode_error_returns_empty():
+    """``.json()`` raising ``UnicodeDecodeError`` (e.g. binary body) → empty."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.side_effect = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+    assert extract_detail(resp) == ""

--- a/tests/test__http.py
+++ b/tests/test__http.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import httpx
+import pytest
 
 from kagura_memory._http import extract_detail
 
@@ -22,7 +23,7 @@ def _response_with_json(payload: object) -> MagicMock:
 
 
 def _response_with_bad_json() -> MagicMock:
-    """Mock whose ``.json()`` raises — simulates a non-JSON / HTML / empty body."""
+    """Mock whose ``.json()`` raises ``ValueError`` — simulates a non-JSON body."""
     resp = MagicMock(spec=httpx.Response)
     resp.json.side_effect = ValueError("not json")
     return resp
@@ -48,21 +49,45 @@ def test_empty_string_detail_returns_empty():
 # ---------------------------------------------------------------------------
 
 
-def test_single_validation_error_formats_with_loc_path():
-    """The motivating case from #110: a single 422 with ``loc=[body, workspace_id]``."""
-    resp = _response_with_json(
-        {
-            "detail": [
+@pytest.mark.parametrize(
+    "detail, expected",
+    [
+        # The motivating case from #110: single 422 with loc=[body, workspace_id]
+        pytest.param(
+            [
                 {
                     "type": "uuid_parsing",
                     "loc": ["body", "workspace_id"],
                     "msg": "Input should be a valid UUID",
                     "input": "auto",
                 }
-            ]
-        }
-    )
-    assert extract_detail(resp) == "body.workspace_id: Input should be a valid UUID"
+            ],
+            "body.workspace_id: Input should be a valid UUID",
+            id="loc_path",
+        ),
+        # FastAPI puts list indices in loc as ints — stringify so the path stays printable
+        pytest.param(
+            [{"loc": ["body", "items", 0, "name"], "msg": "Field required"}],
+            "body.items.0.name: Field required",
+            id="integer_index_in_loc",
+        ),
+        # msg-only entry (non-field validator) → return msg alone
+        pytest.param(
+            [{"msg": "Internal validation failure"}],
+            "Internal validation failure",
+            id="missing_loc",
+        ),
+        # loc: [] is treated the same as missing loc
+        pytest.param(
+            [{"loc": [], "msg": "Top-level validation failure"}],
+            "Top-level validation failure",
+            id="empty_loc",
+        ),
+    ],
+)
+def test_single_entry_loc_variants(detail: list[dict], expected: str):
+    """Single-entry FastAPI 422 shapes: loc with strings, ints, missing, or empty."""
+    assert extract_detail(_response_with_json({"detail": detail})) == expected
 
 
 def test_multiple_validation_errors_joined_with_semicolon():
@@ -79,42 +104,6 @@ def test_multiple_validation_errors_joined_with_semicolon():
         "body.workspace_id: Input should be a valid UUID; "
         "body.size_bytes: Input should be greater than 0"
     )
-
-
-def test_loc_with_integer_list_index_stringified():
-    """FastAPI puts list indices in ``loc`` as ints — stringify so the path stays printable."""
-    resp = _response_with_json(
-        {
-            "detail": [
-                {"loc": ["body", "items", 0, "name"], "msg": "Field required"},
-            ]
-        }
-    )
-    assert extract_detail(resp) == "body.items.0.name: Field required"
-
-
-def test_missing_loc_uses_msg_alone():
-    """Entry with ``msg`` but no ``loc`` (e.g. a non-field validator) → return msg alone."""
-    resp = _response_with_json(
-        {
-            "detail": [
-                {"msg": "Internal validation failure"},
-            ]
-        }
-    )
-    assert extract_detail(resp) == "Internal validation failure"
-
-
-def test_empty_loc_list_uses_msg_alone():
-    """``loc: []`` is treated the same as missing ``loc``."""
-    resp = _response_with_json(
-        {
-            "detail": [
-                {"loc": [], "msg": "Top-level validation failure"},
-            ]
-        }
-    )
-    assert extract_detail(resp) == "Top-level validation failure"
 
 
 def test_malformed_entries_skipped_well_formed_kept():


### PR DESCRIPTION
## Summary

- `extract_detail()` が FastAPI の `RequestValidationError` 形式 (`detail: [{loc, msg, type}, ...]`) を扱えるよう拡張。各 entry を `<loc.path>: <msg>` で整形し `"; "` で連結
- これまで 422 が CLI に `Error: HTTP 422` だけで表示されていた問題を解決。例: `kagura files upload ...` で workspace_id がバリデーション失敗した場合、`HTTP 422: body.workspace_id: Input should be a valid UUID` のように原因が分かるようになる
- `tests/test__http.py` を新規作成し、AC 通り list / str / 不正 / 空 をカバー（15 ケース、parametrize 利用）

## Part 1 of #110

Issue #110 は A/B/C の三段：
- **A. `extract_detail` で FastAPI 422 を整形** ← この PR
- B. FilesClient を OAuth credentials 対応に — 別 PR
- C. CLI で workspace_id を OAuth profile から自動採用 — 同上

gate1 review (`/claude-c-suite:ask` → CTO) で A を先行 PR 化する判断。A は B/C と独立してリリース可能で、main に乗ると B/C 実装中の debug が楽になる。

## Behavior change

| 入力 | Before | After |
|---|---|---|
| `{"detail": "User not found"}` | `"User not found"` | `"User not found"` (unchanged) |
| `{"detail": [{loc, msg, ...}, ...]}` (422) | `""` (空文字、`HTTP 422` だけ表示) | `"body.workspace_id: Input should be a valid UUID"` |
| 非 JSON / 非 dict / 想定外型 | `""` | `""` (unchanged) |

callers (`files_client.py`, `resource_client.py`, `auth/device_flow.py`) は全て str truthy/falsy 利用なので破壊的変更なし。

## Test plan

- [x] `uv run pytest tests/test__http.py` → 15/15 pass
- [x] `uv run pytest tests/test_files_client.py tests/test_client.py` → 161/161 pass (回帰なし)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format src/ tests/` clean
- [x] `uv run pyright src/kagura_memory/_http.py` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)