### PR TITLE
feat(cli): add --verbose / --progress flags + NDJSON progress for AI consumers

### DIFF
--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -12,7 +12,7 @@ import litellm
 
 from .client import KaguraClient
 from .exceptions import KaguraAuthError, KaguraConnectionError, KaguraLLMError, KaguraRateLimitError
-from .logger import VerboseLogger
+from .logger import _NULL_LOGGER, VerboseLogger
 from .models import (
     AnalysisResult,
     ExploredMemory,
@@ -78,7 +78,9 @@ class KaguraAgent:
         self._ollama_stream = ollama_stream
         self._ollama_client: httpx.AsyncClient | None = None
         self.client = KaguraClient(api_key, mcp_url, timeout)
-        self.logger: VerboseLogger | None = None
+        # Default to the NO-OP logger so call sites can drop `if self.logger:`
+        # guards. process(verbose=N) overwrites this with a real instance.
+        self.logger: VerboseLogger = _NULL_LOGGER
 
         # Generic cache system with individual timestamps (5 minutes TTL)
         self._cache: dict[str, tuple[Any, float]] = {}
@@ -140,9 +142,8 @@ class KaguraAgent:
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:
-                if self.logger:
-                    hook_name = getattr(fn, "__name__", repr(fn))
-                    self.logger.warning(f"Hook '{hook_name}' failed: {e}")
+                hook_name = getattr(fn, "__name__", repr(fn))
+                self.logger.warning(f"Hook '{hook_name}' failed: {e}")
 
     def skill(self, name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
         """Register a skill.
@@ -237,13 +238,12 @@ class KaguraAgent:
                 return copy.deepcopy(data)
 
         # Cache miss or expired - fetch new data
-        if self.logger:
-            self.logger.detail(f"Fetching {label}", "cache miss or expired")
+        self.logger.detail(f"Fetching {label}", "cache miss or expired")
 
         data = await fetch_fn()
         self._cache[cache_key] = (data, time.time())
 
-        if self.logger and data:
+        if data:
             count = len(data) if isinstance(data, list) else "N/A"
             self.logger.detail(f"Cached {label}", f"{count} items" if count != "N/A" else "")
 
@@ -367,8 +367,7 @@ class KaguraAgent:
                 if attempt == self.max_retries - 1:
                     raise
                 wait_time = 2**attempt
-                if self.logger:
-                    self.logger.warning(f"Rate limited, retrying in {wait_time}s...")
+                self.logger.warning(f"Rate limited, retrying in {wait_time}s...")
                 await asyncio.sleep(wait_time)
 
             except json.JSONDecodeError as e:
@@ -459,8 +458,7 @@ class KaguraAgent:
             KaguraLLMError: LLM call failed
             KaguraRateLimitError: Rate limit exceeded
         """
-        if self.logger:
-            self.logger.action("Analyzing session with LLM", f"model={self.model}")
+        self.logger.action("Analyzing session with LLM", f"model={self.model}")
 
         # Build prompt (with or without enhanced context)
         if use_enhanced_context:
@@ -469,32 +467,27 @@ class KaguraAgent:
                 user_prompt = build_analysis_prompt_with_tools(
                     session, enhanced_ctx["tools"], enhanced_ctx["contexts"]
                 )
-
-                if self.logger:
-                    tools_count = len(enhanced_ctx["tools"])
-                    contexts_count = len(enhanced_ctx["contexts"])
-                    self.logger.detail(
-                        "Using enhanced context", f"{tools_count} tools, {contexts_count} contexts"
-                    )
+                tools_count = len(enhanced_ctx["tools"])
+                contexts_count = len(enhanced_ctx["contexts"])
+                self.logger.detail(
+                    "Using enhanced context", f"{tools_count} tools, {contexts_count} contexts"
+                )
             except KaguraAuthError:
                 raise  # Don't swallow auth errors — surface to caller
             except KaguraConnectionError as e:
                 # Fallback to basic prompt only for network/server errors
-                if self.logger:
-                    self.logger.warning(f"Enhanced context failed, using basic prompt: {e}")
+                self.logger.warning(f"Enhanced context failed, using basic prompt: {e}")
                 user_prompt = build_analysis_prompt(session)
             except Exception as e:
-                if self.logger:
-                    self.logger.warning(f"Enhanced context failed, using basic prompt: {e}")
+                self.logger.warning(f"Enhanced context failed, using basic prompt: {e}")
                 user_prompt = build_analysis_prompt(session)
         else:
             user_prompt = build_analysis_prompt(session)
 
-        if self.logger:
-            self.logger.debug(
-                "LLM Prompt",
-                {"system": SYSTEM_PROMPT[:200] + "...", "user": user_prompt[:500] + "..."},
-            )
+        self.logger.debug(
+            "LLM Prompt",
+            {"system": SYSTEM_PROMPT[:200] + "...", "user": user_prompt[:500] + "..."},
+        )
 
         # Call LLM
         messages = [
@@ -503,12 +496,11 @@ class KaguraAgent:
         ]
         analysis_data, response = await self._call_llm(messages, temperature=0.3)
 
-        if self.logger:
-            self.logger.debug("LLM Response", analysis_data)
+        self.logger.debug("LLM Response", analysis_data)
 
         # Extract and log usage
         llm_usage = self._extract_usage(response)
-        if llm_usage and self.logger:
+        if llm_usage:
             self.logger.detail(
                 "Tokens used",
                 f"{llm_usage.total_tokens} (prompt: {llm_usage.prompt_tokens}, "
@@ -547,8 +539,7 @@ class KaguraAgent:
 
         for query_info in queries:
             query = query_info.query
-            if self.logger:
-                self.logger.action("Recalling memories", f'query="{query}"')
+            self.logger.action("Recalling memories", f'query="{query}"')
 
             result = await self.client.recall(ctx, query, k=recall_k, filters=query_info.filters)
 
@@ -562,13 +553,11 @@ class KaguraAgent:
                 )
 
             actions.append(f"recall: {query}")
-            if self.logger:
-                self.logger.detail("Found memories", len(recalled))
+            self.logger.detail("Found memories", len(recalled))
 
             # Deep mode: explore if results found
             if deep and recalled:
-                if self.logger:
-                    self.logger.action("Deep exploration", f"seed={recalled[0].memory_id}")
+                self.logger.action("Deep exploration", f"seed={recalled[0].memory_id}")
                 seed_id = recalled[0].memory_id
 
                 try:
@@ -591,14 +580,12 @@ class KaguraAgent:
                         )
 
                     actions.append(f"explore: depth=2, found={len(explored)}")
-                    if self.logger:
-                        self.logger.detail("Explored memories", len(explored))
+                    self.logger.detail("Explored memories", len(explored))
 
                 except KaguraAuthError:
                     raise
                 except Exception as e:
-                    if self.logger:
-                        self.logger.warning(f"Explore failed: {e}")
+                    self.logger.warning(f"Explore failed: {e}")
 
         return recalled, explored, actions
 
@@ -619,8 +606,7 @@ class KaguraAgent:
         actions: list[str] = []
 
         for mem in memories:
-            if self.logger:
-                self.logger.action("Storing memory", f'summary="{mem.summary[:50]}..."')
+            self.logger.action("Storing memory", f'summary="{mem.summary[:50]}..."')
 
             try:
                 result = await self.client.remember(
@@ -635,14 +621,12 @@ class KaguraAgent:
                 remembered.append(MemoryInfo(memory_id=result["memory_id"], summary=mem.summary))
 
                 actions.append(f"remember: {mem.summary[:50]}")
-                if self.logger:
-                    self.logger.success(f"Stored memory: {result['memory_id']}")
+                self.logger.success(f"Stored memory: {result['memory_id']}")
 
             except KaguraAuthError:
                 raise  # Auth errors are unrecoverable — surface to caller
             except Exception as e:
-                if self.logger:
-                    self.logger.error(f"Failed to store memory: {e}")
+                self.logger.error(f"Failed to store memory: {e}")
 
         return remembered, actions
 
@@ -659,8 +643,7 @@ class KaguraAgent:
         Raises:
             KaguraLLMError: Context selection failed
         """
-        if self.logger:
-            self.logger.action("Auto-selecting context")
+        self.logger.action("Auto-selecting context")
 
         # Get available contexts
         contexts_response = await self.client.list_contexts()
@@ -672,8 +655,7 @@ class KaguraAgent:
         # If only one context, use it
         if len(contexts) == 1:
             selected = contexts[0]["id"]
-            if self.logger:
-                self.logger.detail("Auto-selected", f"{contexts[0]['name']} (only option)")
+            self.logger.detail("Auto-selected", f"{contexts[0]['name']} (only option)")
             return selected
 
         # Use LLM to select best context
@@ -689,15 +671,14 @@ class KaguraAgent:
 
             selected_id = result.get("selected_context_id")
 
-            if selected_id and self.logger:
+            if selected_id:
                 self.logger.detail("Context selected", result.get("reason", ""))
 
             return selected_id or contexts[0]["id"]
 
         except Exception as e:
             # Fallback to first context
-            if self.logger:
-                self.logger.warning(f"Context selection failed, using first context: {e}")
+            self.logger.warning(f"Context selection failed, using first context: {e}")
             return contexts[0]["id"]
 
     async def process(

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1485,20 +1485,57 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version, v
             stage="import_start",
         )
 
-    # Batch ingest (100 at a time)
+    # Batch ingest (100 at a time). The CLI command is ONE user-facing
+    # operation, so it must emit exactly one terminal event. ``ingest_events``
+    # also has its own per-call terminal contract — calling it N times with
+    # the same logger would produce N ``kind=success`` events and break the
+    # "wait for the first success/error" reader contract. Resolution: pass
+    # ``logger=None`` to the SDK (suppresses its terminal events), emit
+    # per-batch progress here at the CLI level, and close with one terminal
+    # event at the very end covering the whole import.
     async def op(client: ResourceClient) -> str:
         total_created = 0
         total_failed = 0
         all_errors: list[dict] = []
-        for start in range(0, len(events), 100):
-            batch = events[start : start + 100]
-            result = await client.ingest_events(resource_id, api_key, batch, logger=logger)
-            total_created += result.created_count
-            total_failed += result.failed_count
-            all_errors.extend(result.errors[:5])  # Keep first 5 errors per batch
+        batch_count = (len(events) + 99) // 100
+        try:
+            for i, start in enumerate(range(0, len(events), 100), 1):
+                batch = events[start : start + 100]
+                if logger is not None:
+                    logger.action(
+                        "Ingesting batch",
+                        f"{i}/{batch_count} ({len(batch)} event(s))",
+                        stage="import_batch",
+                    )
+                result = await client.ingest_events(resource_id, api_key, batch, logger=None)
+                total_created += result.created_count
+                total_failed += result.failed_count
+                all_errors.extend(result.errors[:5])  # Keep first 5 errors per batch
+        except BaseException as e:
+            if logger is not None:
+                logger.error(
+                    f"Import failed: {e}",
+                    stage="complete",
+                    detail={
+                        "created_so_far": total_created,
+                        "failed_so_far": total_failed,
+                        "total_events": len(events),
+                    },
+                )
+            raise
         output: dict = {"created": total_created, "failed": total_failed, "total": len(events)}
         if all_errors:
             output["errors"] = all_errors[:10]  # Show first 10 errors total
+        if logger is not None:
+            logger.success(
+                "Import complete",
+                stage="complete",
+                detail={
+                    "created": total_created,
+                    "failed": total_failed,
+                    "total": len(events),
+                },
+            )
         return json.dumps(output, indent=2, ensure_ascii=False)
 
     _run_resource_command(op)

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -16,9 +16,44 @@ from .auth.credentials import get_shared_state
 from .client import KaguraClient
 from .config import load_config
 from .files_client import FilesClient
+from .logger import VerboseLogger
 from .models import Message, ProcessResult, ResourceEventRequest, Session
 from .resource_client import ResourceClient
 from .setup_claude import run_setup_claude
+
+_PROGRESS_CHOICES = ["rich", "json", "none"]
+
+
+def _resolve_progress_logger(verbose: int, progress: str | None) -> VerboseLogger | None:
+    """Resolve ``-v`` / ``--progress`` CLI flags to a ``VerboseLogger`` (or None).
+
+    Issue #108 precedence rule (canonical):
+
+    1. ``--progress`` explicit wins; format is exactly its value.
+    2. ``--progress`` omitted → ``rich`` if ``-v`` count ≥ 1, else ``none``.
+    3. ``-v`` level controls Rich verbosity (1=actions, 2=details, 3=debug).
+       For ``--progress=json``, ``-v`` is ignored — JSON path always emits all
+       ``kind`` values (downstream consumers filter).
+    4. ``--progress=none`` is always silent regardless of ``-v`` count.
+
+    Returns ``None`` for the silent path so entry points can keep
+    ``logger: VerboseLogger | None = None`` and normalize internally.
+    """
+    if progress is not None:
+        progress = progress.lower()
+    if progress == "none":
+        return None
+    if progress == "json":
+        # level is irrelevant for JSON; pick the max so explicit -v isn't lost
+        # if the caller later switches output_format at the logger level.
+        return VerboseLogger(level=max(1, verbose), output_format="json")
+    if progress == "rich":
+        return VerboseLogger(level=max(1, verbose), output_format="rich")
+    # progress was omitted — fall back to -v presence.
+    if verbose >= 1:
+        return VerboseLogger(level=verbose, output_format="rich")
+    return None
+
 
 # =============================================================================
 # Helper Functions
@@ -93,8 +128,8 @@ main.add_command(_auth_group, name="auth")
 @main.command()
 @click.option("--message", "-m", help="Single message to process")
 @click.option("--file", "-f", type=click.File("r"), help="Session JSON file")
-@click.option("--deep", is_flag=True, help="Enable deep search (Phase 2)")
-@click.option("--verbose", "-v", count=True, help="Increase verbosity (Phase 2)")
+@click.option("--deep", is_flag=True, help="Enable deep search via memory graph exploration")
+@click.option("--verbose", "-v", count=True, help="Increase verbosity (repeatable: -v, -vv, -vvv)")
 def process(message, file, deep, verbose):
     """
     Process session with AI analysis.
@@ -338,6 +373,21 @@ def explore(context_id, memory_id, depth, min_weight):
         "Default is a human-readable summary."
     ),
 )
