### PR TITLE
feat(files): wire FilesClient to OAuth credentials + CLI workspace_id auto

### DIFF
--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -1,0 +1,116 @@
+"""Credential resolution shared by REST/MCP clients in this SDK.
+
+Centralizes the precedence chain — explicit arg > ``KAGURA_API_KEY`` env >
+OAuth profile in ``~/.kagura/credentials.json`` > ``.kagura.json`` config —
+in one module so that :class:`KaguraClient` (MCP), :class:`FilesClient`
+(REST + R2 PUT), and future REST clients (e.g. ``ResourceClient``) all
+resolve credentials identically without import-direction inversion.
+
+Returns one of two result types:
+
+- :class:`_StaticAuth` — long-lived API key, baked into the client's
+  ``Authorization`` header at construction.
+- :class:`_OAuthAuth` — :class:`auth.credentials.KaguraOAuth` httpx.Auth
+  subclass, injects a fresh access_token per request and coordinates
+  refresh via a process-wide :class:`asyncio.Lock`.
+
+This module imports only from ``auth.credentials``, ``config``, and
+``exceptions`` — never from ``_http``. The reverse direction (``_http``
+importing ``_auth``) must also be avoided so the dependency stays
+one-way.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from .auth.credentials import KaguraOAuth, get_shared_state
+from .config import load_config
+from .exceptions import KaguraAuthError
+
+_DEFAULT_MCP_URL = "https://memory.kagura-ai.com/mcp"
+
+
+@dataclass
+class _StaticAuth:
+    """Long-lived API key resolution result."""
+
+    api_key: str
+    mcp_url: str
+
+
+@dataclass
+class _OAuthAuth:
+    """OAuth credentials.json resolution result."""
+
+    oauth: KaguraOAuth
+    mcp_url: str
+
+
+def _resolve_auth(
+    *,
+    api_key: str | None,
+    mcp_url: str | None,
+    profile: str | None,
+) -> _StaticAuth | _OAuthAuth:
+    """Pick a credential source per the documented precedence chain.
+
+    See :meth:`KaguraClient.__init__` for the full order. Raises
+    :class:`KaguraAuthError` when no source produces credentials.
+    """
+    # 1. Explicit constructor argument wins absolutely.
+    # Empty / whitespace-only api_key is treated the same as None — sending
+    # `Authorization: Bearer ` would always 401 and is never what the caller
+    # intended; fall through to the env / OAuth / .kagura.json chain instead.
+    if api_key is not None and api_key.strip():
+        return _StaticAuth(api_key=api_key, mcp_url=mcp_url or _DEFAULT_MCP_URL)
+
+    # 2. KAGURA_API_KEY env var (highest auto-resolution priority).
+    # Strip-check mirrors the explicit-arg path above: a whitespace-only
+    # env var would otherwise send `Authorization: Bearer ` and 401.
+    env_key = os.getenv("KAGURA_API_KEY")
+    if env_key and env_key.strip():
+        return _StaticAuth(
+            api_key=env_key,
+            mcp_url=mcp_url or os.getenv("KAGURA_MCP_URL") or _DEFAULT_MCP_URL,
+        )
+
+    # 3. OAuth profile from credentials.json: explicit > KAGURA_PROFILE > default.
+    target_profile = profile or os.getenv("KAGURA_PROFILE")
+    state = get_shared_state(profile=target_profile)
+    if state is not None:
+        return _OAuthAuth(
+            oauth=KaguraOAuth(state),
+            mcp_url=mcp_url or state.credentials.mcp_url,
+        )
+    if target_profile:
+        # An explicit profile name (via arg or KAGURA_PROFILE env) was
+        # requested but credentials.json has no such profile. Falling
+        # through to .kagura.json would silently authenticate with the
+        # wrong account, so raise instead.
+        source = "profile argument" if profile else "KAGURA_PROFILE env"
+        raise KaguraAuthError(
+            f"Profile '{target_profile}' (from {source}) not found in credentials.json.\n"
+            f"  Run: kagura auth login --profile {target_profile}\n"
+            f"  Or inspect ~/.kagura/credentials.json to see which profiles exist."
+        )
+
+    # 4. Legacy .kagura.json (which itself env-falls-back internally).
+    # Apply the same whitespace-only strip check used for the explicit
+    # arg and KAGURA_API_KEY env paths so a stray-whitespace config file
+    # doesn't produce a guaranteed-401 `Authorization: Bearer ` header.
+    cfg = load_config()
+    cfg_key = cfg.get("api_key", "")
+    if cfg_key and cfg_key.strip():
+        return _StaticAuth(
+            api_key=cfg_key,
+            mcp_url=mcp_url or cfg.get("mcp_url") or _DEFAULT_MCP_URL,
+        )
+
+    raise KaguraAuthError(
+        "No credentials found.\n"
+        "  Run: kagura auth login\n"
+        "  Or set: KAGURA_API_KEY=<your key>\n"
+        '  Or create: .kagura.json with {"api_key": "..."}'
+    )

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -11,6 +12,7 @@ import click
 
 from .agent import KaguraAgent
 from .auth.cli import auth as _auth_group
+from .auth.credentials import get_shared_state
 from .client import KaguraClient
 from .config import load_config
 from .files_client import FilesClient
@@ -1425,15 +1427,55 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version):
 # Files (`kagura files ...`) — server v0.15.1+
 # =============================================================================
 
+# Sentinel for `kagura setup claude`-generated `.kagura.json` — means
+# "fill in workspace_id from the OAuth profile or --context-id at runtime."
+# Defined as a constant so the CLI, tests, and any future config writer
+# share one source of truth and cannot drift.
+_CONTEXT_ID_AUTO = "auto"
+
 
 def _build_files_client(config: dict[str, Any]) -> FilesClient:
-    """Build a FilesClient from an already-loaded config dict."""
-    if not config.get("api_key"):
-        raise click.ClickException("No API key found. Set KAGURA_API_KEY or create .kagura.json")
+    """Build a FilesClient using the shared credential resolution chain.
+
+    Delegates to :meth:`FilesClient.from_mcp_url`, which runs
+    ``_resolve_auth`` (explicit api_key > ``KAGURA_API_KEY`` env > OAuth
+    profile in ``~/.kagura/credentials.json`` > ``.kagura.json``). When
+    no source produces credentials the resolver raises ``KaguraAuthError``,
+    which ``_run_files_command`` reformats as a ``click.ClickException``.
+    """
     return FilesClient.from_mcp_url(
-        api_key=config.get("api_key", ""),
-        mcp_url=config.get("mcp_url", "https://memory.kagura-ai.com/mcp"),
+        api_key=config.get("api_key") or None,
+        mcp_url=config.get("mcp_url") or None,
     )
+
+
+def _resolve_files_context_id(config: dict[str, Any], context_id: str | None) -> str:
+    """Resolve the workspace UUID for a Files CLI command.
+
+    Order: explicit ``--context-id`` flag > ``.kagura.json`` (skipping the
+    :data:`_CONTEXT_ID_AUTO` sentinel) > OAuth profile's ``workspace_id``
+    from ``~/.kagura/credentials.json``. Returns ``""`` when every source
+    is empty or the sentinel; the caller surfaces a single actionable error.
+
+    The sentinel is a CLI-level concern: the SDK only accepts real UUIDs
+    (``FilesClient`` validates at the entry point per issue #110). This
+    function converts ``"auto"`` to the right UUID before any SDK call.
+    """
+    if context_id and context_id.strip() and context_id != _CONTEXT_ID_AUTO:
+        return context_id
+
+    cfg_ctx = (config.get("context_id") or "").strip()
+    if cfg_ctx and cfg_ctx != _CONTEXT_ID_AUTO:
+        return cfg_ctx
+
+    # OAuth profile path: kagura auth login stored the workspace_id during
+    # /device consent. This is the natural fallback for users who logged in
+    # but never edited .kagura.json.
+    state = get_shared_state(profile=os.getenv("KAGURA_PROFILE"))
+    if state is not None and state.credentials.workspace_id:
+        return state.credentials.workspace_id
+
+    return ""
 
 
 def _run_files_command(
@@ -1444,23 +1486,20 @@ def _run_files_command(
 ) -> None:
     """Execute a FilesClient operation with standard boilerplate.
 
-    Validates api_key first (matching ``_run_client_command``'s order)
-    so the operator sees a consistent error when both api_key and
-    context_id are missing.
+    Credential and context resolution both delegate to the shared chain
+    (env > OAuth profile > .kagura.json). The operator sees a single
+    error message that points at all three sources when nothing resolves.
     """
     try:
         config = load_config()
-        if not config.get("api_key"):
-            raise click.ClickException(
-                "No API key found. Set KAGURA_API_KEY or create .kagura.json"
-            )
 
         ctx_id = ""
         if needs_context:
-            ctx_id = context_id or config.get("context_id") or ""
+            ctx_id = _resolve_files_context_id(config, context_id)
             if not ctx_id:
                 raise click.ClickException(
-                    "context_id required. Use --context-id or set in .kagura.json"
+                    "context_id required. Use --context-id, set context_id in "
+                    ".kagura.json, or run `kagura auth login` to bind a workspace."
                 )
 
         client = _build_files_client(config)

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -3,16 +3,13 @@
 import itertools
 import json
 import logging
-import os
-from dataclasses import dataclass
 from typing import Any, Literal, TypeVar
 
 import httpx
 from pydantic import BaseModel as _BaseModel
 
+from ._auth import _resolve_auth, _StaticAuth
 from ._http import SDK_VERSION, base_url_from_mcp, validate_https_url
-from .auth.credentials import KaguraOAuth, get_shared_state
-from .config import load_config
 from .exceptions import KaguraAuthError, KaguraConnectionError, KaguraError, KaguraNotFoundError
 from .models import (
     ContextInfo,
@@ -44,93 +41,6 @@ tool calls never raise on version mismatch, and older servers may
 silently ignore unknown parameters."""
 
 _MIN_SERVER_VERSION_TUPLE = tuple(int(x) for x in MIN_SERVER_VERSION.split(".")[:3])
-
-
-_DEFAULT_MCP_URL = "https://memory.kagura-ai.com/mcp"
-
-
-@dataclass
-class _StaticAuth:
-    """Long-lived API key resolution result."""
-
-    api_key: str
-    mcp_url: str
-
-
-@dataclass
-class _OAuthAuth:
-    """OAuth credentials.json resolution result."""
-
-    oauth: KaguraOAuth
-    mcp_url: str
-
-
-def _resolve_auth(
-    *,
-    api_key: str | None,
-    mcp_url: str | None,
-    profile: str | None,
-) -> _StaticAuth | _OAuthAuth:
-    """Pick a credential source per the documented precedence chain.
-
-    See :meth:`KaguraClient.__init__` for the full order. Raises
-    :class:`KaguraAuthError` when no source produces credentials.
-    """
-    # 1. Explicit constructor argument wins absolutely.
-    # Empty / whitespace-only api_key is treated the same as None — sending
-    # `Authorization: Bearer ` would always 401 and is never what the caller
-    # intended; fall through to the env / OAuth / .kagura.json chain instead.
-    if api_key is not None and api_key.strip():
-        return _StaticAuth(api_key=api_key, mcp_url=mcp_url or _DEFAULT_MCP_URL)
-
-    # 2. KAGURA_API_KEY env var (highest auto-resolution priority).
-    # Strip-check mirrors the explicit-arg path above: a whitespace-only
-    # env var would otherwise send `Authorization: Bearer ` and 401.
-    env_key = os.getenv("KAGURA_API_KEY")
-    if env_key and env_key.strip():
-        return _StaticAuth(
-            api_key=env_key,
-            mcp_url=mcp_url or os.getenv("KAGURA_MCP_URL") or _DEFAULT_MCP_URL,
-        )
-
-    # 3. OAuth profile from credentials.json: explicit > KAGURA_PROFILE > default.
-    target_profile = profile or os.getenv("KAGURA_PROFILE")
-    state = get_shared_state(profile=target_profile)
-    if state is not None:
-        return _OAuthAuth(
-            oauth=KaguraOAuth(state),
-            mcp_url=mcp_url or state.credentials.mcp_url,
-        )
-    if target_profile:
-        # An explicit profile name (via arg or KAGURA_PROFILE env) was
-        # requested but credentials.json has no such profile. Falling
-        # through to .kagura.json would silently authenticate with the
-        # wrong account, so raise instead.
-        source = "profile argument" if profile else "KAGURA_PROFILE env"
-        raise KaguraAuthError(
-            f"Profile '{target_profile}' (from {source}) not found in credentials.json.\n"
-            f"  Run: kagura auth login --profile {target_profile}\n"
-            f"  Or inspect ~/.kagura/credentials.json to see which profiles exist."
-        )
-
-    # 4. Legacy .kagura.json (which itself env-falls-back internally).
-    # Apply the same whitespace-only strip check used for the explicit
-    # arg and KAGURA_API_KEY env paths so a stray-whitespace config file
-    # doesn't produce a guaranteed-401 `Authorization: Bearer ` header.
-    cfg = load_config()
-    cfg_key = cfg.get("api_key", "")
-    if cfg_key and cfg_key.strip():
-        return _StaticAuth(
-            api_key=cfg_key,
-            mcp_url=mcp_url or cfg.get("mcp_url") or _DEFAULT_MCP_URL,
-        )
-
-    raise KaguraAuthError(
-        "No credentials found.\n"
-        "  Run: kagura auth login\n"
-        "  Or set: KAGURA_API_KEY=<your key>\n"
-        '  Or create: .kagura.json with {"api_key": "..."}'
-    )
 
 
 class KaguraClient:

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -23,12 +23,15 @@ import asyncio
 import base64
 import hashlib
 import mimetypes
+import uuid
 from pathlib import Path
 from typing import Any, Literal
 
 import httpx
 
+from ._auth import _resolve_auth, _StaticAuth
 from ._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
+from .auth.credentials import KaguraOAuth
 from .exceptions import (
     KaguraAuthError,
     KaguraConnectionError,
@@ -62,34 +65,70 @@ class FilesClient:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         base_url: str = "https://memory.kagura-ai.com",
         timeout: float = 30.0,
         upload_timeout: float = 300.0,
+        *,
+        _oauth: KaguraOAuth | None = None,
     ) -> None:
-        """Initialize FilesClient.
+        """Initialize FilesClient with a static API key.
+
+        For OAuth profile resolution (the auto chain env → ``~/.kagura/
+        credentials.json`` → ``.kagura.json``), use :meth:`from_mcp_url`
+        which runs the resolver and selects the right transport.
 
         Args:
-            api_key: Kagura API key (Bearer token for API operations).
+            api_key: Kagura API key (Bearer token). Required unless
+                ``_oauth`` is supplied (see ``from_mcp_url``).
             base_url: REST API base URL (without path).
             timeout: API request timeout in seconds.
             upload_timeout: R2 PUT timeout in seconds (defaults to 5
                 minutes to accommodate large files on slow networks).
+            _oauth: Private. ``from_mcp_url`` passes a ``KaguraOAuth``
+                instance for OAuth profile authentication. Public
+                callers should not set this.
+
+        Raises:
+            ValueError: If neither ``api_key`` nor ``_oauth`` is given.
+                The OAuth path is intentionally not auto-resolved here
+                so that bare ``FilesClient()`` does not silently read
+                ``~/.kagura/credentials.json`` — that's the
+                ``from_mcp_url`` factory's job.
         """
+        if api_key is None and _oauth is None:
+            raise ValueError(
+                "FilesClient requires api_key, or use FilesClient.from_mcp_url(...) "
+                "to resolve credentials from environment, OAuth profile, or .kagura.json."
+            )
+
         stripped_url = base_url.rstrip("/")
         validate_https_url(stripped_url, label="Base URL")
 
         self.base_url = stripped_url
-        self._client = httpx.AsyncClient(
-            timeout=timeout,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "User-Agent": f"kagura-memory-sdk/{SDK_VERSION}",
-            },
-        )
-        # Separate client for outbound PUT to the object store. Carries
-        # no Bearer header so a future contributor cannot accidentally
-        # leak the API key by adding another method that reuses it.
+        if _oauth is not None:
+            # OAuth path: KaguraOAuth injects a fresh access_token per request
+            # and coordinates refresh via the process-wide credentials lock.
+            self._client = httpx.AsyncClient(
+                timeout=timeout,
+                headers={"User-Agent": f"kagura-memory-sdk/{SDK_VERSION}"},
+                auth=_oauth,
+            )
+        else:
+            # Static path: bake the bearer header once. ``api_key`` is not
+            # stored as an instance attribute (per python.md "Never store
+            # API keys as instance attributes").
+            self._client = httpx.AsyncClient(
+                timeout=timeout,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": f"kagura-memory-sdk/{SDK_VERSION}",
+                },
+            )
+        # Defense in depth: never pass auth= or an Authorization header here.
+        # Bearer / OAuth credentials must not reach R2 — the presigned PUT
+        # carries its own short-lived SigV4 signature. A separate httpx client
+        # makes the no-auth invariant structural, not just a runtime convention.
         self._upload_client = httpx.AsyncClient(
             timeout=upload_timeout,
             headers={"User-Agent": f"kagura-memory-sdk/{SDK_VERSION}"},
@@ -98,23 +137,52 @@ class FilesClient:
     @classmethod
     def from_mcp_url(
         cls,
-        api_key: str,
-        mcp_url: str = "https://memory.kagura-ai.com/mcp",
+        api_key: str | None = None,
+        mcp_url: str | None = None,
         timeout: float = 30.0,
         upload_timeout: float = 300.0,
+        *,
+        profile: str | None = None,
     ) -> FilesClient:
-        """Create FilesClient by deriving the REST base URL from an MCP URL.
+        """Create FilesClient by resolving credentials from the SDK chain.
 
-        Strips ``/mcp`` and everything after it. Handles both
-        ``/mcp`` and ``/mcp/w/{workspace_id}`` formats.
+        Runs :func:`_resolve_auth` with the same precedence chain as
+        :class:`KaguraClient`: explicit ``api_key`` > ``KAGURA_API_KEY``
+        env > OAuth profile from ``~/.kagura/credentials.json`` >
+        ``.kagura.json``. The chosen credential source picks the
+        transport: a static API key bakes the Bearer header once; an
+        OAuth profile installs a ``KaguraOAuth`` httpx.Auth handler
+        with automatic refresh.
+
+        The REST ``base_url`` is derived from the resolved ``mcp_url``
+        (strips ``/mcp`` and any ``/mcp/w/{workspace_id}`` suffix).
+
+        Args:
+            api_key: Explicit Kagura API key. Skips the resolution chain.
+            mcp_url: Explicit MCP URL. When omitted, the OAuth profile's
+                stored ``mcp_url`` is used (or
+                ``https://memory.kagura-ai.com/mcp`` as a final default).
+            timeout: API request timeout in seconds.
+            upload_timeout: R2 PUT timeout in seconds.
+            profile: Named OAuth profile to load (overrides
+                ``KAGURA_PROFILE`` env and the credentials file's
+                ``default_profile``).
         """
-        url = mcp_url.rstrip("/")
-        base_url = base_url_from_mcp(url)
+        resolved = _resolve_auth(api_key=api_key, mcp_url=mcp_url, profile=profile)
+        base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
+
+        if isinstance(resolved, _StaticAuth):
+            return cls(
+                api_key=resolved.api_key,
+                base_url=base_url,
+                timeout=timeout,
+                upload_timeout=upload_timeout,
+            )
         return cls(
-            api_key=api_key,
             base_url=base_url,
             timeout=timeout,
             upload_timeout=upload_timeout,
+            _oauth=resolved.oauth,
         )
 
     # -------------------------------------------------------------------
@@ -257,6 +325,7 @@ class FilesClient:
             KaguraAuthError, KaguraNotFoundError, KaguraQuotaError,
             KaguraConnectionError: see class docstring.
         """
+        _validate_context_id(context_id)
         resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
         size_bytes = len(body)
         resolved_content_type = _resolve_content_type(content_type, resolved_filename)
@@ -329,6 +398,7 @@ class FilesClient:
             ``next_cursor`` (always ``None`` against the current
             server).
         """
+        _validate_context_id(context_id)
         params: dict[str, Any] = {"workspace_id": context_id, "limit": limit}
         if cursor is not None:
             params["cursor"] = cursor
@@ -400,6 +470,34 @@ def _extract_existing_file(error: KaguraConnectionError) -> FileObject | None:
     if not isinstance(existing, dict):
         return None
     return FileObject.model_validate(existing)
+
+
+def _validate_context_id(context_id: str) -> None:
+    """Fail fast on a non-UUID ``context_id``.
+
+    The server's ``/api/v1/files/*`` endpoints validate ``workspace_id``
+    server-side and return 422, but the round-trip masks a class of
+    common errors — e.g. passing the CLI sentinel ``"auto"`` straight
+    through to the SDK without resolution. Raising locally turns that
+    into a clear ``ValueError`` instead of a generic HTTP status.
+
+    Args:
+        context_id: The workspace UUID to validate.
+
+    Raises:
+        ValueError: If ``context_id`` is not a parseable UUID. The
+            message points the caller at the OAuth profile's
+            ``workspace_id`` and ``kagura context list``, which are the
+            two ways the SDK expects ``context_id`` to be sourced.
+    """
+    try:
+        uuid.UUID(context_id)
+    except (ValueError, TypeError, AttributeError) as e:
+        raise ValueError(
+            f"context_id must be a UUID; got {context_id!r}. "
+            "Use the OAuth profile's workspace_id, a UUID from "
+            "`kagura context list`, or run `kagura auth login` first."
+        ) from e
 
 
 def _resolve_content_type(content_type: str | None, filename: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,8 +53,8 @@ def test_remember_missing_api_key(mock_config, monkeypatch, tmp_path):
         "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
         tmp_path / "missing-credentials.json",
     )
-    # Also short-circuit the .kagura.json fallback inside KaguraClient._resolve_auth.
-    monkeypatch.setattr("kagura_memory.client.load_config", lambda: {"api_key": ""})
+    # Also short-circuit the .kagura.json fallback inside _resolve_auth.
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {"api_key": ""})
     runner = CliRunner()
     result = runner.invoke(main, ["remember", "-s", "test", "--content", "data"])
     assert result.exit_code != 0
@@ -901,7 +901,7 @@ def test_get_kagura_client_missing_api_key(mock_config, monkeypatch, tmp_path):
         "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
         tmp_path / "missing-credentials.json",
     )
