### PR TITLE
fix(cli/files): pair workspace_id with credential source

### DIFF
--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Literal
 
 from .auth.credentials import KaguraOAuth, get_shared_state
 from .config import load_config
@@ -31,21 +32,43 @@ from .exceptions import KaguraAuthError
 
 _DEFAULT_MCP_URL = "https://memory.kagura-ai.com/mcp"
 
+# Which precedence branch produced a ``_StaticAuth``. CLI-layer code uses
+# this to resolve ``workspace_id`` from the same source as ``api_key`` —
+# api_key and workspace_id form an inseparable pair (an api_key is
+# provisioned for one specific workspace), so cross-source mixing is the
+# class of bug we are preventing (see issue #115).
+_StaticSource = Literal["explicit", "env", "config"]
+
 
 @dataclass
 class _StaticAuth:
-    """Long-lived API key resolution result."""
+    """Long-lived API key resolution result.
+
+    ``source`` records which branch of :func:`_resolve_auth`'s precedence
+    chain produced this result. The CLI layer reads it to pick the
+    matching ``workspace_id`` source (e.g. ``source="config"`` ⇒
+    ``workspace_id`` must come from the same ``.kagura.json``).
+    """
 
     api_key: str
     mcp_url: str
+    source: _StaticSource
 
 
 @dataclass
 class _OAuthAuth:
-    """OAuth credentials.json resolution result."""
+    """OAuth credentials.json resolution result.
+
+    ``workspace_id`` is a snapshot from the OAuth profile at resolution
+    time (i.e. what ``kagura auth login`` last stored). It is the
+    workspace bound to this api_key/token pair — the CLI layer uses it
+    directly so it cannot accidentally mix with an api_key from a
+    different source (issue #115).
+    """
 
     oauth: KaguraOAuth
     mcp_url: str