+@click.option(
+    "--verbose",
+    "-v",
+    count=True,
+    help="Increase verbosity (repeatable: -v, -vv, -vvv).",
+)
+@click.option(
+    "--progress",
+    type=click.Choice(_PROGRESS_CHOICES, case_sensitive=False),
+    default=None,
+    help=(
+        "Progress output format. Default: rich if -v given, none otherwise. "
+        "Use json for AI agents / scripts."
+    ),
+)
 def ingest_file(
     source,
     context_id,
@@ -354,6 +404,8 @@ def ingest_file(
     allow_system_paths,
     dry_run,
     as_json,
+    verbose,
+    progress,
 ):
     """Ingest a URL or local file into Memory Cloud.
 
@@ -440,6 +492,7 @@ def ingest_file(
                         allow_http=allow_http,
                         allow_system_paths=allow_system_paths,
                         archive_original=archive,
+                        logger=_resolve_progress_logger(verbose, progress),
                     )
                 finally:
                     if files_client is not None:
@@ -1318,7 +1371,22 @@ def resource_setup(resource_id, summary, description, quota):
 )
 @click.option("--id-column", help="Column name to use as doc_id (default: row number)")
 @click.option("--version", "-V", type=click.IntRange(1), default=1, help="Version (>=1)")
-def resource_import(resource_id, api_key, input_file, fmt, id_column, version):
+@click.option(
+    "--verbose",
+    "-v",
+    count=True,
+    help="Increase verbosity (repeatable: -v, -vv, -vvv).",
+)
+@click.option(
+    "--progress",
+    type=click.Choice(_PROGRESS_CHOICES, case_sensitive=False),
+    default=None,
+    help=(
+        "Progress output format. Default: rich if -v given, none otherwise. "
+        "Use json for AI agents / scripts."
+    ),
+)
+def resource_import(resource_id, api_key, input_file, fmt, id_column, version, verbose, progress):
     """
     Import data from CSV, JSON, or JSONL file.
 
@@ -1403,6 +1471,7 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version):
         )
 
     click.echo(f"Importing {len(events)} events...")
+    logger = _resolve_progress_logger(verbose, progress)
 
     # Batch ingest (100 at a time)
     async def op(client: ResourceClient) -> str:
@@ -1411,7 +1480,7 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version):
         all_errors: list[dict] = []
         for start in range(0, len(events), 100):
             batch = events[start : start + 100]
-            result = await client.ingest_events(resource_id, api_key, batch)
+            result = await client.ingest_events(resource_id, api_key, batch, logger=logger)
             total_created += result.created_count
             total_failed += result.failed_count
             all_errors.extend(result.errors[:5])  # Keep first 5 errors per batch
@@ -1527,19 +1596,42 @@ def files():
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--context-id", "-c", help="Target context (workspace) UUID")
 @click.option("--content-type", "-t", help="MIME type override (default: sniffed)")
-def files_upload(path: Path, context_id: str | None, content_type: str | None):
+@click.option(
+    "--verbose",
+    "-v",
+    count=True,
+    help="Increase verbosity (repeatable: -v, -vv, -vvv).",
+)
+@click.option(
+    "--progress",
+    type=click.Choice(_PROGRESS_CHOICES, case_sensitive=False),
+    default=None,
+    help=(
+        "Progress output format. Default: rich if -v given, none otherwise. "
+        "Use json for AI agents / scripts."
+    ),
+)
+def files_upload(
+    path: Path,
+    context_id: str | None,
+    content_type: str | None,
+    verbose: int,
+    progress: str | None,
+):
     """
     Upload a file to Kagura Memory Cloud.
 
     Example:
       kagura files upload ./report.pdf --context-id ctx-uuid
     """
+    logger = _resolve_progress_logger(verbose, progress)
 
     async def op(client: FilesClient, ctx: str) -> str:
         result = await client.upload(
             context_id=ctx,
             source=path,
             content_type=content_type,
+            logger=logger,
         )
         return result.model_dump_json(indent=2)
 

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1470,8 +1470,20 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version, v
             )
         )
 
-    click.echo(f"Importing {len(events)} events...")
     logger = _resolve_progress_logger(verbose, progress)
+    # Pre-flight announcement: keep stdout strictly machine-readable (the
+    # JSON output below) by routing the human-readable count to stderr.
+    # Suppress entirely when progress is silent (--progress=none, or no -v
+    # and no --progress) so scripts piping stderr to /dev/null see nothing
+    # unexpected; otherwise emit it as a structured "start" action through
+    # the logger so the rich path stays consistent and json consumers get
+    # a parseable event.
+    if logger is not None:
+        logger.action(
+            "Importing events",
+            f"{len(events)} event(s)",
+            stage="import_start",
+        )
 
     # Batch ingest (100 at a time)
     async def op(client: ResourceClient) -> str:

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -328,27 +328,33 @@ class FilesClient:
             KaguraConnectionError: see class docstring.
         """
         log = normalize_logger(logger)
-        _validate_context_id(context_id)
-        resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
-        size_bytes = len(body)
-        resolved_content_type = _resolve_content_type(content_type, resolved_filename)
-
-        log.action(
-            "Reserving upload",
-            f"{resolved_filename} ({size_bytes} bytes)",
-            stage="reserve",
-        )
-        reserve_body = {
-            "workspace_id": context_id,
-            "filename": resolved_filename,
-            "content_type": resolved_content_type,
-            "size_bytes": size_bytes,
-            "sha256": sha256_hex,
-        }
-
         reserved_file_id: str | None = None
         uploaded = False
         try:
+            # Pre-flight validators and source preparation can raise too
+            # (ValueError from _validate_context_id, FileNotFoundError /
+            # ValueError from _prepare_source). They live INSIDE the try so
+            # those failures also get a terminal kind=error event before
+            # propagating — matching the contract documented in the logger
+            # module's "terminal-event" docstring.
+            _validate_context_id(context_id)
+            resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
+            size_bytes = len(body)
+            resolved_content_type = _resolve_content_type(content_type, resolved_filename)
+
+            log.action(
+                "Reserving upload",
+                f"{resolved_filename} ({size_bytes} bytes)",
+                stage="reserve",
+            )
+            reserve_body = {
+                "workspace_id": context_id,
+                "filename": resolved_filename,
+                "content_type": resolved_content_type,
+                "size_bytes": size_bytes,
+                "sha256": sha256_hex,
+            }
+
             try:
                 reserve_resp = await self._request(
                     "POST", "/api/v1/files/reserve", json=reserve_body

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -330,6 +330,15 @@ class FilesClient:
         log = normalize_logger(logger)
         reserved_file_id: str | None = None
         uploaded = False
+        # ``confirm_started`` flips True when the confirm HTTP request is
+        # dispatched; ``confirmed`` flips True only after the server response
+        # is fully parsed into a FileObject. The two flags together let an AI
+        # consumer reading the terminal-error detail tell apart "confirm
+        # never ran — safe to redo from scratch" vs "confirm dispatched but
+        # we don't know if the server processed it — must verify before
+        # retrying".
+        confirm_started = False
+        confirmed = False
         try:
             # Pre-flight validators and source preparation can raise too
             # (ValueError from _validate_context_id, FileNotFoundError /
@@ -385,12 +394,14 @@ class FilesClient:
             uploaded = True
 
             log.action("Confirming upload", stage="confirm")
+            confirm_started = True
             confirm_resp = await self._request(
                 "POST",
                 f"/api/v1/files/{reserve.file_id}/confirm",
                 json={"sha256": sha256_hex},
             )
             result = FileObject.model_validate(confirm_resp.json())
+            confirmed = True
             log.success(
                 "Upload complete",
                 stage="complete",
@@ -400,13 +411,18 @@ class FilesClient:
         except BaseException as e:
             # Terminal-event guarantee: include partial state so a recovering
             # AI consumer can decide whether to retry confirm vs re-upload.
+            # ``confirm_started`` AND NOT ``confirmed`` is the ambiguous case
+            # (the server may have processed the confirm, but we lost the
+            # response) — consumers should verify file state before retrying
+            # rather than re-uploading.
             log.error(
                 f"Upload failed: {e}",
                 stage="complete",
                 detail={
                     "reserved_file_id": reserved_file_id,
                     "uploaded": uploaded,
-                    "confirmed": False,
+                    "confirm_started": confirm_started,
+                    "confirmed": confirmed,
                 },
             )
             raise

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -39,7 +39,7 @@ from .exceptions import (
     KaguraNotFoundError,
     KaguraQuotaError,
 )
-from .logger import _NULL_LOGGER, VerboseLogger
+from .logger import VerboseLogger, normalize_logger
 from .models import (
     FileDownloadUrlResponse,
     FileListResponse,
@@ -327,7 +327,7 @@ class FilesClient:
             KaguraAuthError, KaguraNotFoundError, KaguraQuotaError,
             KaguraConnectionError: see class docstring.
         """
-        log = logger or _NULL_LOGGER
+        log = normalize_logger(logger)
         _validate_context_id(context_id)
         resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
         size_bytes = len(body)

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -39,6 +39,7 @@ from .exceptions import (
     KaguraNotFoundError,
     KaguraQuotaError,
 )
+from .logger import _NULL_LOGGER, VerboseLogger
 from .models import (
     FileDownloadUrlResponse,
     FileListResponse,
@@ -281,6 +282,7 @@ class FilesClient:
         source: Path | bytes,
         filename: str | None = None,
         content_type: str | None = None,
+        logger: VerboseLogger | None = None,
     ) -> FileObject:
         """Upload a file to Kagura Memory Cloud.
 
@@ -325,11 +327,17 @@ class FilesClient:
             KaguraAuthError, KaguraNotFoundError, KaguraQuotaError,
             KaguraConnectionError: see class docstring.
         """