-    monkeypatch.setattr("kagura_memory.client.load_config", lambda: {"api_key": ""})
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {"api_key": ""})
 
     runner = CliRunner()
     result = runner.invoke(main, ["sleep", "rollback", "ctx-1", "rid-9", "-y"])

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -1,10 +1,16 @@
 """Tests for `kagura files ...` CLI commands."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from click.testing import CliRunner
 
+from kagura_memory.auth.credentials import (
+    CredentialsFile,
+    OAuthCredentials,
+    reset_state_cache,
+    save_credentials_file,
+)
 from kagura_memory.cli import main
 from kagura_memory.models import FileListResponse, FileObject
 
@@ -65,21 +71,35 @@ def test_files_upload(mock_client_cls, mock_config, tmp_path):
 
 
 @patch("kagura_memory.cli.load_config")
-def test_files_upload_missing_api_key(mock_config, tmp_path):
-    """upload with context-id provided but no api_key → No API key error."""
+def test_files_upload_missing_credentials(mock_config, monkeypatch, tmp_path):
+    """upload with context-id but no api_key + no OAuth profile → credentials error."""
     mock_config.return_value = {"api_key": "", "context_id": SAMPLE_CTX_ID}
+    # Block every credential source so the resolver chain reaches its terminal raise.
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {"api_key": ""})
     p = tmp_path / "hello.txt"
     p.write_text("hi")
     runner = CliRunner()
     result = runner.invoke(main, ["files", "upload", str(p)])
     assert result.exit_code != 0
-    assert "No API key" in result.output
+    assert "No credentials found" in result.output or "kagura auth login" in result.output
 
 
 @patch("kagura_memory.cli.load_config")
-def test_files_upload_missing_context(mock_config, tmp_path):
-    """upload without --context-id and without .kagura.json default → error."""
+def test_files_upload_missing_context(mock_config, monkeypatch, tmp_path):
+    """upload without --context-id and without any workspace source → context_id required."""
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+    # Block the OAuth profile workspace_id fallback so context_id stays empty.
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
     p = tmp_path / "hello.txt"
     p.write_text("hi")
     runner = CliRunner()
@@ -161,3 +181,104 @@ def test_files_list(mock_client_cls, mock_config):
     call = mock_client.list.call_args
     assert call.kwargs["context_id"] == SAMPLE_CTX_ID
     assert call.kwargs["limit"] == 50
+
+
+# ============================================================================
+# OAuth credentials.json-only flow (#110 headline scenario)
+# ============================================================================
+
+
+def _oauth_creds_with_workspace(workspace_id: str) -> OAuthCredentials:
+    return OAuthCredentials(
+        server="https://oauth.example.com",
+        mcp_url="https://oauth.example.com/mcp",
+        client_id="kagura-cli",
+        access_token="atok-cli-test",
+        refresh_token="rtok-cli-test",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope="memory:write",
+        workspace_id=workspace_id,
+        workspace_name="cli-test-ws",
+        user_email="cli@example.com",
+        issued_at=datetime.now(UTC),
+    )
+
+
+def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_path):
+    """`.kagura.json` absent + credentials.json present → workspace_id from OAuth profile.
+
+    Headline scenario from #110: ``kagura auth login`` populates the
+    profile's ``workspace_id``; subsequent ``kagura files upload`` with
+    neither ``--context-id`` nor ``.kagura.json.context_id`` must resolve
+    the workspace via the OAuth profile and succeed.
+    """
+    fake_creds_path = tmp_path / "credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+
+    cf = CredentialsFile()
+    cf.set_profile("default", _oauth_creds_with_workspace(SAMPLE_CTX_ID))
+    save_credentials_file(cf, fake_creds_path)
+    reset_state_cache()
+
+    with (
+        patch("kagura_memory.cli.load_config", return_value={}),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    ):
+        mock_client = _mock_files_client("upload", _file_object())
+        mock_client_cls.from_mcp_url.return_value = mock_client
+
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p)])
+
+    reset_state_cache()
+
+    assert result.exit_code == 0, result.output
+    mock_client.upload.assert_awaited_once()
+    assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
+
+
+def test_files_upload_treats_context_id_auto_as_unset(monkeypatch, tmp_path):
+    """`.kagura.json` with ``context_id: "auto"`` should not reach the SDK.
+
+    The CLI converts the ``"auto"`` sentinel to the OAuth profile's
+    workspace_id before calling ``FilesClient.upload``. Previously this
+    would forward ``"auto"`` straight to the server and hit a 422
+    ``workspace_id`` validation error.
+    """
+    fake_creds_path = tmp_path / "credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+
+    cf = CredentialsFile()
+    cf.set_profile("default", _oauth_creds_with_workspace(SAMPLE_CTX_ID))
+    save_credentials_file(cf, fake_creds_path)
+    reset_state_cache()
+
+    from kagura_memory.cli import _CONTEXT_ID_AUTO
+
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={"api_key": "key", "context_id": _CONTEXT_ID_AUTO},
+        ),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    ):
+        mock_client = _mock_files_client("upload", _file_object())
+        mock_client_cls.from_mcp_url.return_value = mock_client
+
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p)])
+
+    reset_state_cache()
+
+    assert result.exit_code == 0, result.output
+    assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
+    assert mock_client.upload.call_args.kwargs["context_id"] != _CONTEXT_ID_AUTO

--- a/tests/test_client_auth_resolution.py
+++ b/tests/test_client_auth_resolution.py
@@ -45,7 +45,7 @@ def isolated_credentials(tmp_path: Path, monkeypatch):
     monkeypatch.delenv("KAGURA_PROFILE", raising=False)
     monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
     # Also short-circuit load_config so legacy .kagura.json paths don't leak.
-    monkeypatch.setattr("kagura_memory.client.load_config", lambda: {"api_key": ""})
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {"api_key": ""})
     reset_state_cache()
     yield fake_path
     reset_state_cache()

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -2,6 +2,7 @@
 
 import base64
 import hashlib
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,6 +18,14 @@ from kagura_memory import (
     KaguraIntegrityError,
     KaguraNotFoundError,
     KaguraQuotaError,
+)
+from kagura_memory.auth.credentials import (
+    CredentialsFile,
+    KaguraOAuth,
+    OAuthCredentials,
+    get_shared_state,
+    reset_state_cache,
+    save_credentials_file,
 )
 
 # ============================================================================
@@ -133,6 +142,234 @@ def test_upload_client_has_no_authorization_header():
     assert "Authorization" not in client._upload_client.headers
     # Sanity: the API client still has it.
     assert client._client.headers.get("Authorization") == "Bearer kagura_secret"
+
+
+def test_upload_client_has_no_auth_handler_static_path():
+    """Defense in depth: ``_upload_client._auth`` must be ``None`` on the static path.
+
+    The static path uses an ``Authorization`` header on ``_client``; a stray
+    ``httpx.Auth`` on ``_upload_client`` would silently inject credentials into
+    R2 PUT requests. Lock the invariant so a future refactor cannot regress it.
+    """
+    client = FilesClient(api_key="kagura_secret", base_url="https://example.com")
+    assert client._upload_client.auth is None
+    # Sanity: the static API client also has no httpx.Auth — it uses the header.
+    assert client._client.auth is None
+
+
+def test_init_requires_api_key_or_oauth():
+    """Bare FilesClient() must refuse construction with a helpful pointer.
+
+    Auto-resolving credentials at ``__init__`` would silently read
+    ``~/.kagura/credentials.json`` from disk on every constructor call.
+    Force the OAuth path through ``from_mcp_url`` so the disk read is
+    explicit and discoverable in the call site.
+    """
+    with pytest.raises(ValueError, match="from_mcp_url"):
+        FilesClient()  # type: ignore[call-overload]
+
+
+# ============================================================================
+# SDK-level UUID validation (FilesClient.upload / list early reject)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_context_id",
+    ["auto", "not-a-uuid", "", "12345"],
+    ids=["auto-sentinel", "garbage", "empty", "short-digits"],
+)
+async def test_upload_rejects_non_uuid_context_id_locally(bad_context_id: str):
+    """``FilesClient.upload`` must reject non-UUID context_id before the server round-trip.
+
+    Issue #110 motivating case: passing the CLI's ``"auto"`` sentinel
+    straight through previously surfaced as a generic ``HTTP 422``.
+    Local validation turns it into a clear ``ValueError`` whose message
+    points the caller at the OAuth profile's workspace_id.
+    """
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with pytest.raises(ValueError, match="context_id must be a UUID"):
+        await client.upload(context_id=bad_context_id, source=SAMPLE_BODY, filename="x.txt")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_rejects_non_uuid_context_id_locally():
+    """``FilesClient.list`` shares the early reject so neither verb hits the wire."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with pytest.raises(ValueError, match="context_id must be a UUID"):
+        await client.list(context_id="auto")
+    await client.close()
+
+
+# ============================================================================
+# OAuth resolution (FilesClient.from_mcp_url with profile / credentials.json)
+# ============================================================================
+
+
+def _make_oauth_creds(
+    workspace_id: str = "00000000-0000-0000-0000-0000000000ff",
+    expires_in_seconds: int = 3600,
+) -> OAuthCredentials:
+    """Build a usable OAuthCredentials fixture for FilesClient.from_mcp_url tests."""
+    return OAuthCredentials(
+        server="https://oauth.example.com",
+        mcp_url="https://oauth.example.com/mcp",
+        client_id="kagura-cli",
+        access_token="atok-files-test",
+        refresh_token="rtok-files-test",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
+        scope="memory:read memory:write",
+        workspace_id=workspace_id,
+        workspace_name="files-test-ws",
+        user_email="files@example.com",
+        issued_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def _isolated_credentials(tmp_path: Path, monkeypatch):
+    """Redirect credentials.json to tmp_path and clear all credential env vars.
+
+    Without this isolation, the OAuth resolution path on the developer's
+    machine would silently pick up the real ~/.kagura/credentials.json.
+    """
+    fake_path = tmp_path / "credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {"api_key": ""})
+    reset_state_cache()
+    yield fake_path
+    reset_state_cache()
+
+
+def test_from_mcp_url_static_path_unchanged(_isolated_credentials):
+    """from_mcp_url(api_key=...) keeps the static-bearer behavior intact."""
+    client = FilesClient.from_mcp_url(
+        api_key="kagura_explicit",
+        mcp_url="https://memory.kagura-ai.com/mcp",
+    )
+    assert client._client.headers.get("Authorization") == "Bearer kagura_explicit"
+    assert client._client.auth is None
+    assert "Authorization" not in client._upload_client.headers
+    assert client._upload_client.auth is None
+
+
+def test_from_mcp_url_resolves_oauth_profile(_isolated_credentials):
+    """With api_key=None and a profile saved on disk, from_mcp_url uses KaguraOAuth."""
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _isolated_credentials)
+
+    client = FilesClient.from_mcp_url(api_key=None, profile="default")
+
+    # OAuth path: no static Authorization header; httpx.Auth installed instead.
+    assert "Authorization" not in client._client.headers
+    assert isinstance(client._client.auth, KaguraOAuth)
+    # base_url is derived from the profile's stored mcp_url.
+    assert client.base_url == "https://oauth.example.com"
+    # The R2-bound client must remain auth-less even when OAuth is in play.
+    assert client._upload_client.auth is None
+    assert "Authorization" not in client._upload_client.headers
+
+
+def test_from_mcp_url_missing_profile_raises_loud(_isolated_credentials):
+    """Explicit profile arg with no matching credentials.json entry raises."""
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _isolated_credentials)
+    with pytest.raises(KaguraAuthError, match="Profile 'nonexistent'"):
+        FilesClient.from_mcp_url(api_key=None, profile="nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_upload_client_drops_bearer_in_oauth_mode(_isolated_credentials):
+    """CSO finding: OAuth-mode R2 PUT must never carry an Authorization header.
+
+    The KaguraOAuth httpx.Auth subclass injects ``Authorization`` per-request
+    on the client it is attached to. ``_upload_client`` is constructed without
+    ``auth=`` so the OAuth handler is structurally unable to reach it — this
+    test pins that invariant by inspecting the actual PUT call's headers.
+    """
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _isolated_credentials)
+
+    client = FilesClient.from_mcp_url(api_key=None, profile="default")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict(status="uploaded"))
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="oauth.txt",
+        )
+
+    put_headers = mock_put.call_args.kwargs["headers"]
+    assert "Authorization" not in put_headers, (
+        f"R2 PUT must not carry Authorization header in OAuth mode; got: {put_headers}"
+    )
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_oauth_refresh_fires_when_token_near_expiry(_isolated_credentials):
+    """KaguraOAuth refresh fires through FilesClient just like through KaguraClient.
+
+    Stores a credential expiring inside the refresh skew window (5 min default)
+    and stubs the device-flow refresh path. Calling the auth handler's
+    ``_maybe_refresh`` directly is sufficient — the production code reaches
+    the same entry point on every request through ``async_auth_flow``.
+    Bypassing the full httpx round-trip keeps the test focused on the
+    refresh wiring rather than re-testing httpx's auth-flow machinery.
+    """
+    near_expiry = _make_oauth_creds(expires_in_seconds=10)  # well inside 5-min skew
+    cf = CredentialsFile()
+    cf.set_profile("default", near_expiry)
+    save_credentials_file(cf, _isolated_credentials)
+    reset_state_cache()
+
+    rotated_token = MagicMock()
+    rotated_token.access_token = "atok-rotated"
+    rotated_token.refresh_token = None  # server omits → keep old refresh_token
+    rotated_token.expires_at = datetime.now(UTC) + timedelta(hours=1)
+    rotated_token.scope = "memory:read memory:write"
+
+    with (
+        patch(
+            "kagura_memory.auth.device_flow.refresh_access_token",
+            new_callable=AsyncMock,
+            return_value=rotated_token,
+        ) as mock_refresh,
+        patch("kagura_memory.auth.device_flow.make_oauth_client") as mock_client_factory,
+    ):
+        mock_oauth_client = AsyncMock()
+        mock_oauth_client.__aenter__ = AsyncMock(return_value=mock_oauth_client)
+        mock_oauth_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_factory.return_value = mock_oauth_client
+
+        client = FilesClient.from_mcp_url(api_key=None, profile="default")
+        assert isinstance(client._client.auth, KaguraOAuth)
+        await client._client.auth._maybe_refresh()
+
+    mock_refresh.assert_awaited_once()
+    state = get_shared_state(profile="default")
+    assert state is not None
+    assert state.credentials.access_token == "atok-rotated"
+    await client.close()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- **B** — `FilesClient` is now OAuth-aware via the same `_resolve_auth` chain as `KaguraClient` (env → `~/.kagura/credentials.json` → `.kagura.json`). After `kagura auth login`, `FilesClient.from_mcp_url()` picks up the profile, installs `KaguraOAuth` httpx.Auth with auto-refresh, and Bearer credentials remain structurally unable to reach R2 PUTs.
- **C** — The CLI auto-resolves `workspace_id` from the OAuth profile when `--context-id` is missing and `.kagura.json` is absent or set to the `"auto"` sentinel. The previous "Error: HTTP 422" experience disappears for the OAuth-login-only flow.
- **Refactor** — `_resolve_auth`, `_StaticAuth`, `_OAuthAuth` extracted from `client.py` to `src/kagura_memory/_auth.py` (one-way dependency: `_auth` ← `client`, `_auth` ← `files_client`).
- **SDK fail-fast** — Non-UUID `context_id` (including the CLI's `"auto"` sentinel passed through unresolved) now raises a clear `ValueError` at `FilesClient.upload`/`list` entry instead of bouncing off the server as HTTP 422.

## Closes #110 (parts B + C; A shipped in #111)

Issue #110 was split per gate1 design review:
- **A** — `extract_detail` FastAPI 422 formatting — **shipped in #111** (`eef7ab2`)
- **B + C** — this PR

## CSO-flagged Bearer-leak test gap (now closed)

The existing `test_upload_client_has_no_authorization_header` only covered the static api_key path. Two new tests close the OAuth path gap:

- `test_upload_client_drops_bearer_in_oauth_mode` — inspects the actual R2 PUT `call_args` headers to assert `Authorization` is absent under OAuth.
- `test_upload_client_has_no_auth_handler_static_path` — locks the `_upload_client.auth is None` invariant on both paths (defense in depth against a future contributor accidentally attaching `auth=` to the upload client).

Plus a 3-line "Defense in depth" comment above `_upload_client` construction documenting the WHY behind the structural separation.

## Headline scenario verified

```bash
# Before this PR — .kagura.json with "context_id": "auto", credentials.json populated
$ kagura files upload report.md
Error: HTTP 422

# After this PR
$ kagura files upload report.md
{ ... FileObject ... }
```

## Test plan

- [x] `uv run pytest --ignore=tests/eval` → **630 passed**, 1 skipped (unrelated)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format src/ tests/` clean
- [x] `uv run pyright src/` → 0 errors
- [x] OAuth refresh path exercised via FilesClient (test_oauth_refresh_fires_when_token_near_expiry)
- [x] Bearer never reaches R2 PUT under OAuth (test_upload_client_drops_bearer_in_oauth_mode)
- [x] credentials.json-only flow succeeds end-to-end (test_files_upload_uses_oauth_workspace_id_when_no_context)

## Out of scope (follow-ups)

- ResourceClient OAuth wiring — natural next consumer of `_auth.py`; separate issue.
- Test fixture unification (`_make_oauth_creds`, `_isolated_credentials` are duplicated across 3 test files) — pure test refactor.
- `get_shared_state` reads `credentials.json` twice per `kagura files upload` (once for `context_id` resolution, once for `FilesClient` construction). Sub-millisecond cost on local SSD; pass-through optimization can land later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