+    workspace_id: str | None
 
 
 def _resolve_auth(
@@ -64,7 +87,7 @@ def _resolve_auth(
     # `Authorization: Bearer ` would always 401 and is never what the caller
     # intended; fall through to the env / OAuth / .kagura.json chain instead.
     if api_key is not None and api_key.strip():
-        return _StaticAuth(api_key=api_key, mcp_url=mcp_url or _DEFAULT_MCP_URL)
+        return _StaticAuth(api_key=api_key, mcp_url=mcp_url or _DEFAULT_MCP_URL, source="explicit")
 
     # 2. KAGURA_API_KEY env var (highest auto-resolution priority).
     # Strip-check mirrors the explicit-arg path above: a whitespace-only
@@ -74,6 +97,7 @@ def _resolve_auth(
         return _StaticAuth(
             api_key=env_key,
             mcp_url=mcp_url or os.getenv("KAGURA_MCP_URL") or _DEFAULT_MCP_URL,
+            source="env",
         )
 
     # 3. OAuth profile from credentials.json: explicit > KAGURA_PROFILE > default.
@@ -83,6 +107,7 @@ def _resolve_auth(
         return _OAuthAuth(
             oauth=KaguraOAuth(state),
             mcp_url=mcp_url or state.credentials.mcp_url,
+            workspace_id=state.credentials.workspace_id,
         )
     if target_profile:
         # An explicit profile name (via arg or KAGURA_PROFILE env) was
@@ -106,6 +131,7 @@ def _resolve_auth(
         return _StaticAuth(
             api_key=cfg_key,
             mcp_url=mcp_url or cfg.get("mcp_url") or _DEFAULT_MCP_URL,
+            source="config",
         )
 
     raise KaguraAuthError(

--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -39,6 +39,24 @@ _DEFAULT_MCP_URL = "https://memory.kagura-ai.com/mcp"
 # class of bug we are preventing (see issue #115).
 _StaticSource = Literal["explicit", "env", "config"]
 
+# Superset of :data:`_StaticSource` that also covers the ``_OAuthAuth``
+# branch. Used by client code (e.g. :class:`FilesClient`) to remember
+# which branch built the client, so a 403 can surface an actionable
+# "credential source X expects workspace Y" hint.
+_AuthSource = Literal["explicit", "env", "config", "oauth"]
+
+# Human-readable label for each credential source — single source of
+# truth shared by the CLI's `_resolve_workspace_from_source` error
+# messages and the SDK's 403 hint formatter. Keeping one mapping
+# prevents the two surfaces from drifting and surfacing inconsistent
+# names for the same source ("KAGURA_API_KEY env" vs "env variable").
+_SOURCE_LABEL: dict[_AuthSource, str] = {
+    "explicit": "explicit api_key argument",
+    "env": "KAGURA_API_KEY env",
+    "config": ".kagura.json",
+    "oauth": "OAuth profile (~/.kagura/credentials.json)",
+}
+
 
 @dataclass
 class _StaticAuth:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1611,21 +1611,6 @@ def _resolve_workspace_from_source(
     )
 
 
-def _build_files_client_from_auth(auth: _StaticAuth | _OAuthAuth) -> FilesClient:
-    """Construct a :class:`FilesClient` from a pre-resolved auth result.
-
-    Mirrors the construction logic of :meth:`FilesClient.from_mcp_url`
-    but takes an already-resolved auth (so the CLI can resolve once and
-    derive both ``api_key`` and ``workspace_id`` from the same source).
-    """
-    from ._http import base_url_from_mcp
-
-    base_url = base_url_from_mcp(auth.mcp_url.rstrip("/"))
-    if isinstance(auth, _StaticAuth):
-        return FilesClient(api_key=auth.api_key, base_url=base_url)
-    return FilesClient(base_url=base_url, _oauth=auth.oauth)
-
-
 def _resolve_files_auth(config: dict[str, Any]) -> _StaticAuth | _OAuthAuth:
     """Resolve credentials for the Files CLI with accurate source tagging.
 
@@ -1673,7 +1658,7 @@ def _build_files_client(
     """
     auth = _resolve_files_auth(config)
     workspace_id = _resolve_workspace_from_source(auth, config, explicit_ctx)
-    return _build_files_client_from_auth(auth), workspace_id
+    return FilesClient._from_resolved_auth(auth), workspace_id
 
 
 def _run_files_command(
@@ -1698,7 +1683,7 @@ def _run_files_command(
         if needs_context:
             client, ctx_id = _build_files_client(config, context_id)
         else:
-            client = _build_files_client_from_auth(_resolve_files_auth(config))
+            client = FilesClient._from_resolved_auth(_resolve_files_auth(config))
 
         async def _run() -> Any:
             async with client:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1583,9 +1583,15 @@ def _resolve_workspace_from_source(
     Raises ``click.ClickException`` with an actionable message when no
     same-source workspace can be formed.
     """
-    # 1. Explicit -c always wins, regardless of source.
-    if explicit_ctx and explicit_ctx.strip() and explicit_ctx != _CONTEXT_ID_AUTO:
-        return explicit_ctx
+    # 1. Explicit -c always wins, regardless of source. Normalize via .strip()
+    #    so that whitespace-padded inputs (e.g. ``--context-id "  auto  "`` or
+    #    a UUID with surrounding spaces) are treated consistently: the
+    #    sentinel comparison ignores padding, and the returned value never
+    #    carries spaces downstream to FilesClient's UUID validator.
+    if explicit_ctx:
+        stripped_ctx = explicit_ctx.strip()
+        if stripped_ctx and stripped_ctx != _CONTEXT_ID_AUTO:
+            return stripped_ctx
 
     # 2. OAuth path: workspace is a snapshot from the profile.
     if isinstance(auth, _OAuthAuth):

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -10,9 +10,9 @@ from typing import Any
 
 import click
 
+from ._auth import _DEFAULT_MCP_URL, _OAuthAuth, _resolve_auth, _StaticAuth
 from .agent import KaguraAgent
 from .auth.cli import auth as _auth_group
-from .auth.credentials import get_shared_state
 from .client import KaguraClient
 from .config import load_config
 from .files_client import FilesClient
@@ -1546,54 +1546,134 @@ def resource_import(resource_id, api_key, input_file, fmt, id_column, version, v
 # =============================================================================
 
 # Sentinel for `kagura setup claude`-generated `.kagura.json` — means
-# "fill in workspace_id from the OAuth profile or --context-id at runtime."
-# Defined as a constant so the CLI, tests, and any future config writer
-# share one source of truth and cannot drift.
+# "fill in workspace_id from the credential source the resolver picks
+# at runtime." Defined as a constant so the CLI, tests, and any future
+# config writer share one source of truth and cannot drift.
 _CONTEXT_ID_AUTO = "auto"
 
 
-def _build_files_client(config: dict[str, Any]) -> FilesClient:
-    """Build a FilesClient using the shared credential resolution chain.
+def _resolve_workspace_from_source(
+    auth: _StaticAuth | _OAuthAuth,
+    config: dict[str, Any],
+    explicit_ctx: str | None,
+) -> str:
+    """Resolve workspace_id from the SAME source as ``api_key`` (issue #115).
 
-    Delegates to :meth:`FilesClient.from_mcp_url`, which runs
-    ``_resolve_auth`` (explicit api_key > ``KAGURA_API_KEY`` env > OAuth
-    profile in ``~/.kagura/credentials.json`` > ``.kagura.json``). When
-    no source produces credentials the resolver raises ``KaguraAuthError``,
-    which ``_run_files_command`` reformats as a ``click.ClickException``.
+    An api_key is provisioned for one specific workspace; mixing one
+    source's api_key with another source's workspace_id is never
+    correct (best case: 403; worst case: silently writing to the wrong
+    workspace). This function pairs the two so the resolver picks both
+    from the same branch:
+
+    1. ``--context-id <uuid>`` always wins — operator override.
+    2. ``_OAuthAuth`` → ``workspace_id`` snapshot from the OAuth
+       profile (i.e. what ``kagura auth login`` stored).
+    3. ``_StaticAuth(source="config")`` → ``.kagura.json``'s
+       ``context_id`` (skipping the :data:`_CONTEXT_ID_AUTO` sentinel).
+    4. ``_StaticAuth(source="env" | "explicit")`` → error, because env
+       / explicit api_keys carry no associated workspace source. The
+       operator must pass ``--context-id``.
+
+    Raises ``click.ClickException`` with an actionable message when no
+    same-source workspace can be formed.
     """
-    return FilesClient.from_mcp_url(
-        api_key=config.get("api_key") or None,
-        mcp_url=config.get("mcp_url") or None,
+    # 1. Explicit -c always wins, regardless of source.
+    if explicit_ctx and explicit_ctx.strip() and explicit_ctx != _CONTEXT_ID_AUTO:
+        return explicit_ctx
+
+    # 2. OAuth path: workspace is a snapshot from the profile.
+    if isinstance(auth, _OAuthAuth):
+        if auth.workspace_id:
+            return auth.workspace_id
+        raise click.ClickException(
+            "OAuth profile has no workspace bound. Re-run `kagura auth login` "
+            "or pass --context-id <uuid>."
+        )
+
+    # 3. Static api_key from .kagura.json → workspace must come from the
+    #    same .kagura.json (context_id field, not the "auto" sentinel).
+    if auth.source == "config":
+        cfg_ctx = (config.get("context_id") or "").strip()
+        if cfg_ctx and cfg_ctx != _CONTEXT_ID_AUTO:
+            return cfg_ctx
+        raise click.ClickException(
+            '.kagura.json has api_key but context_id is missing or "auto". '
+            "Set context_id to the workspace UUID bound to this api_key, "
+            "or pass --context-id. (Falling back to the OAuth profile would "
+            "mix credential sources — see issue #115.)"
+        )
+
+    # 4. env / explicit api_key: no associated workspace source.
+    src_label = "KAGURA_API_KEY env" if auth.source == "env" else "explicit api_key argument"
+    raise click.ClickException(
+        f"api_key from {src_label} has no associated workspace; pass --context-id "
+        "(mixing api_key and OAuth profile's workspace is not allowed — see issue #115)."
     )
 
 
-def _resolve_files_context_id(config: dict[str, Any], context_id: str | None) -> str:
-    """Resolve the workspace UUID for a Files CLI command.
+def _build_files_client_from_auth(auth: _StaticAuth | _OAuthAuth) -> FilesClient:
+    """Construct a :class:`FilesClient` from a pre-resolved auth result.
 
-    Order: explicit ``--context-id`` flag > ``.kagura.json`` (skipping the
-    :data:`_CONTEXT_ID_AUTO` sentinel) > OAuth profile's ``workspace_id``
-    from ``~/.kagura/credentials.json``. Returns ``""`` when every source
-    is empty or the sentinel; the caller surfaces a single actionable error.
-
-    The sentinel is a CLI-level concern: the SDK only accepts real UUIDs
-    (``FilesClient`` validates at the entry point per issue #110). This
-    function converts ``"auto"`` to the right UUID before any SDK call.
+    Mirrors the construction logic of :meth:`FilesClient.from_mcp_url`
+    but takes an already-resolved auth (so the CLI can resolve once and
+    derive both ``api_key`` and ``workspace_id`` from the same source).
     """
-    if context_id and context_id.strip() and context_id != _CONTEXT_ID_AUTO:
-        return context_id
+    from ._http import base_url_from_mcp
 
-    cfg_ctx = (config.get("context_id") or "").strip()
-    if cfg_ctx and cfg_ctx != _CONTEXT_ID_AUTO:
-        return cfg_ctx
+    base_url = base_url_from_mcp(auth.mcp_url.rstrip("/"))
+    if isinstance(auth, _StaticAuth):
+        return FilesClient(api_key=auth.api_key, base_url=base_url)
+    return FilesClient(base_url=base_url, _oauth=auth.oauth)
 
-    # OAuth profile path: kagura auth login stored the workspace_id during
-    # /device consent. This is the natural fallback for users who logged in
-    # but never edited .kagura.json.
-    state = get_shared_state(profile=os.getenv("KAGURA_PROFILE"))
-    if state is not None and state.credentials.workspace_id:
-        return state.credentials.workspace_id
 
-    return ""
+def _resolve_files_auth(config: dict[str, Any]) -> _StaticAuth | _OAuthAuth:
+    """Resolve credentials for the Files CLI with accurate source tagging.
+
+    Preserves the historic CLI precedence — ``.kagura.json`` api_key
+    wins over the env/OAuth chain — but tags the resolved auth as
+    ``source="config"`` instead of routing through ``_resolve_auth``'s
+    priority-1 (explicit) branch. That distinction is what
+    :func:`_resolve_workspace_from_source` reads to pair workspace_id
+    correctly (issue #115): if the api_key came from ``.kagura.json``,
+    the workspace_id must come from the same ``.kagura.json``.
+    """
+    cfg_key = (config.get("api_key") or "").strip()
+    if cfg_key:
+        return _StaticAuth(
+            api_key=cfg_key,
+            mcp_url=(config.get("mcp_url") or _DEFAULT_MCP_URL),
+            source="config",
+        )
+    # No config api_key — walk the rest of the resolver chain
+    # (env → OAuth profile → terminal raise). ``api_key=None`` keeps
+    # priority 1 unused; priority 4 (.kagura.json fallback inside
+    # _resolve_auth) is dead code here because we just confirmed
+    # config has no api_key.
+    return _resolve_auth(
+        api_key=None,
+        mcp_url=config.get("mcp_url") or None,
+        profile=os.getenv("KAGURA_PROFILE"),
+    )
+
+
+def _build_files_client(
+    config: dict[str, Any], explicit_ctx: str | None
+) -> tuple[FilesClient, str]:
+    """Build a (FilesClient, workspace_id) pair from the same credential source.
+
+    Resolves the credential chain once via :func:`_resolve_files_auth`
+    and pairs ``workspace_id`` to it via
+    :func:`_resolve_workspace_from_source`. Returning the pair lets the
+    caller use the resolved workspace directly instead of re-running an
+    independent resolution chain (the bug fixed by issue #115).
+
+    Raises ``click.ClickException`` when no same-source pair can be
+    formed; raises :class:`KaguraAuthError` (via ``_resolve_auth``)
+    when no credentials exist at all.
+    """
+    auth = _resolve_files_auth(config)
+    workspace_id = _resolve_workspace_from_source(auth, config, explicit_ctx)
+    return _build_files_client_from_auth(auth), workspace_id
 
 
 def _run_files_command(
@@ -1604,23 +1684,21 @@ def _run_files_command(
 ) -> None:
     """Execute a FilesClient operation with standard boilerplate.
 
-    Credential and context resolution both delegate to the shared chain
-    (env > OAuth profile > .kagura.json). The operator sees a single
-    error message that points at all three sources when nothing resolves.
+    When ``needs_context=True`` (the default), credential and
+    workspace_id are resolved together so they come from the same
+    source — see :func:`_build_files_client`. When ``needs_context=False``
+    (file-id-based operations like ``download-url`` / ``delete``) only
+    the client is built; ``ctx_id`` is the empty string and operations
+    must ignore it.
     """
     try:
         config = load_config()
 
         ctx_id = ""
         if needs_context:
-            ctx_id = _resolve_files_context_id(config, context_id)
-            if not ctx_id:
-                raise click.ClickException(
-                    "context_id required. Use --context-id, set context_id in "
-                    ".kagura.json, or run `kagura auth login` to bind a workspace."
-                )
-
-        client = _build_files_client(config)
+            client, ctx_id = _build_files_client(config, context_id)
+        else:
+            client = _build_files_client_from_auth(_resolve_files_auth(config))
 
         async def _run() -> Any:
             async with client:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -10,7 +10,13 @@ from typing import Any
 
 import click
 
-from ._auth import _DEFAULT_MCP_URL, _OAuthAuth, _resolve_auth, _StaticAuth
+from ._auth import (
+    _DEFAULT_MCP_URL,
+    _SOURCE_LABEL,
+    _OAuthAuth,
+    _resolve_auth,
+    _StaticAuth,
+)
 from .agent import KaguraAgent
 from .auth.cli import auth as _auth_group
 from .client import KaguraClient
@@ -1604,9 +1610,9 @@ def _resolve_workspace_from_source(
         )
 
     # 4. env / explicit api_key: no associated workspace source.
-    src_label = "KAGURA_API_KEY env" if auth.source == "env" else "explicit api_key argument"
     raise click.ClickException(
-        f"api_key from {src_label} has no associated workspace; pass --context-id "
+        f"api_key from {_SOURCE_LABEL[auth.source]} has no associated workspace; "
+        "pass --context-id "
         "(mixing api_key and OAuth profile's workspace is not allowed — see issue #115)."
     )
 
@@ -1641,24 +1647,26 @@ def _resolve_files_auth(config: dict[str, Any]) -> _StaticAuth | _OAuthAuth:
     )
 
 
-def _build_files_client(
-    config: dict[str, Any], explicit_ctx: str | None
-) -> tuple[FilesClient, str]:
-    """Build a (FilesClient, workspace_id) pair from the same credential source.
+def _bound_workspace_for_hint(auth: _StaticAuth | _OAuthAuth, config: dict[str, Any]) -> str | None:
+    """The workspace BOUND to the api_key source — for 403 hint display only.
 
-    Resolves the credential chain once via :func:`_resolve_files_auth`
-    and pairs ``workspace_id`` to it via
-    :func:`_resolve_workspace_from_source`. Returning the pair lets the
-    caller use the resolved workspace directly instead of re-running an
-    independent resolution chain (the bug fixed by issue #115).
+    Used by :func:`_run_files_command` to thread the right
+    "source workspace" prefix into :class:`FilesClient` so a 403 can
+    show ``api_key source: .kagura.json (workspace=<source-bound>)``
+    next to the request's target workspace. Returns ``None`` when no
+    workspace is bound to the source (env / explicit api_key) so the
+    formatter renders ``<none>`` instead.
 
-    Raises ``click.ClickException`` when no same-source pair can be
-    formed; raises :class:`KaguraAuthError` (via ``_resolve_auth``)
-    when no credentials exist at all.
+    OAuth callers receive their workspace hint via the resolver
+    (``_OAuthAuth.workspace_id``); this helper only fills the
+    ``_StaticAuth(source="config")`` case where the bound workspace
+    lives in ``.kagura.json``'s ``context_id`` field.
     """
-    auth = _resolve_files_auth(config)
-    workspace_id = _resolve_workspace_from_source(auth, config, explicit_ctx)
-    return FilesClient._from_resolved_auth(auth), workspace_id
+    if isinstance(auth, _StaticAuth) and auth.source == "config":
+        cfg_ctx = (config.get("context_id") or "").strip()
+        if cfg_ctx and cfg_ctx != _CONTEXT_ID_AUTO:
+            return cfg_ctx
+    return None
 
 
 def _run_files_command(
@@ -1671,19 +1679,24 @@ def _run_files_command(
 
     When ``needs_context=True`` (the default), credential and
     workspace_id are resolved together so they come from the same
-    source — see :func:`_build_files_client`. When ``needs_context=False``
+    source via :func:`_resolve_files_auth` +
+    :func:`_resolve_workspace_from_source`. When ``needs_context=False``
     (file-id-based operations like ``download-url`` / ``delete``) only
     the client is built; ``ctx_id`` is the empty string and operations
     must ignore it.
     """
     try:
         config = load_config()
+        auth = _resolve_files_auth(config)
 
         ctx_id = ""
         if needs_context:
-            client, ctx_id = _build_files_client(config, context_id)
+            ctx_id = _resolve_workspace_from_source(auth, config, context_id)
+            client = FilesClient._from_resolved_auth(
+                auth, workspace_id_hint=_bound_workspace_for_hint(auth, config)
+            )
         else:
-            client = FilesClient._from_resolved_auth(_resolve_files_auth(config))
+            client = FilesClient._from_resolved_auth(auth)
 
         async def _run() -> Any:
             async with client:

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -629,7 +629,10 @@ def _format_workspace_403_hint(
     """
     if auth_source is None:
         return "HTTP 403"
-    source_label = _SOURCE_LABEL[auth_source]
+    # Use .get() with the raw value as fallback so an unexpected source tag
+    # (shouldn't happen — _auth_source is set by internal resolver code only)
+    # can never raise KeyError mid-403-handling and mask the real HTTP error.
+    source_label = _SOURCE_LABEL.get(auth_source, str(auth_source))
     lines = [
         "HTTP 403 — workspace not accessible with current credentials.",
         f"  api_key source: {source_label} (workspace={_short_workspace(source_workspace_hint)})",

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -29,7 +29,13 @@ from typing import Any, Literal
 
 import httpx
 
-from ._auth import _OAuthAuth, _resolve_auth, _StaticAuth, _StaticSource
+from ._auth import (
+    _SOURCE_LABEL,
+    _AuthSource,
+    _OAuthAuth,
+    _resolve_auth,
+    _StaticAuth,
+)
 from ._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
 from .auth.credentials import KaguraOAuth
 from .exceptions import (
@@ -72,7 +78,7 @@ class FilesClient:
         upload_timeout: float = 300.0,
         *,
         _oauth: KaguraOAuth | None = None,
-        _auth_source: _StaticSource | Literal["oauth"] | None = None,
+        _auth_source: _AuthSource | None = None,
         _workspace_id_hint: str | None = None,
     ) -> None:
         """Initialize FilesClient with a static API key.
@@ -150,8 +156,8 @@ class FilesClient:
         # "HTTP 403". Storing the source label and a workspace UUID is
         # not sensitive (no api_key value is retained — see python.md
         # "Never store API keys as instance attributes").
-        self._auth_source = _auth_source
-        self._workspace_id_hint = _workspace_id_hint
+        self._auth_source: _AuthSource | None = _auth_source
+        self._workspace_id_hint: str | None = _workspace_id_hint
 
     @classmethod
     def from_mcp_url(
@@ -197,6 +203,7 @@ class FilesClient:
         *,
         timeout: float = 30.0,
         upload_timeout: float = 300.0,
+        workspace_id_hint: str | None = None,
     ) -> FilesClient:
         """Construct from a pre-resolved auth — internal CLI helper.
 
@@ -205,6 +212,13 @@ class FilesClient:
         and workspace_id can be paired from the same source (#115);
         threading the resolved auth through here keeps construction in
         one place and lets the 403 hint carry the source provenance.
+
+        ``workspace_id_hint`` lets the CLI thread the workspace bound
+        to a static api_key (from ``.kagura.json``'s ``context_id``)
+        into the client so the 403 hint can show it. For the OAuth
+        path the resolver already carries ``workspace_id`` on the
+        :class:`_OAuthAuth` result, so the hint is set from there
+        unconditionally — passing ``workspace_id_hint`` is ignored.
         """
         base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
         if isinstance(resolved, _StaticAuth):
@@ -214,6 +228,7 @@ class FilesClient:
                 timeout=timeout,
                 upload_timeout=upload_timeout,
                 _auth_source=resolved.source,
+                _workspace_id_hint=workspace_id_hint,
             )
         return cls(
             base_url=base_url,
@@ -596,7 +611,7 @@ def _extract_requested_workspace(
 
 def _format_workspace_403_hint(
     *,
-    auth_source: str | None,
+    auth_source: _AuthSource | None,
     source_workspace_hint: str | None,
     requested_workspace: str | None,
 ) -> str:
@@ -614,12 +629,7 @@ def _format_workspace_403_hint(
     """
     if auth_source is None:
         return "HTTP 403"
-    source_label = {
-        "config": ".kagura.json",
-        "env": "KAGURA_API_KEY env",
-        "explicit": "explicit api_key argument",
-        "oauth": "OAuth profile (~/.kagura/credentials.json)",
-    }.get(auth_source, auth_source)
+    source_label = _SOURCE_LABEL[auth_source]
     lines = [
         "HTTP 403 — workspace not accessible with current credentials.",
         f"  api_key source: {source_label} (workspace={_short_workspace(source_workspace_hint)})",

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -266,14 +266,17 @@ class FilesClient:
                 # common 403 cause (api_key bound to workspace A, request
                 # targets workspace B). Surface the credential source and
                 # requested workspace prefix so the cause is visible without
-                # leaking the api_key value or Bearer header. The hint is
-                # advisory — other 403 causes (scope, deactivation) read the
-                # same message and the operator interprets in context.
+                # leaking the api_key value or Bearer header. The hint shape
+                # adapts to whether the failing request carries a workspace —
+                # file-id-based endpoints (download-url/delete) don't, so the
+                # "workspace not accessible / --context-id" language is
+                # suppressed for those to avoid misleading operators.
                 raise KaguraConnectionError(
                     _format_workspace_403_hint(
                         auth_source=self._auth_source,
                         source_workspace_hint=self._workspace_id_hint,
                         requested_workspace=_extract_requested_workspace(json, params),
+                        server_detail=extract_detail(e.response),
                     )
                 ) from e
             if status == 404:
@@ -609,11 +612,34 @@ def _extract_requested_workspace(
     return None
 
 
+def _sanitize_server_detail(detail: str | None) -> str | None:
+    """Drop server-provided detail strings that contain credential markers.
+
+    Server 403 ``detail`` payloads usually surface non-sensitive reasons
+    (scope, deactivation, plan limit) that are valuable to operators —
+    forwarding them helps debugging. But the detail field is operator-
+    facing text the server controls; a future server bug echoing back
+    the Bearer header or api_key would otherwise be passed straight to
+    the user. Drop the detail entirely when it carries any marker that
+    looks credential-shaped. Returns ``None`` when the detail is empty
+    or unsafe to display.
+    """
+    if not detail:
+        return None
+    lowered = detail.lower()
+    # ``api_key=`` covers ``api_key=<value>`` style; ``bearer`` catches
+    # ``Bearer <token>`` echoes; ``authorization`` catches header reflections.
+    if "bearer" in lowered or "authorization" in lowered or "api_key=" in lowered:
+        return None
+    return detail
+
+
 def _format_workspace_403_hint(
     *,
     auth_source: _AuthSource | None,
     source_workspace_hint: str | None,
     requested_workspace: str | None,
+    server_detail: str | None = None,
 ) -> str:
     """Compose the actionable 403 message for issue #115.
 
@@ -622,24 +648,47 @@ def _format_workspace_403_hint(
     threaded through construction) so the message stays compatible
     with existing CLI error-string assertions until they migrate.
 
+    The hint shape adapts to the failing request:
+
+    - When ``requested_workspace`` is set (upload / list endpoints), use
+      workspace-mismatch language and the ``--context-id`` recovery hint.
+    - When ``requested_workspace`` is ``None`` (file-id-based endpoints
+      like download-url / delete), use a generic "access denied"
+      heading and omit the ``--context-id`` hint — those commands do
+      not accept ``--context-id`` and the recovery path is different.
+
+    ``server_detail`` is appended (when non-empty and free of
+    credential-shaped markers) so scope / deactivation / plan-limit
+    reasons surfaced by the server are not lost.
+
     The hint never includes the api_key value or
     ``Authorization: Bearer ...`` header — only the source label and
     the UUID prefixes (per python.md "Never store API keys as instance
     attributes": the api_key is not on the client either).
     """
     if auth_source is None:
-        return "HTTP 403"
+        # Even the bare path can carry a sanitized server detail.
+        safe_detail = _sanitize_server_detail(server_detail)
+        return f"HTTP 403: {safe_detail}" if safe_detail else "HTTP 403"
     # Use .get() with the raw value as fallback so an unexpected source tag
     # (shouldn't happen — _auth_source is set by internal resolver code only)
     # can never raise KeyError mid-403-handling and mask the real HTTP error.
     source_label = _SOURCE_LABEL.get(auth_source, str(auth_source))
+    heading = (
+        "HTTP 403 — workspace not accessible with current credentials."
+        if requested_workspace
+        else "HTTP 403 — access denied with current credentials."
+    )
     lines = [
-        "HTTP 403 — workspace not accessible with current credentials.",
+        heading,
         f"  api_key source: {source_label} (workspace={_short_workspace(source_workspace_hint)})",
     ]
     if requested_workspace:
         lines.append(f"  workspace requested: {_short_workspace(requested_workspace)}")
-    lines.append("  Hint: --context-id may not match the workspace bound to your api_key.")
+        lines.append("  Hint: --context-id may not match the workspace bound to your api_key.")
+    safe_detail = _sanitize_server_detail(server_detail)
+    if safe_detail:
+        lines.append(f"  server detail: {safe_detail}")
     return "\n".join(lines)
 
 

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -29,7 +29,7 @@ from typing import Any, Literal
 
 import httpx
 
-from ._auth import _resolve_auth, _StaticAuth
+from ._auth import _OAuthAuth, _resolve_auth, _StaticAuth, _StaticSource
 from ._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
 from .auth.credentials import KaguraOAuth
 from .exceptions import (
@@ -72,6 +72,8 @@ class FilesClient:
         upload_timeout: float = 300.0,
         *,
         _oauth: KaguraOAuth | None = None,
+        _auth_source: _StaticSource | Literal["oauth"] | None = None,
+        _workspace_id_hint: str | None = None,
     ) -> None:
         """Initialize FilesClient with a static API key.
 
@@ -89,6 +91,14 @@ class FilesClient:
             _oauth: Private. ``from_mcp_url`` passes a ``KaguraOAuth``
                 instance for OAuth profile authentication. Public
                 callers should not set this.
+            _auth_source: Private. Provenance tag describing which
+                ``_resolve_auth`` branch produced the credentials.
+                When set, drives the actionable 403 hint that surfaces
+                cross-source workspace mismatches (issue #115).
+            _workspace_id_hint: Private. The workspace UUID associated
+                with the credential source — used only for the 403
+                hint, never sent on the wire. Sending workspace_id is
+                still the caller's responsibility via ``context_id=``.
 
         Raises:
             ValueError: If neither ``api_key`` nor ``_oauth`` is given.
@@ -134,6 +144,14 @@ class FilesClient:
             timeout=upload_timeout,
             headers={"User-Agent": f"kagura-memory-sdk/{SDK_VERSION}"},
         )
+        # Provenance for the 403 cross-source hint. Neither field is sent
+        # on the wire — they only flavor error messages so a workspace
+        # mismatch surfaces as something actionable instead of a bare
+        # "HTTP 403". Storing the source label and a workspace UUID is
+        # not sensitive (no api_key value is retained — see python.md
+        # "Never store API keys as instance attributes").
+        self._auth_source = _auth_source
+        self._workspace_id_hint = _workspace_id_hint
 
     @classmethod
     def from_mcp_url(
@@ -170,20 +188,40 @@ class FilesClient:
                 ``default_profile``).
         """
         resolved = _resolve_auth(api_key=api_key, mcp_url=mcp_url, profile=profile)
-        base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
+        return cls._from_resolved_auth(resolved, timeout=timeout, upload_timeout=upload_timeout)
 
+    @classmethod
+    def _from_resolved_auth(
+        cls,
+        resolved: _StaticAuth | _OAuthAuth,
+        *,
+        timeout: float = 30.0,
+        upload_timeout: float = 300.0,
+    ) -> FilesClient:
+        """Construct from a pre-resolved auth — internal CLI helper.
+
+        Shared by :meth:`from_mcp_url` (SDK entry) and the CLI
+        (``cli._build_files_client``). The CLI resolves once so api_key
+        and workspace_id can be paired from the same source (#115);
+        threading the resolved auth through here keeps construction in
+        one place and lets the 403 hint carry the source provenance.
+        """
+        base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
         if isinstance(resolved, _StaticAuth):
             return cls(
                 api_key=resolved.api_key,
                 base_url=base_url,
                 timeout=timeout,
                 upload_timeout=upload_timeout,
+                _auth_source=resolved.source,
             )
         return cls(
             base_url=base_url,
             timeout=timeout,
             upload_timeout=upload_timeout,
             _oauth=resolved.oauth,
+            _auth_source="oauth",
+            _workspace_id_hint=resolved.workspace_id,
         )
 
     # -------------------------------------------------------------------
@@ -208,6 +246,21 @@ class FilesClient:
             status = e.response.status_code
             if status == 401:
                 raise KaguraAuthError("Authentication failed. Check your API key.") from e
+            if status == 403:
+                # Issue #115: a workspace-mismatch 403 is the operator's most
+                # common 403 cause (api_key bound to workspace A, request
+                # targets workspace B). Surface the credential source and
+                # requested workspace prefix so the cause is visible without
+                # leaking the api_key value or Bearer header. The hint is
+                # advisory — other 403 causes (scope, deactivation) read the
+                # same message and the operator interprets in context.
+                raise KaguraConnectionError(
+                    _format_workspace_403_hint(
+                        auth_source=self._auth_source,
+                        source_workspace_hint=self._workspace_id_hint,
+                        requested_workspace=_extract_requested_workspace(json, params),
+                    )
+                ) from e
             if status == 404:
                 raise KaguraNotFoundError(extract_detail(e.response) or "Not found") from e
             if status == 429:
@@ -506,6 +559,75 @@ class FilesClient:
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
+
+
+def _short_workspace(uuid_str: str | None) -> str:
+    """Truncate a UUID to its 8-char prefix for log-friendly display.
+
+    Workspace UUIDs are not secret, but the full UUID adds noise to
+    error messages — a prefix is enough to compare against the source's
+    workspace at a glance. Returns ``"<none>"`` for falsy input.
+    """
+    if not uuid_str:
+        return "<none>"
+    return f"{uuid_str[:8]}…"
+
+
+def _extract_requested_workspace(
+    json: dict[str, Any] | None, params: dict[str, Any] | None
+) -> str | None:
+    """Recover the ``workspace_id`` the failing request was targeting.
+
+    File endpoints carry workspace_id in either the JSON body (reserve)
+    or the query string (list). Returns ``None`` when the request was
+    file-id based (download-url / delete / confirm) and no workspace
+    information is on the wire.
+    """
+    if json is not None:
+        ws = json.get("workspace_id")
+        if isinstance(ws, str):
+            return ws
+    if params is not None:
+        ws = params.get("workspace_id")
+        if isinstance(ws, str):
+            return ws
+    return None
+
+
+def _format_workspace_403_hint(
+    *,
+    auth_source: str | None,
+    source_workspace_hint: str | None,
+    requested_workspace: str | None,
+) -> str:
+    """Compose the actionable 403 message for issue #115.
+
+    Always emits a structured hint when ``auth_source`` is set; falls
+    back to the bare ``"HTTP 403"`` for legacy callers (no source
+    threaded through construction) so the message stays compatible
+    with existing CLI error-string assertions until they migrate.
+
+    The hint never includes the api_key value or
+    ``Authorization: Bearer ...`` header — only the source label and
+    the UUID prefixes (per python.md "Never store API keys as instance
+    attributes": the api_key is not on the client either).
+    """
+    if auth_source is None:
+        return "HTTP 403"
+    source_label = {
+        "config": ".kagura.json",
+        "env": "KAGURA_API_KEY env",
+        "explicit": "explicit api_key argument",
+        "oauth": "OAuth profile (~/.kagura/credentials.json)",
+    }.get(auth_source, auth_source)
+    lines = [
+        "HTTP 403 — workspace not accessible with current credentials.",
+        f"  api_key source: {source_label} (workspace={_short_workspace(source_workspace_hint)})",
+    ]
+    if requested_workspace:
+        lines.append(f"  workspace requested: {_short_workspace(requested_workspace)}")
+    lines.append("  Hint: --context-id may not match the workspace bound to your api_key.")
+    return "\n".join(lines)
 
 
 def _extract_existing_file(error: KaguraConnectionError) -> FileObject | None:

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -227,6 +227,45 @@ def _oauth_creds_with_workspace(workspace_id: str) -> OAuthCredentials:
     )
 
 
+def test_files_upload_strips_whitespace_from_explicit_context_id(monkeypatch, tmp_path):
+    """``--context-id`` with surrounding whitespace is normalized before resolution.
+
+    Defends against a class of subtle bugs where a whitespace-padded UUID
+    (e.g. copy-paste from a chat client) would pass the truthy check but
+    then either fail UUID validation downstream or, worse, pass through
+    the ``"auto"`` sentinel comparison without matching the sentinel.
+    """
+    ws = "20000000-0000-0000-0000-000000000003"
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
+    reset_state_cache()
+
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={"api_key": "key", "mcp_url": "https://test.com/mcp"},
+        ),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    ):
+        mock_client = _mock_files_client("upload", _file_object())
+        _wire_files_client_mock(mock_client_cls, mock_client)
+
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p), "--context-id", f"  {ws}  "])
+
+    reset_state_cache()
+
+    assert result.exit_code == 0, result.output
+    # Whitespace was stripped before reaching FilesClient.upload.
+    assert mock_client.upload.call_args.kwargs["context_id"] == ws
+
+
 def test_files_upload_with_explicit_context_id_flag(monkeypatch, tmp_path):
     """``--context-id`` flag is the highest-priority source and bypasses every fallback.
 

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -378,6 +378,38 @@ def test_files_upload_rejects_env_api_key_without_context(monkeypatch, tmp_path)
     assert "--context-id" in result.output
 
 
+def test_files_upload_oauth_profile_without_workspace_id_errors(monkeypatch, tmp_path):
+    """OAuth profile resolved but ``workspace_id`` is empty → actionable error.
+
+    Pre-issue-#170 OAuth profiles did not record ``workspace_id`` (the
+    field was added later). An operator upgrading from such a profile
+    has a valid login but no bound workspace; the CLI must point them
+    at ``kagura auth login`` or ``--context-id``, not produce a 422 at
+    request time.
+    """
+    fake_creds_path = tmp_path / "credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+
+    cf = CredentialsFile()
+    # workspace_id="" simulates the legacy profile shape.
+    cf.set_profile("default", _oauth_creds_with_workspace(""))
+    save_credentials_file(cf, fake_creds_path)
+    reset_state_cache()
+
+    with patch("kagura_memory.cli.load_config", return_value={}):
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p)])
+
+    reset_state_cache()
+
+    assert result.exit_code != 0, result.output
+    assert "kagura auth login" in result.output or "--context-id" in result.output
+
+
 def test_files_upload_env_api_key_with_explicit_context_succeeds(monkeypatch, tmp_path):
     """``KAGURA_API_KEY`` env + ``-c`` → succeed (operator override).
 

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -41,6 +41,19 @@ def _mock_files_client(method_name: str, return_value) -> MagicMock:
     return client
 
 
+def _wire_files_client_mock(mock_client_cls: MagicMock, mock_client: MagicMock) -> None:
+    """Route every CLI entry point on the patched FilesClient to ``mock_client``.
+
+    The CLI may construct via ``FilesClient(...)`` (direct) or
+    ``FilesClient._from_resolved_auth(...)`` (the internal classmethod
+    shared with ``from_mcp_url``). Configure all entry points so test
+    setup stays insensitive to which one the CLI happens to pick.
+    """
+    mock_client_cls.return_value = mock_client
+    mock_client_cls._from_resolved_auth.return_value = mock_client
+    mock_client_cls.from_mcp_url.return_value = mock_client
+
+
 @patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.FilesClient")
 def test_files_upload(mock_client_cls, mock_config, tmp_path):
@@ -53,7 +66,7 @@ def test_files_upload(mock_client_cls, mock_config, tmp_path):
     mock_client = _mock_files_client("upload", _file_object())
     # The CLI constructs FilesClient(...) directly via _build_files_client_from_auth;
     # set return_value so any call to the patched class returns the mock client.
-    mock_client_cls.return_value = mock_client
+    _wire_files_client_mock(mock_client_cls, mock_client)
 
     p = tmp_path / "hello.txt"
     p.write_text("hello kagura files")
@@ -121,7 +134,7 @@ def test_files_upload_missing_context(mock_config, monkeypatch, tmp_path):
 def test_files_download_url(mock_client_cls, mock_config):
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
     mock_client = _mock_files_client("download_url", "https://r2.example.com/get/key?sig=...")
-    mock_client_cls.return_value = mock_client
+    _wire_files_client_mock(mock_client_cls, mock_client)
 
     runner = CliRunner()
     result = runner.invoke(main, ["files", "download-url", SAMPLE_FILE_ID])
@@ -136,7 +149,7 @@ def test_files_download_url(mock_client_cls, mock_config):
 def test_files_delete(mock_client_cls, mock_config):
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
     mock_client = _mock_files_client("delete", None)
-    mock_client_cls.return_value = mock_client
+    _wire_files_client_mock(mock_client_cls, mock_client)
 
     runner = CliRunner()
     result = runner.invoke(main, ["files", "delete", SAMPLE_FILE_ID])
@@ -155,8 +168,8 @@ def test_files_unexpected_exception_wrapped_as_click(mock_client_cls, mock_confi
         "mcp_url": "https://test.com/mcp",
         "context_id": SAMPLE_CTX_ID,
     }
-    # The CLI calls FilesClient(...) directly; have construction raise.
-    mock_client_cls.side_effect = RuntimeError("boom from factory")
+    # The CLI builds via FilesClient._from_resolved_auth(); have it raise.
+    mock_client_cls._from_resolved_auth.side_effect = RuntimeError("boom from factory")
 
     p = tmp_path / "hello.txt"
     p.write_text("hi")
@@ -179,7 +192,7 @@ def test_files_list(mock_client_cls, mock_config):
         "list",
         FileListResponse(files=[_file_object()], next_cursor=None),
     )
-    mock_client_cls.return_value = mock_client
+    _wire_files_client_mock(mock_client_cls, mock_client)
 
     runner = CliRunner()
     result = runner.invoke(main, ["files", "list"])
@@ -242,7 +255,7 @@ def test_files_upload_with_explicit_context_id_flag(monkeypatch, tmp_path):
         patch("kagura_memory.cli.FilesClient") as mock_client_cls,
     ):
         mock_client = _mock_files_client("upload", _file_object())
-        mock_client_cls.return_value = mock_client
+        _wire_files_client_mock(mock_client_cls, mock_client)
 
         p = tmp_path / "hello.txt"
         p.write_text("hi")
@@ -282,7 +295,7 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
         patch("kagura_memory.cli.FilesClient") as mock_client_cls,
     ):
         mock_client = _mock_files_client("upload", _file_object())
-        mock_client_cls.return_value = mock_client
+        _wire_files_client_mock(mock_client_cls, mock_client)
 
         p = tmp_path / "hello.txt"
         p.write_text("hi")
@@ -387,7 +400,7 @@ def test_files_upload_env_api_key_with_explicit_context_succeeds(monkeypatch, tm
         patch("kagura_memory.cli.FilesClient") as mock_client_cls,
     ):
         mock_client = _mock_files_client("upload", _file_object())
-        mock_client_cls.return_value = mock_client
+        _wire_files_client_mock(mock_client_cls, mock_client)
 
         p = tmp_path / "hello.txt"
         p.write_text("hi")

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -51,8 +51,9 @@ def test_files_upload(mock_client_cls, mock_config, tmp_path):
         "context_id": SAMPLE_CTX_ID,
     }
     mock_client = _mock_files_client("upload", _file_object())
-    # FilesClient.from_mcp_url is a classmethod — patch it too
-    mock_client_cls.from_mcp_url.return_value = mock_client
+    # The CLI constructs FilesClient(...) directly via _build_files_client_from_auth;
+    # set return_value so any call to the patched class returns the mock client.
+    mock_client_cls.return_value = mock_client
 
     p = tmp_path / "hello.txt"
     p.write_text("hello kagura files")
@@ -92,9 +93,15 @@ def test_files_upload_missing_credentials(mock_config, monkeypatch, tmp_path):
 
 @patch("kagura_memory.cli.load_config")
 def test_files_upload_missing_context(mock_config, monkeypatch, tmp_path):
-    """upload without --context-id and without any workspace source → context_id required."""
+    """upload with config api_key but no context_id and no -c → same-source error.
+
+    After issue #115, falling through to the OAuth profile's
+    workspace_id is no longer allowed when api_key comes from a
+    different source. With api_key in ``.kagura.json`` and no
+    ``context_id``, the CLI raises an actionable error pointing to
+    ``.kagura.json``'s ``context_id`` field or ``--context-id``.
+    """
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
-    # Block the OAuth profile workspace_id fallback so context_id stays empty.
     monkeypatch.delenv("KAGURA_PROFILE", raising=False)
     monkeypatch.setattr(
         "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
@@ -105,7 +112,8 @@ def test_files_upload_missing_context(mock_config, monkeypatch, tmp_path):
     runner = CliRunner()
     result = runner.invoke(main, ["files", "upload", str(p)])
     assert result.exit_code != 0
-    assert "context_id required" in result.output
+    assert "context_id is missing" in result.output
+    assert "--context-id" in result.output
 
 
 @patch("kagura_memory.cli.load_config")
@@ -113,7 +121,7 @@ def test_files_upload_missing_context(mock_config, monkeypatch, tmp_path):
 def test_files_download_url(mock_client_cls, mock_config):
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
     mock_client = _mock_files_client("download_url", "https://r2.example.com/get/key?sig=...")
-    mock_client_cls.from_mcp_url.return_value = mock_client
+    mock_client_cls.return_value = mock_client
 
     runner = CliRunner()
     result = runner.invoke(main, ["files", "download-url", SAMPLE_FILE_ID])
@@ -128,7 +136,7 @@ def test_files_download_url(mock_client_cls, mock_config):
 def test_files_delete(mock_client_cls, mock_config):
     mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
     mock_client = _mock_files_client("delete", None)
-    mock_client_cls.from_mcp_url.return_value = mock_client
+    mock_client_cls.return_value = mock_client
 
     runner = CliRunner()
     result = runner.invoke(main, ["files", "delete", SAMPLE_FILE_ID])
@@ -147,7 +155,8 @@ def test_files_unexpected_exception_wrapped_as_click(mock_client_cls, mock_confi
         "mcp_url": "https://test.com/mcp",
         "context_id": SAMPLE_CTX_ID,
     }
-    mock_client_cls.from_mcp_url.side_effect = RuntimeError("boom from factory")
+    # The CLI calls FilesClient(...) directly; have construction raise.
+    mock_client_cls.side_effect = RuntimeError("boom from factory")
 
     p = tmp_path / "hello.txt"
     p.write_text("hi")
@@ -170,7 +179,7 @@ def test_files_list(mock_client_cls, mock_config):
         "list",
         FileListResponse(files=[_file_object()], next_cursor=None),
     )
-    mock_client_cls.from_mcp_url.return_value = mock_client
+    mock_client_cls.return_value = mock_client
 
     runner = CliRunner()
     result = runner.invoke(main, ["files", "list"])
@@ -208,10 +217,9 @@ def _oauth_creds_with_workspace(workspace_id: str) -> OAuthCredentials:
 def test_files_upload_with_explicit_context_id_flag(monkeypatch, tmp_path):
     """``--context-id`` flag is the highest-priority source and bypasses every fallback.
 
-    Covers the first branch of ``_resolve_files_context_id``: when the
-    user passes an explicit UUID via ``-c`` / ``--context-id``, neither
-    ``.kagura.json.context_id`` nor the OAuth profile's ``workspace_id``
-    is consulted.
+    The first branch of :func:`_resolve_workspace_from_source`: an
+    explicit UUID via ``-c`` / ``--context-id`` wins over the
+    api_key's same-source workspace and over the OAuth profile.
     """
     explicit_ctx = "20000000-0000-0000-0000-000000000003"
     monkeypatch.delenv("KAGURA_API_KEY", raising=False)
@@ -234,7 +242,7 @@ def test_files_upload_with_explicit_context_id_flag(monkeypatch, tmp_path):
         patch("kagura_memory.cli.FilesClient") as mock_client_cls,
     ):
         mock_client = _mock_files_client("upload", _file_object())
-        mock_client_cls.from_mcp_url.return_value = mock_client
+        mock_client_cls.return_value = mock_client
 
         p = tmp_path / "hello.txt"
         p.write_text("hi")
@@ -254,8 +262,10 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
 
     Headline scenario from #110: ``kagura auth login`` populates the
     profile's ``workspace_id``; subsequent ``kagura files upload`` with
-    neither ``--context-id`` nor ``.kagura.json.context_id`` must resolve
-    the workspace via the OAuth profile and succeed.
+    neither ``--context-id`` nor ``.kagura.json.context_id`` must
+    resolve the workspace via the OAuth profile and succeed. With #115
+    this is the OAuth same-source pair — api_key + workspace_id both
+    come from the OAuth profile.
     """
     fake_creds_path = tmp_path / "credentials.json"
     monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
@@ -272,7 +282,7 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
         patch("kagura_memory.cli.FilesClient") as mock_client_cls,
     ):
         mock_client = _mock_files_client("upload", _file_object())
-        mock_client_cls.from_mcp_url.return_value = mock_client
+        mock_client_cls.return_value = mock_client
 
         p = tmp_path / "hello.txt"
         p.write_text("hi")
@@ -286,13 +296,15 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
     assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
 
 
-def test_files_upload_treats_context_id_auto_as_unset(monkeypatch, tmp_path):
-    """`.kagura.json` with ``context_id: "auto"`` should not reach the SDK.
+def test_files_upload_rejects_auto_sentinel_with_config_api_key(monkeypatch, tmp_path):
+    """``.kagura.json:context_id == "auto"`` + config api_key + OAuth profile → reject.
 
-    The CLI converts the ``"auto"`` sentinel to the OAuth profile's
-    workspace_id before calling ``FilesClient.upload``. Previously this
-    would forward ``"auto"`` straight to the server and hit a 422
-    ``workspace_id`` validation error.
+    Before issue #115 the CLI silently fell through to the OAuth
+    profile's ``workspace_id`` when ``context_id`` was ``"auto"``,
+    even though the api_key came from a different source. That
+    cross-source pairing is the bug; with #115, this scenario now
+    raises a clear error pointing the operator at ``--context-id`` or
+    ``.kagura.json``'s ``context_id`` field.
     """
     fake_creds_path = tmp_path / "credentials.json"
     monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
@@ -306,16 +318,10 @@ def test_files_upload_treats_context_id_auto_as_unset(monkeypatch, tmp_path):
 
     from kagura_memory.cli import _CONTEXT_ID_AUTO
 
-    with (
-        patch(
-            "kagura_memory.cli.load_config",
-            return_value={"api_key": "key", "context_id": _CONTEXT_ID_AUTO},
-        ),
-        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    with patch(
+        "kagura_memory.cli.load_config",
+        return_value={"api_key": "key", "context_id": _CONTEXT_ID_AUTO},
     ):
-        mock_client = _mock_files_client("upload", _file_object())
-        mock_client_cls.from_mcp_url.return_value = mock_client
-
         p = tmp_path / "hello.txt"
         p.write_text("hi")
         runner = CliRunner()
@@ -323,6 +329,72 @@ def test_files_upload_treats_context_id_auto_as_unset(monkeypatch, tmp_path):
 
     reset_state_cache()
 
+    assert result.exit_code != 0, result.output
+    assert "context_id is missing" in result.output or '"auto"' in result.output
+    assert "--context-id" in result.output
+
+
+def test_files_upload_rejects_env_api_key_without_context(monkeypatch, tmp_path):
+    """``KAGURA_API_KEY`` env + OAuth profile + no ``-c`` → reject (no associated workspace).
+
+    Same-source pairing (issue #115): api_key from ``KAGURA_API_KEY``
+    env has no workspace source attached, and falling through to the
+    OAuth profile's ``workspace_id`` would mix sources. The CLI must
+    require ``--context-id`` explicitly.
+    """
+    fake_creds_path = tmp_path / "credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
+    monkeypatch.setenv("KAGURA_API_KEY", "env-key")
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+
+    cf = CredentialsFile()
+    cf.set_profile("default", _oauth_creds_with_workspace(SAMPLE_CTX_ID))
+    save_credentials_file(cf, fake_creds_path)
+    reset_state_cache()
+
+    with patch("kagura_memory.cli.load_config", return_value={}):
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p)])
+
+    reset_state_cache()
+
+    assert result.exit_code != 0, result.output
+    assert "KAGURA_API_KEY env" in result.output
+    assert "--context-id" in result.output
+
+
+def test_files_upload_env_api_key_with_explicit_context_succeeds(monkeypatch, tmp_path):
+    """``KAGURA_API_KEY`` env + ``-c`` → succeed (operator override).
+
+    The mirror of :func:`test_files_upload_rejects_env_api_key_without_context`:
+    once the operator supplies ``--context-id`` explicitly, env-derived
+    api_key is fine — the explicit flag is the highest-priority
+    workspace source regardless of api_key source.
+    """
+    explicit_ctx = "30000000-0000-0000-0000-000000000004"
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
+    monkeypatch.setenv("KAGURA_API_KEY", "env-key")
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    reset_state_cache()
+
+    with (
+        patch("kagura_memory.cli.load_config", return_value={}),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    ):
+        mock_client = _mock_files_client("upload", _file_object())
+        mock_client_cls.return_value = mock_client
+
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p), "--context-id", explicit_ctx])
+
+    reset_state_cache()
+
     assert result.exit_code == 0, result.output
-    assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
-    assert mock_client.upload.call_args.kwargs["context_id"] != _CONTEXT_ID_AUTO
+    assert mock_client.upload.call_args.kwargs["context_id"] == explicit_ctx

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -803,6 +803,24 @@ async def test_request_403_with_source_emits_workspace_hint():
     assert "--context-id" in msg
 
 
+def test_format_workspace_403_hint_handles_unknown_source_tag():
+    """Defensive: an unexpected ``auth_source`` value never raises KeyError.
+
+    ``_auth_source`` is set only by internal resolver code so this path
+    shouldn't fire in practice — but 403 handling must not crash mid-error,
+    or the real HTTP failure would be masked by a KeyError.
+    """
+    from kagura_memory.files_client import _format_workspace_403_hint
+
+    msg = _format_workspace_403_hint(
+        auth_source="unexpected-source-tag",  # type: ignore[arg-type]
+        source_workspace_hint=None,
+        requested_workspace=None,
+    )
+    assert "HTTP 403" in msg
+    assert "unexpected-source-tag" in msg
+
+
 def test_short_workspace_returns_none_for_empty():
     """`_short_workspace` returns the ``<none>`` sentinel for empty/None input."""
     from kagura_memory.files_client import _short_workspace

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -804,6 +804,39 @@ async def test_request_403_with_source_emits_workspace_hint():
 
 
 @pytest.mark.asyncio
+async def test_request_403_config_source_emits_workspace_hint():
+    """Static api_key from ``.kagura.json`` → 403 hint shows the bound workspace.
+
+    After the /simplify refactor the CLI threads
+    ``workspace_id_hint`` into ``FilesClient._from_resolved_auth`` for
+    the ``_StaticAuth(source="config")`` path, so a config-source 403
+    no longer surfaces ``workspace=<none>`` — it shows the workspace
+    UUID prefix the api_key was bound to.
+    """
+    client = FilesClient(
+        api_key="test-key",
+        base_url="https://example.com",
+        _auth_source="config",
+        _workspace_id_hint="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    err_resp = _error_response(403, {"detail": "forbidden"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            await client.list(context_id="11111111-2222-3333-4444-555555555555")
+        msg = str(exc_info.value)
+    await client.close()
+
+    assert ".kagura.json" in msg
+    # Bound workspace prefix surfaces — not "<none>".
+    assert "aaaaaaaa" in msg
+    assert "workspace=<none>" not in msg
+    # Request workspace is distinct from the bound one (the mismatch the
+    # hint is meant to clarify).
+    assert "workspace requested: 11111111" in msg
+
+
+@pytest.mark.asyncio
 async def test_request_403_hint_does_not_leak_api_key_or_bearer():
     """The 403 hint must not include the api_key value or Authorization header.
 

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -753,13 +753,15 @@ async def test_request_401_raises_auth_error():
 
 
 @pytest.mark.asyncio
-async def test_request_403_without_source_is_bare_http_403():
-    """Direct ``FilesClient(api_key=...)`` (no resolver) → bare ``HTTP 403``.
+async def test_request_403_without_source_includes_sanitized_detail():
+    """Direct ``FilesClient(api_key=...)`` (no resolver) → ``HTTP 403`` + server detail.
 
     SDK callers who construct ``FilesClient`` without going through
     ``_from_resolved_auth`` haven't told us their credential source, so
-    we cannot produce the actionable hint. Surface the legacy bare
-    message in that case (no false claims about source mismatch).
+    we cannot produce the workspace-specific hint. But the server's
+    ``detail`` field still flows through (after sanitization), so
+    operators can see "forbidden" / scope-related reasons even on the
+    bare path.
     """
     client = FilesClient(api_key="test-key", base_url="https://example.com")
     err_resp = _error_response(403, {"detail": "forbidden"})
@@ -767,8 +769,45 @@ async def test_request_403_without_source_is_bare_http_403():
         mock_req.return_value = err_resp
         with pytest.raises(KaguraConnectionError) as exc_info:
             await client.delete("some-file-id")
-        assert str(exc_info.value) == "HTTP 403"
+        msg = str(exc_info.value)
     await client.close()
+
+    assert msg == "HTTP 403: forbidden"
+
+
+@pytest.mark.asyncio
+async def test_request_403_without_workspace_uses_generic_heading():
+    """File-id endpoints (no workspace_id on the wire) → generic 403 heading.
+
+    download-url / delete don't accept ``--context-id``, so the
+    workspace-mismatch language and the ``--context-id`` recovery hint
+    are misleading for those commands. The hint adapts: keep the
+    source label, drop the workspace-specific lines.
+    """
+    client = FilesClient(
+        api_key="test-key",
+        base_url="https://example.com",
+        _auth_source="config",
+        _workspace_id_hint="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    err_resp = _error_response(403, {"detail": "insufficient_scope"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            await client.delete("some-file-id")
+        msg = str(exc_info.value)
+    await client.close()
+
+    assert "HTTP 403" in msg
+    assert "access denied" in msg
+    # workspace-specific language must NOT appear for file-id endpoints.
+    assert "workspace not accessible" not in msg
+    assert "workspace requested:" not in msg
+    assert "--context-id" not in msg
+    # The source provenance and server detail still surface.
+    assert ".kagura.json" in msg
+    assert "aaaaaaaa" in msg
+    assert "insufficient_scope" in msg
 
 
 @pytest.mark.asyncio
@@ -801,6 +840,30 @@ async def test_request_403_with_source_emits_workspace_hint():
     assert "aaaaaaaa" in msg
     assert "workspace requested: 11111111" in msg
     assert "--context-id" in msg
+
+
+def test_sanitize_server_detail_drops_credential_markers():
+    """A server detail string containing credential markers must be dropped.
+
+    ``detail`` is operator-facing text the server controls. A future server
+    bug echoing back the Bearer header or api_key value would otherwise
+    flow straight through to the user. The sanitizer drops any detail
+    that contains common credential-shaped markers.
+    """
+    from kagura_memory.files_client import _sanitize_server_detail
+
+    # Safe details pass through unchanged.
+    assert _sanitize_server_detail("forbidden") == "forbidden"
+    assert _sanitize_server_detail("insufficient_scope") == "insufficient_scope"
+    assert _sanitize_server_detail("account deactivated") == "account deactivated"
+    # Empty / None → None.
+    assert _sanitize_server_detail("") is None
+    assert _sanitize_server_detail(None) is None
+    # Credential markers → drop (case-insensitive).
+    assert _sanitize_server_detail("Bearer rotk-leaked-value") is None
+    assert _sanitize_server_detail("bearer xxx") is None
+    assert _sanitize_server_detail("Authorization: Bearer xxx") is None
+    assert _sanitize_server_detail("api_key=plaintext-bad") is None
 
 
 def test_format_workspace_403_hint_handles_unknown_source_tag():

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -753,6 +753,87 @@ async def test_request_401_raises_auth_error():
 
 
 @pytest.mark.asyncio
+async def test_request_403_without_source_is_bare_http_403():
+    """Direct ``FilesClient(api_key=...)`` (no resolver) → bare ``HTTP 403``.
+
+    SDK callers who construct ``FilesClient`` without going through
+    ``_from_resolved_auth`` haven't told us their credential source, so
+    we cannot produce the actionable hint. Surface the legacy bare
+    message in that case (no false claims about source mismatch).
+    """
+    client = FilesClient(api_key="test-key", base_url="https://example.com")
+    err_resp = _error_response(403, {"detail": "forbidden"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            await client.delete("some-file-id")
+        assert str(exc_info.value) == "HTTP 403"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_request_403_with_source_emits_workspace_hint():
+    """OAuth-sourced client → 403 message names the source and workspace prefix.
+
+    Same-source pairing (#115) attaches ``_auth_source="oauth"`` and
+    the OAuth profile's ``workspace_id`` to the client. On 403 the SDK
+    emits a multi-line hint citing the source label and both the
+    bound and requested workspace prefixes.
+    """
+    client = FilesClient(
+        api_key="test-key",
+        base_url="https://example.com",
+        _auth_source="oauth",
+        _workspace_id_hint="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    err_resp = _error_response(403, {"detail": "forbidden"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            # files list sends workspace_id in query params.
+            await client.list(context_id="11111111-2222-3333-4444-555555555555")
+        msg = str(exc_info.value)
+    await client.close()
+
+    assert "HTTP 403" in msg
+    assert "workspace not accessible" in msg
+    assert "OAuth profile" in msg
+    assert "aaaaaaaa" in msg
+    assert "workspace requested: 11111111" in msg
+    assert "--context-id" in msg
+
+
+@pytest.mark.asyncio
+async def test_request_403_hint_does_not_leak_api_key_or_bearer():
+    """The 403 hint must not include the api_key value or Authorization header.
+
+    python.md rule: never store api_keys as instance attributes. The
+    hint is built from the source label and workspace UUIDs only —
+    this test pins that promise so a future refactor cannot
+    accidentally embed the secret in the operator-facing message.
+    """
+    secret = "kagura_super_secret_api_key_value"
+    client = FilesClient(
+        api_key=secret,
+        base_url="https://example.com",
+        _auth_source="config",
+        _workspace_id_hint="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    err_resp = _error_response(403, {"detail": "forbidden"})
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = err_resp
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            await client.list(context_id="11111111-2222-3333-4444-555555555555")
+        msg = str(exc_info.value)
+    await client.close()
+
+    assert secret not in msg
+    assert "Bearer" not in msg
+    assert "api_key=" not in msg  # no key=value pair surfacing the value
+    assert "Authorization" not in msg
+
+
+@pytest.mark.asyncio
 async def test_request_404_raises_not_found():
     client = FilesClient(api_key="test", base_url="https://example.com")
     err_resp = _error_response(404, {"detail": "file gone"})

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -803,6 +803,35 @@ async def test_request_403_with_source_emits_workspace_hint():
     assert "--context-id" in msg
 
 
+def test_short_workspace_returns_none_for_empty():
+    """`_short_workspace` returns the ``<none>`` sentinel for empty/None input."""
+    from kagura_memory.files_client import _short_workspace
+
+    assert _short_workspace(None) == "<none>"
+    assert _short_workspace("") == "<none>"
+
+
+def test_extract_requested_workspace_handles_no_workspace_path():
+    """``_extract_requested_workspace`` returns None when no workspace_id is carried.
+
+    Covers the file-id-based request path (download-url / delete / confirm)
+    where the 403 hint must render without a "workspace requested:" line.
+    """
+    from kagura_memory.files_client import _extract_requested_workspace
+
+    assert _extract_requested_workspace(None, None) is None
+    assert _extract_requested_workspace({}, None) is None
+    assert _extract_requested_workspace(None, {}) is None
+    # Non-string workspace_id (defensive against malformed payloads) → None.
+    assert _extract_requested_workspace({"workspace_id": None}, None) is None
+    assert _extract_requested_workspace(None, {"workspace_id": 42}) is None
+    # Happy paths: string workspace_id is recovered from either body or params.
+    assert _extract_requested_workspace({"workspace_id": "ws-from-json"}, None) == "ws-from-json"
+    assert (
+        _extract_requested_workspace(None, {"workspace_id": "ws-from-params"}) == "ws-from-params"
+    )
+
+
 @pytest.mark.asyncio
 async def test_request_403_config_source_emits_workspace_hint():
     """Static api_key from ``.kagura.json`` → 403 hint shows the bound workspace.

--- a/uv.lock
+++ b/uv.lock
@@ -840,6 +840,17 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+ingest = [
+    { name = "pillow" },
+]
+ingest-all = [
+    { name = "pillow" },
+    { name = "pymupdf" },
+]
+ingest-pdf = [
+    { name = "pillow" },
+    { name = "pymupdf" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -855,7 +866,12 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "litellm", specifier = ">=1.50,<1.82.7" },
+    { name = "pillow", marker = "extra == 'ingest'", specifier = ">=10.4" },
+    { name = "pillow", marker = "extra == 'ingest-all'", specifier = ">=10.4" },
+    { name = "pillow", marker = "extra == 'ingest-pdf'", specifier = ">=10.4" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pymupdf", marker = "extra == 'ingest-all'", specifier = ">=1.24" },
+    { name = "pymupdf", marker = "extra == 'ingest-pdf'", specifier = ">=1.24" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
@@ -1146,6 +1162,93 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347 },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873 },
+    { url = "https://files.pythonhosted.org/packages/df/21/e3fbdf54408a973c7f7f89a23b2cb97a7ef30c61ab4142af31eee6aebc88/pillow-12.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f490f9368b6fc026f021db16d7ec2fbf7d89e2edb42e8ec09d2c60505f5729c7", size = 6280168 },
+    { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188 },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/220a5994ef1b10e70e85748b75649d77d506499352be135a4989c957b701/pillow-12.2.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3997232e10d2920a68d25191392e3a4487d8183039e1c74c2297f00ed1c50705", size = 6394401 },
+    { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655 },
+    { url = "https://files.pythonhosted.org/packages/6b/3d/45132c57d5fb4b5744567c3817026480ac7fc3ce5d4c47902bc0e7f6f853/pillow-12.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:56a3f9c60a13133a98ecff6197af34d7824de9b7b38c3654861a725c970c197b", size = 6503105 },
+    { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402 },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/2941e42858ebb67e50ae741473de81c2984e6eff7b397017623c676e2e8d/pillow-12.2.0-cp311-cp311-win32.whl", hash = "sha256:8c984051042858021a54926eb597d6ee3012393ce9c181814115df4c60b9a808", size = 6378149 },
+    { url = "https://files.pythonhosted.org/packages/69/42/836b6f3cd7f3e5fa10a1f1a5420447c17966044c8fbf589cc0452d5502db/pillow-12.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:6e6b2a0c538fc200b38ff9eb6628228b77908c319a005815f2dde585a0664b60", size = 7082626 },
+    { url = "https://files.pythonhosted.org/packages/c2/88/549194b5d6f1f494b485e493edc6693c0a16f4ada488e5bd974ed1f42fad/pillow-12.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:9a8a34cc89c67a65ea7437ce257cea81a9dad65b29805f3ecee8c8fe8ff25ffe", size = 2463531 },
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279 },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490 },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462 },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744 },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371 },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215 },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783 },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112 },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489 },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129 },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612 },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837 },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528 },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401 },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094 },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402 },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005 },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669 },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194 },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423 },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667 },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580 },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896 },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266 },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508 },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927 },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624 },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252 },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550 },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114 },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667 },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966 },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241 },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592 },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542 },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765 },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848 },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515 },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159 },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185 },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386 },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384 },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599 },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021 },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360 },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628 },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321 },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723 },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400 },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835 },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225 },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541 },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251 },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807 },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935 },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720 },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498 },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413 },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084 },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152 },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579 },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969 },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674 },
+    { url = "https://files.pythonhosted.org/packages/d4/37/664fca7201f8bb2aa1d20e2c3d5564a62e6ae5111741966c8319ca802361/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d04bfa02cc2d23b497d1e90a0f927070043f6cbf303e738300532379a4b4e0f", size = 5288479 },
+    { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230 },
+    { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404 },
+    { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215 },
+    { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1389,6 +1492,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636 },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238 },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923 },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198 },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609 },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286 },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102 },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #115

## Summary

- Fixes a class-1 authorization bug in the Files CLI: `_build_files_client` resolved `api_key` from one credential chain while `_resolve_files_context_id` resolved `workspace_id` from a different chain, producing `HTTP 403` when an api_key bound to workspace A was sent against workspace B's UUID (worst case: silent writes to the wrong workspace).
- Adds same-source pairing: api_key and workspace_id are now resolved together via `_resolve_files_auth` + `_resolve_workspace_from_source`. The credential source picks both — env / explicit api_keys require `--context-id`, `.kagura.json` api_key reads its own `context_id` field, OAuth uses the profile's bound workspace.
- On 403, surfaces an actionable hint naming the credential source and workspace UUID prefix. The hint never includes the api_key value, the `Authorization: Bearer ...` header, or the literal `Authorization` substring (pinned by `test_request_403_hint_does_not_leak_api_key_or_bearer`).
- Drops the "fall through to OAuth profile's workspace_id" behavior of `.kagura.json:context_id == "auto"` — that fallthrough was the bug. With api_key from `.kagura.json`, `context_id` must be set explicitly or `--context-id` must be passed.

## Implementation notes

Four atomic commits split along architectural boundaries:

1. `refactor(auth)` — add `source: Literal["explicit","env","config"]` to `_StaticAuth` and `workspace_id: str | None` to `_OAuthAuth`. Adds `_AuthSource` (superset including `"oauth"`) and `_SOURCE_LABEL` dict as single source of truth. Pure refactor, no behavior change.
2. `fix(cli/files)` — wire workspace pairing through `_resolve_workspace_from_source` in `cli.py`, delete `_resolve_files_context_id`, return `(client, workspace_id)` pair from `_build_files_client`. Adds env-only / config-only edge case tests.
3. `feat(files)` — surface `_auth_source` + `_workspace_id_hint` on `FilesClient`, add `_from_resolved_auth` classmethod, format the 403 hint in `_request`. Adds leak prevention test.
4. `refactor(cli/files)` — `/simplify` review follow-ups: unify `_AuthSource`/`_SOURCE_LABEL` cross-module, thread `workspace_id_hint` through `_from_resolved_auth` for the static-config path (so the 403 hint no longer shows `workspace=<none>` for the most common bug-triggering setup), consolidate `_run_files_command`.

Plus the bundled `chore(deps)` commit synchronizing `uv.lock` with the `ingest` / `ingest-pdf` / `ingest-all` optional extras declared in `pyproject.toml` (left dangling from PR #109).

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (routed to CTO)
- review provider: copilot

### Behavior changes worth flagging to reviewers

- **`.kagura.json:context_id == "auto"` + static api_key** previously fell through to the OAuth profile's `workspace_id`. After this PR it raises a clear error pointing the operator at `--context-id` or `.kagura.json:context_id`. This is the bug being fixed (#115) — operators who depended on this fallthrough were silently mixing credential sources.
- **`KAGURA_API_KEY` env + OAuth profile + no `-c`** previously used the OAuth profile's workspace_id with the env-derived api_key. Now requires `--context-id` explicitly, since env-derived api_keys have no associated workspace source.
- **`FilesClient.__init__`** gained two private kwargs (`_auth_source`, `_workspace_id_hint`). Underscore-prefixed; SDK convention is "do not construct externally" — use `from_mcp_url` instead. No external callers identified by grep.

### Out of scope (filed separately)

- `ResourceClient` lacks OAuth fallback — discovered during Phase 2 exploration. Separate concern from #115's cross-source mixing class (ResourceClient has no `workspace_id` field on its REST surface). A follow-up issue is planned.
- The Files CLI's documented divergence from `KaguraClient`'s precedence order (config-wins vs env-wins) is noted in `_resolve_files_auth`'s docstring as a future-cleanup item.

### Quality gates

- `uv run pytest --ignore=tests/eval`: **673 passed, 1 skipped**
- `uv run ruff check src/ tests/`: **clean**
- `uv run ruff format --check src/ tests/`: **clean**
- `uv run pyright src/`: **0 errors, 0 warnings**

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/115-feat-fix-cli-files-build-files-client-mixes-c.gate1.md`
- `~/.claude/cache/gh-issue-driven/115-feat-fix-cli-files-build-files-client-mixes-c.gate2.md`

## Test plan

- [x] `pytest` — 673 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `pyright` — 0 errors
- [ ] Manual: `kagura files list` against a `.kagura.json` + OAuth-mixed setup → confirm new error message
- [ ] Manual: trigger a 403 (e.g. `-c <wrong-uuid>`) → confirm hint format and absence of api_key in output

🤖 Generated via /gh-issue-driven:ship