+        log = logger or _NULL_LOGGER
         _validate_context_id(context_id)
         resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
         size_bytes = len(body)
         resolved_content_type = _resolve_content_type(content_type, resolved_filename)
 
+        log.action(
+            "Reserving upload",
+            f"{resolved_filename} ({size_bytes} bytes)",
+            stage="reserve",
+        )
         reserve_body = {
             "workspace_id": context_id,
             "filename": resolved_filename,
@@ -338,32 +346,64 @@ class FilesClient:
             "sha256": sha256_hex,
         }
 
+        reserved_file_id: str | None = None
+        uploaded = False
         try:
-            reserve_resp = await self._request("POST", "/api/v1/files/reserve", json=reserve_body)
-        except KaguraConnectionError as e:
-            # 409 dedup happy-path: server reports the existing file
-            # in the error detail; surface it as a FileObject so the
-            # caller does not have to special-case duplicates.
-            existing = _extract_existing_file(e)
-            if existing is not None:
-                return existing
+            try:
+                reserve_resp = await self._request(
+                    "POST", "/api/v1/files/reserve", json=reserve_body
+                )
+            except KaguraConnectionError as e:
+                # 409 dedup happy-path: server reports the existing file
+                # in the error detail; surface it as a FileObject so the
+                # caller does not have to special-case duplicates.
+                existing = _extract_existing_file(e)
+                if existing is not None:
+                    log.success(
+                        "Dedup hit — existing file returned",
+                        stage="complete",
+                        detail={"file_id": existing.id, "deduped": True},
+                    )
+                    return existing
+                raise
+
+            reserve = FileReserveResponse.model_validate(reserve_resp.json())
+            reserved_file_id = reserve.file_id
+            log.action("Uploading to object store", stage="upload")
+            await self._put_to_object_store(
+                upload_url=reserve.upload_url,
+                body=body,
+                sha256_hex=sha256_hex,
+                content_type=resolved_content_type,
+            )
+            uploaded = True
+
+            log.action("Confirming upload", stage="confirm")
+            confirm_resp = await self._request(
+                "POST",
+                f"/api/v1/files/{reserve.file_id}/confirm",
+                json={"sha256": sha256_hex},
+            )
+            result = FileObject.model_validate(confirm_resp.json())
+            log.success(
+                "Upload complete",
+                stage="complete",
+                detail={"file_id": result.id, "size_bytes": size_bytes},
+            )
+            return result
+        except BaseException as e:
+            # Terminal-event guarantee: include partial state so a recovering
+            # AI consumer can decide whether to retry confirm vs re-upload.
+            log.error(
+                f"Upload failed: {e}",
+                stage="complete",
+                detail={
+                    "reserved_file_id": reserved_file_id,
+                    "uploaded": uploaded,
+                    "confirmed": False,
+                },
+            )
             raise
-
-        reserve = FileReserveResponse.model_validate(reserve_resp.json())
-
-        await self._put_to_object_store(
-            upload_url=reserve.upload_url,
-            body=body,
-            sha256_hex=sha256_hex,
-            content_type=resolved_content_type,
-        )
-
-        confirm_resp = await self._request(
-            "POST",
-            f"/api/v1/files/{reserve.file_id}/confirm",
-            json={"sha256": sha256_hex},
-        )
-        return FileObject.model_validate(confirm_resp.json())
 
     async def download_url(self, file_id: str) -> str:
         """Return a short-lived presigned GET URL for ``file_id``."""

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -21,7 +21,7 @@ from urllib.parse import urlsplit
 from ..client import KaguraClient
 from ..exceptions import KaguraFetchError, KaguraIngestError, KaguraLLMError
 from ..files_client import FilesClient
-from ..logger import _NULL_LOGGER, VerboseLogger
+from ..logger import VerboseLogger, normalize_logger
 from ..models import CostBreakdown, FileObject, IngestErrorRecord, IngestResult
 from ._types import Chunk, ExtractedContent
 from .chunker import chunk as do_chunk
@@ -125,7 +125,7 @@ class FileIngestor:
                 ``kind=error`` as the final event) is honored even when
                 an unhandled exception escapes the body.
         """
-        log = logger or _NULL_LOGGER
+        log = normalize_logger(logger)
         log.action("Fetching source", source, stage="fetch")
         try:
             fetched = await self._fetch(
@@ -290,7 +290,7 @@ class FileIngestor:
         archive_original: bool,
         logger: VerboseLogger | None = None,
     ) -> IngestResult:
-        log = logger or _NULL_LOGGER
+        log = normalize_logger(logger)
         errors: list[IngestErrorRecord] = []
         warnings: list[str] = []
 

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -155,18 +155,23 @@ class FileIngestor:
             # Terminal-event guarantee: emit kind=error before propagating.
             log.error(f"Ingest failed: {e}", stage="complete", detail={"source": source})
             raise
+        # Success means the overview memory was created. Per-section errors
+        # are best-effort (see IngestResult.success): they ride in
+        # ``error_count`` so AI consumers can react, but they do NOT flip the
+        # terminal event to ``kind=error``. Only a missing overview does.
         terminal_detail = {
             "overview_id": result.overview_id,
             "section_count": len(result.section_ids),
+            "error_count": len(result.errors),
         }
-        if result.errors:
+        if result.success:
+            log.success("Ingest complete", stage="complete", detail=terminal_detail)
+        else:
             log.error(
-                f"Ingest finished with {len(result.errors)} error(s)",
+                "Ingest failed — overview not created",
                 stage="complete",
                 detail=terminal_detail,
             )
-        else:
-            log.success("Ingest complete", stage="complete", detail=terminal_detail)
         return result
 
     async def estimate_cost(

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -138,8 +138,12 @@ class FileIngestor:
             )
         except KaguraFetchError as e:
             # Best-effort contract: surface fetch failures via IngestResult
-            # so --json output stays machine-readable for scripts.
-            log.error(f"Fetch failed: {e}", stage="fetch", detail={"source": source})
+            # so --json output stays machine-readable for scripts. Use
+            # stage="complete" because this IS the terminal event for the
+            # ingest operation — keeping all terminal events on the same
+            # stage lets consumers do coarse state tracking without a
+            # special "fetch-failed" stage carve-out.
+            log.error(f"Fetch failed: {e}", stage="complete", detail={"source": source})
             return _fetch_failure_result(source, e, is_dry_run=False, ingestor=self)
         log.detail("Fetched bytes", len(fetched.body), stage="fetch")
         try:

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -21,6 +21,7 @@ from urllib.parse import urlsplit
 from ..client import KaguraClient
 from ..exceptions import KaguraFetchError, KaguraIngestError, KaguraLLMError
 from ..files_client import FilesClient
+from ..logger import _NULL_LOGGER, VerboseLogger
 from ..models import CostBreakdown, FileObject, IngestErrorRecord, IngestResult
 from ._types import Chunk, ExtractedContent
 from .chunker import chunk as do_chunk
@@ -103,6 +104,7 @@ class FileIngestor:
         allow_http: bool = False,
         allow_system_paths: bool = False,
         archive_original: bool = True,
+        logger: VerboseLogger | None = None,
     ) -> IngestResult:
         """Run a full ingestion against ``source``.
 
@@ -115,7 +117,16 @@ class FileIngestor:
                 archival (saves R2 storage; the memory then has no
                 back-reference to the original bytes). No effect when
                 ``files_client`` is None.
+            logger: Optional :class:`VerboseLogger` for progress events
+                (Rich for human stderr, NDJSON for AI consumers). When
+                omitted, the no-op :data:`_NULL_LOGGER` is used and no
+                events are emitted — library default is silent. The
+                terminal-event contract (exactly one ``kind=success`` or
+                ``kind=error`` as the final event) is honored even when
+                an unhandled exception escapes the body.
         """
+        log = logger or _NULL_LOGGER
+        log.action("Fetching source", source, stage="fetch")
         try:
             fetched = await self._fetch(
                 source,
@@ -128,14 +139,35 @@ class FileIngestor:
         except KaguraFetchError as e:
             # Best-effort contract: surface fetch failures via IngestResult
             # so --json output stays machine-readable for scripts.
+            log.error(f"Fetch failed: {e}", stage="fetch", detail={"source": source})
             return _fetch_failure_result(source, e, is_dry_run=False, ingestor=self)
-        return await self._ingest_fetched(
-            fetched,
-            context_id=context_id,
-            tags=tags,
-            importance=importance,
-            archive_original=archive_original,
-        )
+        log.detail("Fetched bytes", len(fetched.body), stage="fetch")
+        try:
+            result = await self._ingest_fetched(
+                fetched,
+                context_id=context_id,
+                tags=tags,
+                importance=importance,
+                archive_original=archive_original,
+                logger=log,
+            )
+        except BaseException as e:
+            # Terminal-event guarantee: emit kind=error before propagating.
+            log.error(f"Ingest failed: {e}", stage="complete", detail={"source": source})
+            raise
+        terminal_detail = {
+            "overview_id": result.overview_id,
+            "section_count": len(result.section_ids),
+        }
+        if result.errors:
+            log.error(
+                f"Ingest finished with {len(result.errors)} error(s)",
+                stage="complete",
+                detail=terminal_detail,
+            )
+        else:
+            log.success("Ingest complete", stage="complete", detail=terminal_detail)
+        return result
 
     async def estimate_cost(
         self,
@@ -256,10 +288,13 @@ class FileIngestor:
         tags: list[str] | None,
         importance: float,
         archive_original: bool,
+        logger: VerboseLogger | None = None,
     ) -> IngestResult:
+        log = logger or _NULL_LOGGER
         errors: list[IngestErrorRecord] = []
         warnings: list[str] = []
 
+        log.action("Extracting and chunking", stage="chunk")
         try:
             content, chunks = self._extract_and_chunk(fetched)
         except (KaguraIngestError, ValueError) as e:
@@ -296,10 +331,13 @@ class FileIngestor:
                 self._archive_original(fetched, context_id=context_id, errors=errors)
             )
 
+        log.action(f"Summarizing {len(chunks)} section(s)", stage="summarize")
         section_summaries = await self._summarize_sections(chunks, errors)
+        log.detail("Sections summarized", len(section_summaries), stage="summarize")
 
         # Build the overview from the section summaries (in parallel with
         # the still-pending archive_task, if any).
+        log.action("Summarizing overview", stage="summarize")
         try:
             overview_summary = await self._text.summarize_overview(
                 [s for s in section_summaries if s], max_tokens=_DEFAULT_OVERVIEW_TOKENS

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -81,13 +81,18 @@ class VerboseLogger:
         """Initialize a logger.
 
         Args:
-            level: Rich-path verbosity threshold. ``0`` is silent
-                (matches the ``--progress=none`` and ``-v`` not given
-                case), ``1`` shows actions/success/warning,
-                ``2`` adds details, ``3`` adds debug panels. Ignored
-                when ``output_format="json"`` — the JSON path emits
-                every event regardless of level (downstream consumers
-                filter by ``kind``).
+            level: Rich-path verbosity threshold for non-error events.
+                ``0`` silences ``action``/``detail``/``success``/
+                ``warning``/``debug`` (matches the ``--progress=none``
+                and ``-v`` not given case), ``1`` shows actions /
+                success / warning, ``2`` adds details, ``3`` adds debug
+                panels. ``error`` is the one exception — terminal
+                failures render on the Rich path regardless of level,
+                because hiding an error behind ``-v`` is rarely what
+                a CLI user wants. Ignored entirely when
+                ``output_format="json"``: the JSON path emits every
+                event regardless of level so downstream consumers can
+                filter by ``kind``.
             console: Optional Rich :class:`Console` instance. When
                 omitted, a stderr-bound console is created. Tests
                 pass a stub here to capture output.
@@ -105,6 +110,22 @@ class VerboseLogger:
     def _should_log_rich(self, min_level: int) -> bool:
         """True iff this logger should render a Rich event at ``min_level``."""
         return self.output_format == "rich" and self.level >= min_level
