### PR TITLE
chore(test): close patch coverage gaps from #110 B+C

### DIFF
--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -205,6 +205,50 @@ def _oauth_creds_with_workspace(workspace_id: str) -> OAuthCredentials:
     )
 
 
+def test_files_upload_with_explicit_context_id_flag(monkeypatch, tmp_path):
+    """``--context-id`` flag is the highest-priority source and bypasses every fallback.
+
+    Covers the first branch of ``_resolve_files_context_id``: when the
+    user passes an explicit UUID via ``-c`` / ``--context-id``, neither
+    ``.kagura.json.context_id`` nor the OAuth profile's ``workspace_id``
+    is consulted.
+    """
+    explicit_ctx = "20000000-0000-0000-0000-000000000003"
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
+    reset_state_cache()
+
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={
+                "api_key": "key",
+                "mcp_url": "https://test.com/mcp",
+                "context_id": SAMPLE_CTX_ID,
+            },
+        ),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    ):
+        mock_client = _mock_files_client("upload", _file_object())
+        mock_client_cls.from_mcp_url.return_value = mock_client
+
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p), "--context-id", explicit_ctx])
+
+    reset_state_cache()
+
+    assert result.exit_code == 0, result.output
+    assert mock_client.upload.call_args.kwargs["context_id"] == explicit_ctx
+    # Confirms the flag won over the .kagura.json default.
+    assert mock_client.upload.call_args.kwargs["context_id"] != SAMPLE_CTX_ID
+
+
 def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_path):
     """`.kagura.json` absent + credentials.json present → workspace_id from OAuth profile.
 

--- a/tests/test_client_auth_resolution.py
+++ b/tests/test_client_auth_resolution.py
@@ -281,3 +281,39 @@ def test_explicit_mcp_url_overrides_profile_mcp_url(isolated_credentials):
 
     client = KaguraClient(mcp_url="https://override.example.com/mcp")
     assert client.mcp_url == "https://override.example.com/mcp"
+
+
+# ---------------------------------------------------------------------------
+# Terminal .kagura.json fallback (static path of last resort)
+# ---------------------------------------------------------------------------
+
+
+def test_kagura_json_fallback_static_path(tmp_path: Path, monkeypatch):
+    """Last branch of the resolver: api_key=None, env clear, no profile → .kagura.json wins.
+
+    The credentials precedence ends at ``.kagura.json``; when every
+    earlier source (explicit arg, ``KAGURA_API_KEY``, OAuth profile) is
+    absent and the legacy config has an ``api_key``, the resolver must
+    return a ``_StaticAuth`` carrying that key. ``isolated_credentials``
+    blanks ``load_config`` for tests that exercise OAuth paths, so this
+    branch needs a dedicated fixture that lets ``load_config`` produce
+    a real ``api_key``.
+    """
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    monkeypatch.setattr(
+        "kagura_memory._auth.load_config",
+        lambda: {"api_key": "key-from-dot-kagura", "mcp_url": "https://legacy.example.com/mcp"},
+    )
+    reset_state_cache()
+
+    client = KaguraClient()
+    assert client._client.headers.get("Authorization") == "Bearer key-from-dot-kagura"
+    assert client._client.auth is None  # static path, no httpx.Auth attached
+    assert client.mcp_url == "https://legacy.example.com/mcp"
+    reset_state_cache()


### PR DESCRIPTION
## Summary

Closes the two uncovered new lines from PR #112 (codecov patch coverage 97.01% → 100% expected):

- `_auth.py:106` — the `.kagura.json` static fallback branch of `_resolve_auth`
- `cli.py:1465` — the explicit `--context-id` flag early return in `_resolve_files_context_id`

## Why these were missed

PR #112's `isolated_credentials` fixture deliberately blanks `load_config` so that OAuth-path tests cannot leak through to `.kagura.json`. That same fixture made the terminal `.kagura.json` static path of `_resolve_auth` impossible to exercise from existing tests — so the test-time isolation needed for the OAuth tests created a coverage hole in the very fallback they were protecting against.

For `_resolve_files_context_id`, none of the new tests called `kagura files upload --context-id <uuid>` directly; they all relied on resolver fallbacks via config or OAuth profile.

## Test plan

- [x] `tests/test_client_auth_resolution.py::test_kagura_json_fallback_static_path` — terminal `.kagura.json` branch with all earlier sources blocked
- [x] `tests/test_cli_files.py::test_files_upload_with_explicit_context_id_flag` — `--context-id` flag wins over `.kagura.json.context_id` and reaches `FilesClient.upload` verbatim
- [x] `_auth.py` coverage: 97% → 100%
- [x] cli.py patch coverage for #110 diff: closes the 1465 gap (pre-existing CLI command lines remain uncovered, out of scope)
- [x] `uv run pytest --ignore=tests/eval` → 632 passed
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run pyright src/` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)