+
+    def _safe_rich_print(self, *args: Any, **kwargs: Any) -> None:
+        """Wrap ``Console.print`` so a broken stderr pipe never crashes the caller.
+
+        The Rich path normally goes through a ``Console(stderr=True)``
+        instance. When a downstream consumer of the stderr pipe exits
+        early (``kagura ingest -v | head -n 1``) Rich's writer raises
+        ``BrokenPipeError`` / ``OSError`` mid-call — without this guard
+        the underlying SDK operation would crash because of its own
+        observability stream. Matches the JSON path's
+        ``except OSError`` in :meth:`_emit_json`.
+        """
+        try:
+            self._console.print(*args, **kwargs)
+        except OSError:
+            pass
 
     def _emit_json(
         self,
@@ -181,11 +202,11 @@ class VerboseLogger:
             return
         if not self._should_log_rich(1):
             return
-        self._console.print(f"[bold blue]→[/bold blue] {action}", end="")
+        self._safe_rich_print(f"[bold blue]→[/bold blue] {action}", end="")
         if details:
-            self._console.print(f" [dim]{details}[/dim]")
+            self._safe_rich_print(f" [dim]{details}[/dim]")
         else:
-            self._console.print()
+            self._safe_rich_print()
 
     def detail(self, key: str, value: Any, *, stage: str | None = None) -> None:
         """Log a structured detail — ``kind=detail``, level ≥ 2."""
@@ -196,7 +217,7 @@ class VerboseLogger:
             return
         if not self._should_log_rich(2):
             return
-        self._console.print(f"  [cyan]•[/cyan] {key}: [yellow]{value}[/yellow]")
+        self._safe_rich_print(f"  [cyan]•[/cyan] {key}: [yellow]{value}[/yellow]")
 
     def debug(
         self, title: str, data: Any, syntax: str = "json", *, stage: str | None = None
@@ -223,13 +244,21 @@ class VerboseLogger:
             return
         if not self._should_log_rich(3):
             return
-        if isinstance(data, (dict, list)):
-            data_str = json.dumps(data, indent=2, ensure_ascii=False)
-        else:
-            data_str = str(data)
+        # Same best-effort serialization as the JSON path: a dict/list with
+        # non-serializable members (Path, UUID, …) should render via
+        # ``default=str``, and an object whose ``__str__`` raises should
+        # surface as a labelled placeholder rather than crashing the caller.
+        # The never-raise contract applies to the Rich path too.
+        try:
+            if isinstance(data, (dict, list)):
+                data_str = json.dumps(data, indent=2, ensure_ascii=False, default=str)
+            else:
+                data_str = str(data)
+        except Exception:  # noqa: BLE001 — best-effort fallback for any serialization error
+            data_str = f"<{type(data).__name__} serialization failed>"
         if len(data_str) > 2000:
             data_str = data_str[:2000] + "\n... (truncated)"
-        self._console.print(
+        self._safe_rich_print(
             Panel(
                 Syntax(data_str, syntax, theme="monokai", word_wrap=True),
                 title=f"[bold magenta]{title}[/bold magenta]",
@@ -258,7 +287,7 @@ class VerboseLogger:
             return
         if not self._should_log_rich(1):
             return
-        self._console.print(f"[bold green]✓[/bold green] {message}")
+        self._safe_rich_print(f"[bold green]✓[/bold green] {message}")
 
     def warning(self, message: str, *, stage: str | None = None) -> None:
         """Log a non-fatal warning — ``kind=warning``, level ≥ 1.
@@ -273,7 +302,7 @@ class VerboseLogger:
             return
         if not self._should_log_rich(1):
             return
-        self._console.print(f"[bold yellow]⚠[/bold yellow] {message}")
+        self._safe_rich_print(f"[bold yellow]⚠[/bold yellow] {message}")
 
     def error(
         self,
@@ -295,7 +324,7 @@ class VerboseLogger:
             self._emit_json(kind="error", stage=stage, msg=message, detail=detail)
             return
         # Rich path: error always renders, regardless of self.level.
-        self._console.print(f"[bold red]✗[/bold red] {message}", style="bold red")
+        self._safe_rich_print(f"[bold red]✗[/bold red] {message}", style="bold red")
 
 
 _NULL_LOGGER: VerboseLogger = VerboseLogger(level=0, output_format="none")

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -125,6 +125,10 @@ class VerboseLogger:
         try:
             self._console.print(*args, **kwargs)
         except OSError:
+            # Deliberately silent: progress logging must never crash the
+            # operation it is reporting on. See the function docstring
+            # above and the module-level "progress logging must never
+            # raise" contract for the rationale.
             pass
 
     def _emit_json(

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -1,63 +1,203 @@
-"""Verbose logging utilities using Rich library."""
+"""Verbose logging for the Kagura SDK and CLI.
+
+Two consumer classes share one event stream, three render formats:
+
+- **Human operators** read Rich-formatted glyphs/colors on stderr
+  (``output_format="rich"``, level-filtered by ``-v`` count).
+- **AI agents / scripts** read newline-delimited JSON on stderr
+  (``output_format="json"``); they parse the stream with ``jq -c`` or
+  any line-buffered JSON reader and wait for the terminal event
+  (``kind in ("success", "error")``) to know the operation finished.
+- **Library callers** that don't opt in get silent output via
+  :data:`_NULL_LOGGER` (``output_format="none"``).
+
+**Stderr-only invariant**: both the Rich and JSON paths write to
+``sys.stderr``. Progress must never collide with structured result
+output on stdout (CLI consumers pipe stdout through ``jq``).
+
+**Concurrency contract — single-producer per instance**: each logger
+instance is meant to be driven by a single async task or thread.
+Concurrent writes from multiple producers to the same instance would
+interleave NDJSON lines and break line-buffered parsers downstream.
+Operation-level dependency injection (each ``ingest()`` / ``upload()``
+/ ``ingest_events()`` call gets its own logger) makes this the default
+shape; if a future caller wants to fan out across tasks, it must
+construct one logger per task and merge streams externally.
+
+**Terminal-event contract**: callers that opt into the JSON path
+should emit exactly one terminal event per operation, with either
+``kind="success"`` or ``kind="error"`` as the **final** event in the
+stream. Mid-stream non-fatal warnings use ``kind="warning"``;
+``success`` / ``error`` appear ONLY at the end. AI consumers safely
+``wait while kind not in ("success", "error")`` and treat the first
+matching event as terminal. The logger itself does not enforce this —
+entry points (``FileIngestor.ingest``, ``FilesClient.upload``,
+``ResourceClient.ingest_events``) wrap their main body in
+``try/except`` so that even an unhandled exception still emits a
+terminal ``kind="error"`` before propagating.
+"""
+
+from __future__ import annotations
 
 import json
-from typing import Any
+import sys
+from datetime import UTC, datetime
+from typing import Any, Literal
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
 
+OutputFormat = Literal["rich", "json", "none"]
+"""The three render targets for a :class:`VerboseLogger` instance."""
+
+_NDJSON_SCHEMA_VERSION = 1
+"""Schema version field embedded in every NDJSON event.
+
+Bumped only when the wire format adds/removes/renames fields in a way
+that breaks consumers that already shipped against ``v=1``. Consumers
+MUST check ``v`` and refuse to parse unknown values (forward-compat:
+additions inside a major version are allowed; removals are not)."""
+
 
 class VerboseLogger:
-    """Handles verbose output at different levels."""
+    """Emit progress events for long-running SDK operations.
 
-    def __init__(self, level: int = 0, console: Console | None = None):
-        """
-        Initialize logger with verbosity level.
+    The six public methods (:meth:`action`, :meth:`detail`,
+    :meth:`success`, :meth:`warning`, :meth:`error`, :meth:`debug`)
+    are render-format-agnostic — each picks the right path based on
+    ``output_format`` and silently drops the call when the level
+    filter rejects it. See the module docstring for the concurrency
+    and terminal-event contracts.
+    """
+
+    def __init__(
+        self,
+        level: int = 0,
+        console: Console | None = None,
+        *,
+        output_format: OutputFormat = "rich",
+    ):
+        """Initialize a logger.
 
         Args:
-            level: 0=silent, 1=major actions, 2=detailed, 3=debug
-            console: Optional Rich Console instance (default: new Console())
+            level: Rich-path verbosity threshold. ``0`` is silent
+                (matches the ``--progress=none`` and ``-v`` not given
+                case), ``1`` shows actions/success/warning,
+                ``2`` adds details, ``3`` adds debug panels. Ignored
+                when ``output_format="json"`` — the JSON path emits
+                every event regardless of level (downstream consumers
+                filter by ``kind``).
+            console: Optional Rich :class:`Console` instance. When
+                omitted, a stderr-bound console is created. Tests
+                pass a stub here to capture output.
+            output_format: ``"rich"`` for Rich glyphs/colors,
+                ``"json"`` for newline-delimited JSON, ``"none"`` for
+                a NO-OP logger (used by :data:`_NULL_LOGGER`).
         """
         self.level = level
-        self._console = console or Console()
+        self.output_format: OutputFormat = output_format
+        # stderr-bound so progress never lands on stdout. Rich's
+        # auto-detect handles TTY-vs-pipe degradation (no ANSI escapes
+        # leak into a redirected stderr).
+        self._console = console or Console(stderr=True)
 
-    def _should_log(self, min_level: int) -> bool:
-        """Check if current verbosity level should log."""
-        return self.level >= min_level
+    def _should_log_rich(self, min_level: int) -> bool:
+        """True iff this logger should render a Rich event at ``min_level``."""
+        return self.output_format == "rich" and self.level >= min_level
 
-    def action(self, action: str, details: str = "") -> None:
-        """Log major action (level 1+)."""
-        if not self._should_log(1):
+    def _emit_json(
+        self,
+        *,
+        kind: str,
+        stage: str | None,
+        msg: str | None = None,
+        detail: dict[str, Any] | None = None,
+        count: int | None = None,
+        duration_ms: float | None = None,
+    ) -> None:
+        """Serialize one NDJSON event to stderr.
+
+        Writes directly to ``sys.stderr`` (not via Rich) so the line
+        is exactly one ``\\n``-terminated JSON object with no markup
+        injection. ``stage=None`` becomes ``"unknown"`` to keep the
+        field required-and-present for downstream parsers.
+        """
+        event: dict[str, Any] = {
+            "v": _NDJSON_SCHEMA_VERSION,
+            "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.")
+            + f"{datetime.now(UTC).microsecond // 1000:03d}Z",
+            "stage": stage or "unknown",
+            "kind": kind,
+        }
+        if msg:
+            event["msg"] = msg
+        if detail:
+            event["detail"] = detail
+        if count is not None:
+            event["count"] = count
+        if duration_ms is not None:
+            event["duration_ms"] = duration_ms
+        sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
+        sys.stderr.flush()
+
+    def action(self, action: str, details: str = "", *, stage: str | None = None) -> None:
+        """Log a major action — ``kind=action``, level ≥ 1."""
+        if self.output_format == "none":
             return
-
+        if self.output_format == "json":
+            self._emit_json(
+                kind="action",
+                stage=stage,
+                msg=action,
+                detail={"desc": details} if details else None,
+            )
+            return
+        if not self._should_log_rich(1):
+            return
         self._console.print(f"[bold blue]→[/bold blue] {action}", end="")
         if details:
             self._console.print(f" [dim]{details}[/dim]")
         else:
             self._console.print()
 
-    def detail(self, key: str, value: Any) -> None:
-        """Log detailed information (level 2+)."""
-        if not self._should_log(2):
+    def detail(self, key: str, value: Any, *, stage: str | None = None) -> None:
+        """Log a structured detail — ``kind=detail``, level ≥ 2."""
+        if self.output_format == "none":
             return
-
+        if self.output_format == "json":
+            self._emit_json(kind="detail", stage=stage, msg=key, detail={"value": value})
+            return
+        if not self._should_log_rich(2):
+            return
         self._console.print(f"  [cyan]•[/cyan] {key}: [yellow]{value}[/yellow]")
 
-    def debug(self, title: str, data: Any, syntax: str = "json") -> None:
-        """Log debug information (level 3+)."""
-        if not self._should_log(3):
+    def debug(
+        self, title: str, data: Any, syntax: str = "json", *, stage: str | None = None
+    ) -> None:
+        """Log a debug payload — ``kind=debug``, level ≥ 3."""
+        if self.output_format == "none":
             return
-
+        if self.output_format == "json":
+            # Serialize the payload so the JSON line stays a single object.
+            try:
+                serialized = (
+                    data
+                    if isinstance(data, (dict, list, str, int, float, bool, type(None)))
+                    else str(data)
+                )
+            except Exception:  # noqa: BLE001 — defensive: fall back to str on any repr error
+                serialized = str(data)
+            self._emit_json(kind="debug", stage=stage, msg=title, detail={"data": serialized})
+            return
+        if not self._should_log_rich(3):
+            return
         if isinstance(data, (dict, list)):
             data_str = json.dumps(data, indent=2, ensure_ascii=False)
         else:
             data_str = str(data)
-
-        # Truncate if too long
         if len(data_str) > 2000:
             data_str = data_str[:2000] + "\n... (truncated)"
-
         self._console.print(
             Panel(
                 Syntax(data_str, syntax, theme="monokai", word_wrap=True),
@@ -67,20 +207,72 @@ class VerboseLogger:
             )
         )
 
-    def success(self, message: str) -> None:
-        """Log success message (level 1+)."""
-        if not self._should_log(1):
-            return
+    def success(
+        self,
+        message: str,
+        *,
+        stage: str | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        """Log a terminal success event — ``kind=success``, level ≥ 1.
 
+        Per the terminal-event contract (module docstring), callers
+        should emit success **exactly once** as the final event for
+        an operation. Mid-stream OK states use :meth:`action` instead.
+        """
+        if self.output_format == "none":
+            return
+        if self.output_format == "json":
+            self._emit_json(kind="success", stage=stage, msg=message, detail=detail)
+            return
+        if not self._should_log_rich(1):
+            return
         self._console.print(f"[bold green]✓[/bold green] {message}")
 
-    def warning(self, message: str) -> None:
-        """Log warning (level 1+)."""
-        if not self._should_log(1):
-            return
+    def warning(self, message: str, *, stage: str | None = None) -> None:
+        """Log a non-fatal warning — ``kind=warning``, level ≥ 1.
 
+        Mid-stream warnings stay non-terminal (they don't conclude
+        the operation). Use :meth:`error` to signal a terminal failure.
+        """
+        if self.output_format == "none":
+            return
+        if self.output_format == "json":
+            self._emit_json(kind="warning", stage=stage, msg=message)
+            return
+        if not self._should_log_rich(1):
+            return
         self._console.print(f"[bold yellow]⚠[/bold yellow] {message}")
 
-    def error(self, message: str) -> None:
-        """Log error (always shown)."""
+    def error(
+        self,
+        message: str,
+        *,
+        stage: str | None = None,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        """Log a terminal error event — ``kind=error``, always shown.
+
+        Per the terminal-event contract, callers should emit error
+        **exactly once** as the final event when the operation fails.
+        Unlike the other methods, the Rich path renders errors at any
+        level (errors are too important to gate behind ``-v``).
+        """
+        if self.output_format == "none":
+            return
+        if self.output_format == "json":
+            self._emit_json(kind="error", stage=stage, msg=message, detail=detail)
+            return
+        # Rich path: error always renders, regardless of self.level.
         self._console.print(f"[bold red]✗[/bold red] {message}", style="bold red")
+
+
+_NULL_LOGGER: VerboseLogger = VerboseLogger(level=0, output_format="none")
+"""Module-level NO-OP logger.
+
+Entry points that take ``logger: VerboseLogger | None = None`` should
+normalize ``None`` to :data:`_NULL_LOGGER` so call sites can drop the
+``if self.logger:`` guards. The instance is stateless beyond the
+output_format check, so a single shared instance is safe across
+threads / async tasks (every method returns at the ``"none"`` short-
+circuit before touching any state)."""

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -139,12 +139,23 @@ class VerboseLogger:
             event["msg"] = msg
         if detail:
             event["detail"] = detail
-        # ``default=str`` makes the JSON path best-effort: a non-serializable
-        # object in ``detail`` (Path, UUID, custom dataclass, …) is rendered
-        # via ``str()`` instead of crashing the operation we are reporting on.
-        # Progress logging must never raise — the caller has more important
-        # work to do than worry about its observability stream.
-        line = json.dumps(event, ensure_ascii=False, default=str) + "\n"
+        # Serialization is best-effort. ``default=str`` handles common non-
+        # serializable types (Path, UUID, …), but a class with a broken
+        # ``__str__`` or a circular reference can still raise. The outer
+        # try-except guarantees the "progress logging must never raise"
+        # contract — on any serialization failure we emit a minimal
+        # placeholder so the terminal-event invariant still holds.
+        try:
+            line = json.dumps(event, ensure_ascii=False, default=str) + "\n"
+        except Exception:  # noqa: BLE001 — best-effort fallback for any json.dumps error
+            fallback = {
+                "v": _NDJSON_SCHEMA_VERSION,
+                "ts": event["ts"],
+                "stage": event["stage"],
+                "kind": event["kind"],
+                "msg": "<event serialization failed>",
+            }
+            line = json.dumps(fallback) + "\n"
         try:
             sys.stderr.write(line)
             sys.stderr.flush()
@@ -194,16 +205,20 @@ class VerboseLogger:
         if self.output_format == "none":
             return
         if self.output_format == "json":
-            # Serialize non-primitive payloads via str() so the JSON line stays
-            # a single object. A class with a broken ``__str__`` will surface
-            # the exception to the caller — the logger does not silently
-            # swallow it, since hiding a broken debug payload makes the bug
-            # harder to find than a loud error during dev/CI.
-            serialized = (
-                data
-                if isinstance(data, (dict, list, str, int, float, bool, type(None)))
-                else str(data)
-            )
+            # Serialize non-primitive payloads via str() so the JSON line
+            # stays a single object. A class with a broken ``__str__``
+            # would otherwise crash the operation; per the "progress
+            # logging must never raise" contract, fall back to a safe
+            # placeholder that names the type without invoking its
+            # stringification. ``_emit_json`` has its own outer safety
+            # net for json.dumps failures.
+            if isinstance(data, (dict, list, str, int, float, bool, type(None))):
+                serialized: Any = data
+            else:
+                try:
+                    serialized = str(data)
+                except Exception:  # noqa: BLE001 — never crash the caller on a bad __str__
+                    serialized = f"<{type(data).__name__} __str__ raised>"
             self._emit_json(kind="debug", stage=stage, msg=title, detail={"data": serialized})
             return
         if not self._should_log_rich(3):

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -221,7 +221,16 @@ class VerboseLogger:
             return
         if not self._should_log_rich(2):
             return
-        self._safe_rich_print(f"  [cyan]•[/cyan] {key}: [yellow]{value}[/yellow]")
+        # f-string interpolation calls ``value.__format__`` / ``__str__``
+        # BEFORE ``_safe_rich_print`` runs, so a broken stringifier would
+        # crash the caller without ever reaching the OSError guard.
+        # Pre-stringify defensively so the never-raise contract holds for
+        # the detail Rich path the same way it does for debug().
+        try:
+            value_str = str(value)
+        except Exception:  # noqa: BLE001 — never crash the caller on a bad __str__
+            value_str = f"<{type(value).__name__} __str__ raised>"
+        self._safe_rich_print(f"  [cyan]•[/cyan] {key}: [yellow]{value_str}[/yellow]")
 
     def debug(
         self, title: str, data: Any, syntax: str = "json", *, stage: str | None = None

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -125,10 +125,13 @@ class VerboseLogger:
         top-level event shape minimal so future fields don't bloat
         ``v=1``; consumers tolerate unknown ``detail`` keys.
         """
+        # Capture `now` once: two separate ``datetime.now()`` calls would race
+        # across a second boundary and produce an inconsistent ``ts`` field
+        # (seconds from the first call, milliseconds from the second).
+        now = datetime.now(UTC)
         event: dict[str, Any] = {
             "v": _NDJSON_SCHEMA_VERSION,
-            "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.")
-            + f"{datetime.now(UTC).microsecond // 1000:03d}Z",
+            "ts": now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z",
             "stage": stage or "unknown",
             "kind": kind,
         }
@@ -136,7 +139,12 @@ class VerboseLogger:
             event["msg"] = msg
         if detail:
             event["detail"] = detail
-        sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
+        # ``default=str`` makes the JSON path best-effort: a non-serializable
+        # object in ``detail`` (Path, UUID, custom dataclass, …) is rendered
+        # via ``str()`` instead of crashing the operation we are reporting on.
+        # Progress logging must never raise — the caller has more important
+        # work to do than worry about its observability stream.
+        sys.stderr.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
         sys.stderr.flush()
 
     def action(self, action: str, details: str = "", *, stage: str | None = None) -> None:
@@ -270,8 +278,21 @@ _NULL_LOGGER: VerboseLogger = VerboseLogger(level=0, output_format="none")
 """Module-level NO-OP logger.
 
 Entry points that take ``logger: VerboseLogger | None = None`` should
-normalize ``None`` to :data:`_NULL_LOGGER` so call sites can drop the
-``if self.logger:`` guards. The instance is stateless beyond the
-output_format check, so a single shared instance is safe across
-threads / async tasks (every method returns at the ``"none"`` short-
-circuit before touching any state)."""
+normalize ``None`` to :data:`_NULL_LOGGER` via :func:`normalize_logger`
+so call sites can drop the ``if self.logger:`` guards. The instance is
+stateless beyond the output_format check, so a single shared instance
+is safe across threads / async tasks (every method returns at the
+``"none"`` short-circuit before touching any state)."""
+
+
+def normalize_logger(logger: VerboseLogger | None) -> VerboseLogger:
+    """Return ``logger`` when given, else the module-level :data:`_NULL_LOGGER`.
+
+    The recommended way for SDK entry points (``FileIngestor.ingest``,
+    ``FilesClient.upload``, ``ResourceClient.ingest_events``) to accept
+    an optional logger without scattering ``logger or _NULL_LOGGER``
+    expressions across the codebase. Keeping the normalization in one
+    place also means the no-op fallback is documented at the import
+    site rather than at every call site.
+    """
+    return logger if logger is not None else _NULL_LOGGER

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -113,15 +113,17 @@ class VerboseLogger:
         stage: str | None,
         msg: str | None = None,
         detail: dict[str, Any] | None = None,
-        count: int | None = None,
-        duration_ms: float | None = None,
     ) -> None:
         """Serialize one NDJSON event to stderr.
 
         Writes directly to ``sys.stderr`` (not via Rich) so the line
         is exactly one ``\\n``-terminated JSON object with no markup
         injection. ``stage=None`` becomes ``"unknown"`` to keep the
-        field required-and-present for downstream parsers.
+        field required-and-present for downstream parsers. Stage-
+        specific structured fields (counts, durations, file_id, ...)
+        ride in the ``detail`` dict — the schema deliberately keeps the
+        top-level event shape minimal so future fields don't bloat
+        ``v=1``; consumers tolerate unknown ``detail`` keys.
         """
         event: dict[str, Any] = {
             "v": _NDJSON_SCHEMA_VERSION,
@@ -134,10 +136,6 @@ class VerboseLogger:
             event["msg"] = msg
         if detail:
             event["detail"] = detail
-        if count is not None:
-            event["count"] = count
-        if duration_ms is not None:
-            event["duration_ms"] = duration_ms
         sys.stderr.write(json.dumps(event, ensure_ascii=False) + "\n")
         sys.stderr.flush()
 
@@ -179,15 +177,16 @@ class VerboseLogger:
         if self.output_format == "none":
             return
         if self.output_format == "json":
-            # Serialize the payload so the JSON line stays a single object.
-            try:
-                serialized = (
-                    data
-                    if isinstance(data, (dict, list, str, int, float, bool, type(None)))
-                    else str(data)
-                )
-            except Exception:  # noqa: BLE001 — defensive: fall back to str on any repr error
-                serialized = str(data)
+            # Serialize non-primitive payloads via str() so the JSON line stays
+            # a single object. A class with a broken ``__str__`` will surface
+            # the exception to the caller — the logger does not silently
+            # swallow it, since hiding a broken debug payload makes the bug
+            # harder to find than a loud error during dev/CI.
+            serialized = (
+                data
+                if isinstance(data, (dict, list, str, int, float, bool, type(None)))
+                else str(data)
+            )
             self._emit_json(kind="debug", stage=stage, msg=title, detail={"data": serialized})
             return
         if not self._should_log_rich(3):

--- a/src/kagura_memory/logger.py
+++ b/src/kagura_memory/logger.py
@@ -144,8 +144,17 @@ class VerboseLogger:
         # via ``str()`` instead of crashing the operation we are reporting on.
         # Progress logging must never raise — the caller has more important
         # work to do than worry about its observability stream.
-        sys.stderr.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
-        sys.stderr.flush()
+        line = json.dumps(event, ensure_ascii=False, default=str) + "\n"
+        try:
+            sys.stderr.write(line)
+            sys.stderr.flush()
+        except OSError:
+            # Downstream consumer closed stderr early (BrokenPipeError) or
+            # the FD is otherwise unwritable. Swallow — the operation being
+            # logged must not crash because its observability stream went
+            # away. Matches the "progress logging must never raise" contract
+            # in the module docstring.
+            pass
 
     def action(self, action: str, details: str = "", *, stage: str | None = None) -> None:
         """Log a major action — ``kind=action``, level ≥ 1."""

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -14,7 +14,7 @@ from .exceptions import (
     KaguraNotFoundError,
     KaguraQuotaError,
 )
-from .logger import _NULL_LOGGER, VerboseLogger
+from .logger import VerboseLogger, normalize_logger
 from .models import (
     IndexerStatusResponse,
     PaginatedResourceTokensResponse,
@@ -424,7 +424,7 @@ class ResourceClient:
         Returns:
             Batch ingestion result with created/failed counts.
         """
-        log = logger or _NULL_LOGGER
+        log = normalize_logger(logger)
         log.action(
             "Ingesting events batch",
             f"{len(events)} event(s) for resource {resource_id}",

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -14,6 +14,7 @@ from .exceptions import (
     KaguraNotFoundError,
     KaguraQuotaError,
 )
+from .logger import _NULL_LOGGER, VerboseLogger
 from .models import (
     IndexerStatusResponse,
     PaginatedResourceTokensResponse,
@@ -407,6 +408,7 @@ class ResourceClient:
         resource_id: str,
         resource_api_key: str,
         events: list[ResourceEventRequest],
+        logger: VerboseLogger | None = None,
     ) -> ResourceEventBatchResponse:
         """Ingest a batch of resource events (max 100).
 
@@ -414,18 +416,45 @@ class ResourceClient:
             resource_id: Resource identifier.
             resource_api_key: Resource API key (X-Resource-API-Key header).
             events: List of events to ingest (1-100).
+            logger: Optional :class:`VerboseLogger` for progress events.
+                Honors the terminal-event contract — an unhandled
+                exception still emits ``kind=error`` with partial
+                progress in ``detail`` before propagating.
 
         Returns:
             Batch ingestion result with created/failed counts.
         """
-        batch = ResourceEventBatchRequest(events=events)
-        response = await self._request(
-            "POST",
-            f"/api/v1/resources/{resource_id}/events/batch",
-            json=batch.model_dump(exclude_none=True),
-            extra_headers={"X-Resource-API-Key": resource_api_key},
+        log = logger or _NULL_LOGGER
+        log.action(
+            "Ingesting events batch",
+            f"{len(events)} event(s) for resource {resource_id}",
+            stage="ingest_events",
         )
-        return ResourceEventBatchResponse.model_validate(response.json())
+        try:
+            batch = ResourceEventBatchRequest(events=events)
+            response = await self._request(
+                "POST",
+                f"/api/v1/resources/{resource_id}/events/batch",
+                json=batch.model_dump(exclude_none=True),
+                extra_headers={"X-Resource-API-Key": resource_api_key},
+            )
+            result = ResourceEventBatchResponse.model_validate(response.json())
+        except BaseException as e:
+            log.error(
+                f"Batch ingest failed: {e}",
+                stage="complete",
+                detail={"events_attempted": len(events), "resource_id": resource_id},
+            )
+            raise
+        log.success(
+            "Batch ingested",
+            stage="complete",
+            detail={
+                "created": result.created_count,
+                "failed": result.failed_count,
+            },
+        )
+        return result
 
     # -------------------------------------------------------------------
     # Lifecycle

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -56,10 +56,17 @@ def test_output_format_none_explicit_is_also_silent(capsys):
 
 
 def _parse_lines(text: str) -> list[dict]:
-    """Parse newline-delimited JSON; assert each line is valid JSON."""
+    """Parse newline-delimited JSON, skipping non-JSON lines.
+
+    CLI tests that capture stderr may see ``click.ClickException`` output
+    (``Error: ...``) interspersed with our NDJSON events. Skip anything
+    that doesn't look like a JSON object so the test focuses on the
+    progress stream's structural correctness.
+    """
     parsed: list[dict] = []
-    for line in text.strip().splitlines():
-        if not line:
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("{"):
             continue
         parsed.append(json.loads(line))
     return parsed
@@ -118,6 +125,29 @@ def test_ndjson_debug_serializes_non_primitive_via_str(capsys):
     events = _parse_lines(capsys.readouterr().err)
     assert events[-1]["kind"] == "debug"
     assert "_CustomPayload" in events[-1]["detail"]["data"]
+
+
+def test_ndjson_emits_placeholder_when_json_dumps_fails(capsys):
+    """``json.dumps`` failures (broken __str__, circular refs) trigger the fallback.
+
+    ``default=str`` only handles non-serializable types whose ``str()`` is
+    well-behaved. A class whose ``__str__`` raises makes ``default=str``
+    itself raise during encoding — the outer ``try/except`` should catch
+    it and emit a minimal placeholder event so the terminal-event
+    invariant still holds.
+    """
+
+    class _BadObject:
+        def __str__(self) -> str:
+            raise RuntimeError("nope")
+
+    logger = VerboseLogger(output_format="json")
+    logger.detail("key", _BadObject(), stage="x")
+    events = _parse_lines(capsys.readouterr().err)
+    assert len(events) == 1
+    assert events[0]["msg"] == "<event serialization failed>"
+    assert events[0]["v"] == 1
+    assert events[0]["kind"] == "detail"
 
 
 def test_ndjson_debug_swallows_broken_str_payload(capsys):
@@ -312,6 +342,108 @@ async def test_files_upload_emits_terminal_error_event_on_validator_failure(caps
     assert events, "validator failure must still emit a terminal event"
     assert events[-1]["kind"] == "error"
     await client.close()
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.ResourceClient")
+def test_resource_import_emits_single_terminal_success(mock_rc_cls, mock_config):
+    """`kagura resource import --progress=json` emits exactly ONE terminal event.
+
+    Even when the CLI loops over multiple batches internally, the user-facing
+    operation is one ``kagura resource import`` invocation and must emit one
+    terminal event total (per the AI-consumer "wait for first success/error"
+    contract). Verifies the round-3 fix that suppressed per-batch terminal
+    events from the SDK and added a single CLI-level closing event.
+    """
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_rc = AsyncMock()
+    # 250 events at batch size 100 → 3 batches, 3 ingest_events calls.
+    mock_rc.ingest_events.return_value = MagicMock(created_count=100, failed_count=0, errors=[])
+    mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
+    mock_rc.__aexit__ = AsyncMock(return_value=None)
+    mock_rc_cls.from_mcp_url.return_value = mock_rc
+
+    jsonl = "\n".join(f'{{"name": "row{i}"}}' for i in range(250))
+    # Click 8.2+ separates stdout / stderr on CliRunner.invoke by default
+    # so we can parse the NDJSON progress stream independently of the
+    # stdout result JSON via result.stderr.
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "resource",
+            "import",
+            "-r",
+            "products",
+            "-k",
+            "TOKEN",
+            "--format",
+            "jsonl",
+            "--progress",
+            "json",
+        ],
+        input=jsonl,
+    )
+    assert result.exit_code == 0, result.output
+
+    events = _parse_lines(result.stderr)
+    # 1 import_start + 3 import_batch + 1 complete (success) = 5 events.
+    terminal = [e for e in events if e["kind"] in ("success", "error")]
+    assert len(terminal) == 1, f"expected exactly 1 terminal event, got {len(terminal)}: {terminal}"
+    assert terminal[0]["kind"] == "success"
+    assert terminal[0]["stage"] == "complete"
+    assert terminal[0]["detail"]["total"] == 250
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.ResourceClient")
+def test_resource_import_emits_terminal_error_on_batch_failure(mock_rc_cls, mock_config):
+    """A mid-loop SDK failure emits exactly ONE terminal kind=error with partial state.
+
+    Locks the round-3 CLI-level ``try/except BaseException`` wrapper around
+    the batch loop so that even when ``ingest_events`` blows up, the user
+    sees a final terminal event reporting how many events were already
+    created/failed before the crash.
+    """
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+
+    mock_rc = AsyncMock()
+    # First batch succeeds (100 created), second batch raises mid-loop.
+    mock_rc.ingest_events.side_effect = [
+        MagicMock(created_count=100, failed_count=0, errors=[]),
+        RuntimeError("simulated server crash"),
+    ]
+    mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
+    mock_rc.__aexit__ = AsyncMock(return_value=None)
+    mock_rc_cls.from_mcp_url.return_value = mock_rc
+
+    jsonl = "\n".join(f'{{"name": "row{i}"}}' for i in range(200))
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "resource",
+            "import",
+            "-r",
+            "products",
+            "-k",
+            "TOKEN",
+            "--format",
+            "jsonl",
+            "--progress",
+            "json",
+        ],
+        input=jsonl,
+    )
+    assert result.exit_code != 0
+
+    events = _parse_lines(result.stderr)
+    terminal = [e for e in events if e["kind"] in ("success", "error")]
+    assert len(terminal) == 1
+    assert terminal[0]["kind"] == "error"
+    assert terminal[0]["detail"]["created_so_far"] == 100
+    assert terminal[0]["detail"]["total_events"] == 200
 
 
 def test_logger_swallows_broken_stderr_pipe(capsys, monkeypatch):

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -267,6 +267,57 @@ async def test_files_upload_emits_terminal_error_event_on_exception(capsys):
 
 
 @pytest.mark.asyncio
+async def test_files_upload_emits_terminal_error_event_on_validator_failure(capsys):
+    """Pre-flight validators (UUID check, source prep) still get terminal kind=error.
+
+    The fix for Copilot's review pulled ``_validate_context_id`` /
+    ``_prepare_source`` / ``_resolve_content_type`` inside the
+    ``try/except BaseException`` so a validator failure also emits a
+    terminal event before the exception propagates — matching the
+    "operation logging never leaves the AI consumer hanging" contract.
+    """
+    from kagura_memory import FilesClient
+
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    logger = VerboseLogger(output_format="json")
+    with pytest.raises(ValueError, match="context_id must be a UUID"):
+        await client.upload(
+            context_id="not-a-uuid",
+            source=b"hello",
+            filename="x.txt",
+            logger=logger,
+        )
+
+    events = _parse_lines(capsys.readouterr().err)
+    assert events, "validator failure must still emit a terminal event"
+    assert events[-1]["kind"] == "error"
+    await client.close()
+
+
+def test_logger_swallows_broken_stderr_pipe(capsys, monkeypatch):
+    """A BrokenPipeError on stderr must not crash the operation being logged.
+
+    Simulates the consumer-pipe-closed-early case (``kagura ingest |
+    head -n 1``) where stderr writes start raising mid-stream. The
+    ``_emit_json`` path catches OSError and drops the line silently —
+    progress logging must never raise per the module docstring.
+    """
+    import sys
+
+    class _BrokenStream:
+        def write(self, data: str) -> int:
+            raise BrokenPipeError("downstream consumer gone")
+
+        def flush(self) -> None:
+            raise BrokenPipeError("downstream consumer gone")
+
+    logger = VerboseLogger(output_format="json")
+    monkeypatch.setattr(sys, "stderr", _BrokenStream())
+    # The call must not raise even though every write raises.
+    logger.action("orphan", stage="x")
+
+
+@pytest.mark.asyncio
 async def test_ingestor_emits_terminal_error_event_on_unhandled_exception(capsys):
     """FileIngestor.ingest's try/except wraps the post-fetch body for terminal error.
 

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -446,6 +446,47 @@ def test_resource_import_emits_terminal_error_on_batch_failure(mock_rc_cls, mock
     assert terminal[0]["detail"]["total_events"] == 200
 
 
+def test_rich_path_swallows_broken_console_print():
+    """A Rich-path ``Console.print`` raising OSError must not crash the caller.
+
+    Locks the ``_safe_rich_print`` wrapper that catches BrokenPipeError /
+    OSError so ``kagura ingest -v | head -n 1`` does not crash the
+    underlying SDK operation when the consumer closes the pipe early.
+    """
+
+    class _BrokenConsole:
+        def print(self, *_args: object, **_kwargs: object) -> None:
+            raise BrokenPipeError("downstream consumer gone")
+
+    logger = VerboseLogger(level=2, console=_BrokenConsole(), output_format="rich")  # type: ignore[arg-type]
+    # Each method exercises the wrapper on a different render path.
+    logger.action("a")
+    logger.detail("k", "v")
+    logger.success("ok")
+    logger.warning("warn")
+    logger.error("boom")
+    logger.debug("dbg", {"x": 1})
+
+
+def test_rich_debug_swallows_broken_str_payload():
+    """The Rich debug path now falls back safely when ``str(data)`` raises.
+
+    Mirrors the JSON path's ``test_ndjson_debug_swallows_broken_str_payload``
+    so the "never raise" contract holds on both render targets — Rich
+    used to call ``str()`` eagerly without a guard.
+    """
+
+    class _BadStr:
+        def __str__(self) -> str:
+            raise RuntimeError("broken __str__")
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True)
+    logger = VerboseLogger(level=3, console=console, output_format="rich")
+    logger.debug("LLM response", _BadStr())  # must not raise
+    assert "serialization failed" in buf.getvalue()
+
+
 def test_logger_swallows_broken_stderr_pipe(capsys, monkeypatch):
     """A BrokenPipeError on stderr must not crash the operation being logged.
 

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -468,6 +468,28 @@ def test_rich_path_swallows_broken_console_print():
     logger.debug("dbg", {"x": 1})
 
 
+def test_rich_detail_swallows_broken_str_value():
+    """``detail()`` Rich path defensively stringifies ``value`` before f-string.
+
+    Without the pre-stringification, ``f"...{value}..."`` would call
+    ``value.__format__`` / ``__str__`` BEFORE ``_safe_rich_print``'s
+    OSError guard could ever run — so a broken ``__str__`` crashes the
+    caller. Locks the never-raise contract for ``detail()`` on the Rich
+    path, matching ``debug()``'s behavior.
+    """
+
+    class _BadStr:
+        def __str__(self) -> str:
+            raise RuntimeError("broken __str__")
+
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True)
+    logger = VerboseLogger(level=2, console=console, output_format="rich")
+    logger.detail("key", _BadStr())  # must not raise
+    assert "_BadStr" in buf.getvalue()
+    assert "raised" in buf.getvalue()
+
+
 def test_rich_debug_swallows_broken_str_payload():
     """The Rich debug path now falls back safely when ``str(data)`` raises.
 

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -100,6 +100,27 @@ def test_ndjson_unknown_stage_when_omitted(capsys):
     assert events[0]["stage"] == "unknown"
 
 
+def test_ndjson_debug_serializes_non_primitive_safely(capsys):
+    """debug() with a non-primitive payload falls back to str() without raising.
+
+    Covers the defensive ``except Exception`` branch around the isinstance
+    fallback — a payload whose ``__str__`` is well-behaved (the common case
+    when an SDK call passes an arbitrary object) still produces a valid
+    NDJSON line.
+    """
+
+    class _CustomPayload:
+        def __repr__(self) -> str:
+            return "_CustomPayload(<x>)"
+
+    logger = VerboseLogger(output_format="json")
+    logger.debug("LLM response", _CustomPayload(), stage="summarize")
+    events = _parse_lines(capsys.readouterr().err)
+    assert events[-1]["kind"] == "debug"
+    # The non-primitive is stringified, not dropped.
+    assert "_CustomPayload" in events[-1]["detail"]["data"]
+
+
 def test_ndjson_level_is_ignored(capsys):
     """JSON path emits every event regardless of `level` — consumers filter."""
     logger = VerboseLogger(level=0, output_format="json")
@@ -243,6 +264,44 @@ async def test_files_upload_emits_terminal_error_event_on_exception(capsys):
 # ---------------------------------------------------------------------------
 # Library default is silent (no logger= → no progress emission)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingestor_emits_terminal_error_event_on_unhandled_exception(capsys):
+    """FileIngestor.ingest's try/except wraps the post-fetch body for terminal error.
+
+    If ``_ingest_fetched`` raises (e.g. KaguraLLMError leaks through the
+    inner handlers), ``ingest`` still emits a ``kind=error`` final event
+    on the JSON path before propagating. Mirrors the FilesClient.upload
+    contract verified above.
+    """
+    from kagura_memory.ingest.ingestor import FileIngestor
+
+    ingestor = MagicMock(spec=FileIngestor)
+    # Stub _fetch to succeed so we reach the wrapped _ingest_fetched call.
+    fetched = MagicMock()
+    fetched.body = b"hello"
+    fetched.source_uri = "file:///tmp/x.txt"
+    fetched.source_type = "file"
+
+    ingestor._fetch = AsyncMock(return_value=fetched)
+    ingestor._ingest_fetched = AsyncMock(side_effect=RuntimeError("simulated llm crash"))
+    # Re-use the real method bound to the mock spec.
+    ingestor.ingest = FileIngestor.ingest.__get__(ingestor)
+
+    logger = VerboseLogger(output_format="json")
+    with pytest.raises(RuntimeError, match="simulated llm crash"):
+        await ingestor.ingest(
+            "file:///tmp/x.txt",
+            context_id="00000000-0000-0000-0000-000000000001",
+            logger=logger,
+        )
+
+    events = _parse_lines(capsys.readouterr().err)
+    assert events, "expected at least one NDJSON event before propagation"
+    terminal = events[-1]
+    assert terminal["kind"] == "error", f"terminal must be kind=error; got {terminal}"
+    assert terminal["stage"] == "complete"
 
 
 @pytest.mark.asyncio

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -1,0 +1,297 @@
+"""Tests for the #108 additions to VerboseLogger and the CLI flag plumbing.
+
+Covers:
+- ``output_format`` switch (rich / json / none) and the ``_NULL_LOGGER`` no-op.
+- NDJSON schema invariants (``v``, ``ts``, ``stage``, ``kind``).
+- Terminal-event contract — entry points emit exactly one ``kind=success`` or
+  ``kind=error`` final event even when an unhandled exception propagates.
+- CLI ``-v`` / ``--progress`` precedence table (the 8 cells from issue #108).
+- ``--help`` text no longer says ``(Phase 2)`` for ``--verbose`` / ``--deep``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from rich.console import Console
+
+from kagura_memory.cli import _resolve_progress_logger, main
+from kagura_memory.logger import _NULL_LOGGER, VerboseLogger
+
+# ---------------------------------------------------------------------------
+# _NULL_LOGGER + output_format=none
+# ---------------------------------------------------------------------------
+
+
+def test_null_logger_is_silent(capsys):
+    """Every method on _NULL_LOGGER is a no-op (no stdout/stderr writes)."""
+    _NULL_LOGGER.action("act", "details", stage="x")
+    _NULL_LOGGER.detail("k", "v", stage="x")
+    _NULL_LOGGER.success("ok", stage="x")
+    _NULL_LOGGER.warning("warn", stage="x")
+    _NULL_LOGGER.error("boom", stage="x")
+    _NULL_LOGGER.debug("dbg", {"a": 1}, stage="x")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_output_format_none_explicit_is_also_silent(capsys):
+    """A regular VerboseLogger with output_format='none' is also silent."""
+    logger = VerboseLogger(level=3, output_format="none")
+    logger.action("a", "b")
+    logger.error("e")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+# ---------------------------------------------------------------------------
+# NDJSON schema invariants
+# ---------------------------------------------------------------------------
+
+
+def _parse_lines(text: str) -> list[dict]:
+    """Parse newline-delimited JSON; assert each line is valid JSON."""
+    parsed: list[dict] = []
+    for line in text.strip().splitlines():
+        if not line:
+            continue
+        parsed.append(json.loads(line))
+    return parsed
+
+
+def test_ndjson_action_emits_required_fields(capsys):
+    logger = VerboseLogger(output_format="json")
+    logger.action("Fetching", "url=https://example.com", stage="fetch")
+    events = _parse_lines(capsys.readouterr().err)
+    assert len(events) == 1
+    e = events[0]
+    assert e["v"] == 1
+    assert "ts" in e and e["ts"].endswith("Z")
+    assert e["stage"] == "fetch"
+    assert e["kind"] == "action"
+    assert e["msg"] == "Fetching"
+    assert e["detail"] == {"desc": "url=https://example.com"}
+
+
+def test_ndjson_kind_is_closed_enum(capsys):
+    logger = VerboseLogger(output_format="json")
+    logger.action("a", stage="s")
+    logger.detail("k", 1, stage="s")
+    logger.warning("w", stage="s")
+    logger.success("ok", stage="s")
+    logger.error("err", stage="s")
+    logger.debug("d", {"x": 1}, stage="s")
+    events = _parse_lines(capsys.readouterr().err)
+    kinds = {e["kind"] for e in events}
+    assert kinds == {"action", "detail", "warning", "success", "error", "debug"}
+
+
+def test_ndjson_unknown_stage_when_omitted(capsys):
+    """stage=None at the call site → ``"unknown"`` on the wire, per spec."""
+    logger = VerboseLogger(output_format="json")
+    logger.action("orphan event")
+    events = _parse_lines(capsys.readouterr().err)
+    assert events[0]["stage"] == "unknown"
+
+
+def test_ndjson_level_is_ignored(capsys):
+    """JSON path emits every event regardless of `level` — consumers filter."""
+    logger = VerboseLogger(level=0, output_format="json")
+    logger.detail("k", 1, stage="s")  # would be silenced at level<2 on Rich path
+    logger.debug("d", {"x": 1}, stage="s")  # likewise level<3
+    events = _parse_lines(capsys.readouterr().err)
+    assert {e["kind"] for e in events} == {"detail", "debug"}
+
+
+# ---------------------------------------------------------------------------
+# Rich-path level filtering
+# ---------------------------------------------------------------------------
+
+
+def _rich_logger(level: int) -> tuple[VerboseLogger, io.StringIO]:
+    """Build a Rich-path logger whose Console writes into a StringIO buffer."""
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, no_color=True)
+    return VerboseLogger(level=level, console=console, output_format="rich"), buf
+
+
+def test_rich_level_1_emits_action_silences_detail():
+    logger, buf = _rich_logger(level=1)
+    logger.action("Doing thing")
+    logger.detail("key", "value")
+    out = buf.getvalue()
+    assert "Doing thing" in out
+    assert "key" not in out  # detail filtered at level 1
+
+
+def test_rich_level_2_emits_detail():
+    logger, buf = _rich_logger(level=2)
+    logger.detail("key", "value")
+    assert "key" in buf.getvalue()
+
+
+def test_rich_error_renders_at_level_0():
+    """Errors render regardless of level — too important to gate behind -v."""
+    logger, buf = _rich_logger(level=0)
+    logger.error("boom")
+    assert "boom" in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# CLI flag precedence (the 8-cell table from issue #108)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "verbose, progress, expect_logger, expect_format, expect_level",
+    [
+        # (verbose count, --progress, returns a logger?, output_format, level)
+        pytest.param(0, None, False, None, None, id="no-flags-silent"),
+        pytest.param(1, None, True, "rich", 1, id="-v-default-rich"),
+        pytest.param(2, None, True, "rich", 2, id="-vv-rich-level-2"),
+        pytest.param(0, "rich", True, "rich", 1, id="progress-rich-default-level-1"),
+        pytest.param(2, "rich", True, "rich", 2, id="-vv-progress-rich-level-2"),
+        pytest.param(0, "json", True, "json", 1, id="progress-json-no-verbose"),
+        pytest.param(2, "json", True, "json", 2, id="-vv-progress-json-level-ignored"),
+        pytest.param(1, "none", False, None, None, id="-v-progress-none-silent-wins"),
+    ],
+)
+def test_cli_progress_precedence_8_cells(
+    verbose, progress, expect_logger, expect_format, expect_level
+):
+    result = _resolve_progress_logger(verbose, progress)
+    if not expect_logger:
+        assert result is None
+        return
+    assert result is not None
+    assert result.output_format == expect_format
+    assert result.level == expect_level
+
+
+# ---------------------------------------------------------------------------
+# --help no longer says (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def test_process_help_drops_phase2_for_verbose_and_deep():
+    """Both --verbose and --deep have shipped — help text was stale."""
+    result = CliRunner().invoke(main, ["process", "--help"])
+    assert result.exit_code == 0
+    assert "(Phase 2)" not in result.output, (
+        f"Stale '(Phase 2)' marker still in `kagura process --help`:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [["ingest", "--help"], ["resource", "import", "--help"], ["files", "upload", "--help"]],
+)
+def test_progress_flag_documented_in_help(command):
+    """--progress is offered with the rich/json/none choices and a hint."""
+    result = CliRunner().invoke(main, command)
+    assert result.exit_code == 0, result.output
+    assert "--progress" in result.output
+    assert "json" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Terminal-event contract on unhandled exception (FilesClient.upload smoke)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_files_upload_emits_terminal_error_event_on_exception(capsys):
+    """An unexpected exception inside upload() still emits ``kind=error`` last.
+
+    Drives :meth:`FilesClient.upload` through ``--progress=json`` (via the
+    in-process logger) with a mocked transport that explodes during reserve.
+    The terminal-event contract requires the stderr stream to end with a
+    ``kind=error`` event before the exception propagates to the caller.
+    """
+    from kagura_memory import FilesClient
+
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    logger = VerboseLogger(output_format="json")
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.side_effect = RuntimeError("simulated transport failure")
+        with pytest.raises(RuntimeError, match="simulated transport"):
+            await client.upload(
+                context_id="00000000-0000-0000-0000-000000000001",
+                source=b"hello",
+                filename="x.txt",
+                logger=logger,
+            )
+
+    events = _parse_lines(capsys.readouterr().err)
+    assert events, "expected at least one NDJSON event before propagation"
+    terminal = events[-1]
+    assert terminal["kind"] == "error", (
+        f"terminal event must be kind=error; got {terminal['kind']}: {terminal}"
+    )
+    # Partial-state contract — recovering AI consumer can act on this.
+    assert "detail" in terminal and "uploaded" in terminal["detail"]
+    await client.close()
+
+
+# ---------------------------------------------------------------------------
+# Library default is silent (no logger= → no progress emission)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_library_default_is_silent(capsys):
+    """FilesClient.upload() without `logger=` produces zero stderr output."""
+    from kagura_memory import FilesClient
+
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    reserve_resp = MagicMock()
+    reserve_resp.status_code = 201
+    reserve_resp.json.return_value = {
+        "file_id": "10000000-0000-0000-0000-000000000002",
+        "upload_url": "https://r2.example.com/k",
+        "expires_at": "2026-05-11T00:05:00Z",
+    }
+    reserve_resp.raise_for_status = MagicMock()
+    reserve_resp.headers = {}
+    confirm_resp = MagicMock()
+    confirm_resp.status_code = 200
+    confirm_resp.json.return_value = {
+        "id": "10000000-0000-0000-0000-000000000002",
+        "workspace_id": "00000000-0000-0000-0000-000000000001",
+        "filename": "x.txt",
+        "content_type": "text/plain",
+        "size_bytes": 5,
+        "sha256": "a" * 64,
+        "status": "uploaded",
+        "created_at": "2026-05-11T00:00:00Z",
+        "uploaded_at": "2026-05-11T00:00:01Z",
+    }
+    confirm_resp.raise_for_status = MagicMock()
+    confirm_resp.headers = {}
+    put_resp = MagicMock()
+    put_resp.status_code = 200
+    put_resp.raise_for_status = MagicMock()
+    put_resp.headers = {}
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+        await client.upload(
+            context_id="00000000-0000-0000-0000-000000000001",
+            source=b"hello",
+            filename="x.txt",
+        )
+
+    # No logger= → no stderr emission.
+    assert capsys.readouterr().err == ""
+    await client.close()

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -100,13 +100,13 @@ def test_ndjson_unknown_stage_when_omitted(capsys):
     assert events[0]["stage"] == "unknown"
 
 
-def test_ndjson_debug_serializes_non_primitive_safely(capsys):
-    """debug() with a non-primitive payload falls back to str() without raising.
+def test_ndjson_debug_serializes_non_primitive_via_str(capsys):
+    """debug() coerces non-primitive payloads through str() into the NDJSON line.
 
-    Covers the defensive ``except Exception`` branch around the isinstance
-    fallback — a payload whose ``__str__`` is well-behaved (the common case
-    when an SDK call passes an arbitrary object) still produces a valid
-    NDJSON line.
+    The well-behaved branch: a custom class with a normal ``__str__`` /
+    ``__repr__`` is rendered into ``detail.data`` rather than dropped.
+    The broken-``__str__`` branch is exercised by
+    ``test_ndjson_debug_swallows_broken_str_payload`` below.
     """
 
     class _CustomPayload:
@@ -117,8 +117,28 @@ def test_ndjson_debug_serializes_non_primitive_safely(capsys):
     logger.debug("LLM response", _CustomPayload(), stage="summarize")
     events = _parse_lines(capsys.readouterr().err)
     assert events[-1]["kind"] == "debug"
-    # The non-primitive is stringified, not dropped.
     assert "_CustomPayload" in events[-1]["detail"]["data"]
+
+
+def test_ndjson_debug_swallows_broken_str_payload(capsys):
+    """A payload whose ``__str__`` raises must not crash the operation.
+
+    Locks the "progress logging must never raise" contract for the
+    debug-JSON path: when ``str(data)`` itself fails, debug() emits a
+    safe placeholder naming the type instead of propagating.
+    """
+
+    class _BadStr:
+        def __str__(self) -> str:
+            raise RuntimeError("broken __str__")
+
+    logger = VerboseLogger(output_format="json")
+    # The call must not raise even though str(_BadStr()) does.
+    logger.debug("LLM response", _BadStr(), stage="summarize")
+    events = _parse_lines(capsys.readouterr().err)
+    assert events[-1]["kind"] == "debug"
+    assert "_BadStr" in events[-1]["detail"]["data"]
+    assert "raised" in events[-1]["detail"]["data"]
 
 
 def test_ndjson_level_is_ignored(capsys):


### PR DESCRIPTION
## Summary

Adds `--verbose / -v` and `--progress {rich,json,none}` to the three long-running CLI commands (`kagura ingest`, `kagura resource import`, `kagura files upload`) so:

- **Human operators** no longer face silent multi-minute hangs (Rich glyphs on stderr).
- **AI agents / scripts** can consume newline-delimited JSON progress events on stderr (`jq -c '.stage' events.jsonl` works) while structured results stay on stdout.
- **Library callers** keep silent defaults — only opt-in via `logger=` produces output.

Closes #108.

## Architecture

Three commits, one logical unit:

| Commit | Scope |
|---|---|
| `2d2ceaa` refactor(logger) | `Console(stderr=True)` + `output_format` dimension + `_NULL_LOGGER` no-op + KaguraAgent guard removal |
| `907488d` feat(sdk) | 3 entry points gain `logger=` + try/except terminal-event guarantee |
| `762ddf4` feat(cli) | `-v` / `--progress` flags + 8-cell precedence helper + `(Phase 2)` cleanup + tests |

## NDJSON event schema (v1)

Every JSON event is one line on stderr, with required fields `v=1`, `ts` (UTC ISO-8601 ms), `stage`, `kind`:

```json
{"v":1,"ts":"2026-05-14T12:00:01.234Z","stage":"fetch","kind":"action","msg":"Fetching","detail":{"desc":"url=file://..."}}
{"v":1,"ts":"2026-05-14T12:00:30.000Z","stage":"complete","kind":"success","detail":{"overview_id":"...","section_count":12}}
```

- `kind` is a closed enum: `action | detail | success | warning | error | debug`.
- `stage` is non-exhaustive (consumers tolerate `"unknown"`).
- **Terminal-event contract**: exactly one `kind in (success, error)` as the final event, including the unhandled-exception path. Verified by `test_files_upload_emits_terminal_error_event_on_exception`.

## Flag precedence (canonical 8-cell table)

| `-v` count | `--progress` | Result |
|---|---|---|
| 0 | (omitted) | silent (no logger) |
| 1+ | (omitted) | rich, level = count |
| 0 | `rich` | rich, level = 1 |
| 1+ | `rich` | rich, level = count |
| 0 | `json` | json, all kinds |
| 1+ | `json` | json, all kinds (`-v` ignored) |
| any | `none` | silent (explicit silence wins) |

All 8 cells covered by `test_cli_progress_precedence_8_cells`.

## Gate1 (DX Lead) — 5 AC additions, all implemented

1. ✅ **Terminal-event guarantee on unhandled exception**: `FileIngestor.ingest`, `FilesClient.upload`, `ResourceClient.ingest_events` wrap their body in `try/except BaseException`, emit `kind=error` with partial state in `detail`, then re-raise. Test: `test_files_upload_emits_terminal_error_event_on_exception`.
2. ✅ **`-v` level filtering implemented**: `VerboseLogger.level` filters Rich-path `detail` at <2 and `debug` at <3. JSON path emits all kinds (downstream filters). Tests: `test_rich_level_1_emits_action_silences_detail`, `test_rich_level_2_emits_detail`.
3. ✅ **CLI help docs for `--progress`**: every command's `--help` shows the choices + a guidance line. Test: `test_progress_flag_documented_in_help` (parametrized over 3 commands).
4. ✅ **Rich non-TTY auto-degrade**: handled by Rich's `Console(stderr=True)` auto-detect; tests use `force_terminal=False, no_color=True`.
5. ✅ **`_NULL_LOGGER` is the `KaguraAgent.__init__` default**: `self.logger: VerboseLogger = _NULL_LOGGER` (was `None`). All ~15 `if self.logger:` guards in agent.py removed.

## Test plan

- [x] `uv run pytest --ignore=tests/eval` → **655 passed**, 1 skipped (+25 new tests, no regressions)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format src/ tests/` clean
- [x] `uv run pyright src/` → 0 errors
- [x] `kagura ingest --progress=json <path> 2>events.jsonl` → valid NDJSON parseable by `jq -c '.v,.stage,.kind'`
- [x] `kagura process --help` no longer says `(Phase 2)` for `--verbose` or `--deep`
- [x] Library default: `await ingestor.ingest(...)` without `logger=` produces zero stderr output
- [x] Terminal-event contract verified on the exception path (FilesClient.upload smoke)
- [x] 8-cell precedence verified (parametrized)

## Out of scope (follow-ups)

- Stage-specific `detail` field documentation in `docs/ndjson-events.md` — current event shapes are correct, but a per-stage field reference would help consumers.
- Verbose for short MCP-hop commands (`remember`, `recall`, etc.) — they complete in <1s; progress would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
