### PR TITLE
feat(cli)!: unify credential resolution chain (#117, #118)

### DIFF
--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from .auth.credentials import KaguraOAuth, get_shared_state
 from .config import load_config
@@ -94,7 +94,7 @@ def _resolve_auth(
     api_key: str | None,
     mcp_url: str | None,
     profile: str | None,
-    config: dict | None = None,
+    config: dict[str, Any] | None = None,
 ) -> _StaticAuth | _OAuthAuth:
     """Pick a credential source per the documented precedence chain.
 

--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -94,11 +94,19 @@ def _resolve_auth(
     api_key: str | None,
     mcp_url: str | None,
     profile: str | None,
+    config: dict | None = None,
 ) -> _StaticAuth | _OAuthAuth:
     """Pick a credential source per the documented precedence chain.
 
     See :meth:`KaguraClient.__init__` for the full order. Raises
     :class:`KaguraAuthError` when no source produces credentials.
+
+    ``config`` is an optional pre-loaded ``.kagura.json`` dict. When
+    provided, the priority-4 fallback uses it directly instead of
+    re-invoking :func:`load_config`, so callers that have already
+    loaded the config (e.g. CLI commands needing ``context_id`` for
+    workspace pairing) avoid a redundant disk read. When ``None``,
+    :func:`load_config` is called as before.
     """
     # 1. Explicit constructor argument wins absolutely.
     # Empty / whitespace-only api_key is treated the same as None — sending
@@ -143,7 +151,7 @@ def _resolve_auth(
     # Apply the same whitespace-only strip check used for the explicit
     # arg and KAGURA_API_KEY env paths so a stray-whitespace config file
     # doesn't produce a guaranteed-401 `Authorization: Bearer ` header.
-    cfg = load_config()
+    cfg = config if config is not None else load_config()
     cfg_key = cfg.get("api_key", "")
     if cfg_key and cfg_key.strip():
         return _StaticAuth(

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -11,7 +11,6 @@ from typing import Any
 import click
 
 from ._auth import (
-    _DEFAULT_MCP_URL,
     _SOURCE_LABEL,
     _OAuthAuth,
     _resolve_auth,
@@ -1623,36 +1622,6 @@ def _resolve_workspace_from_source(
     )
 
 
-def _resolve_files_auth(config: dict[str, Any]) -> _StaticAuth | _OAuthAuth:
-    """Resolve credentials for the Files CLI with accurate source tagging.
-
-    Preserves the historic CLI precedence — ``.kagura.json`` api_key
-    wins over the env/OAuth chain — but tags the resolved auth as
-    ``source="config"`` instead of routing through ``_resolve_auth``'s
-    priority-1 (explicit) branch. That distinction is what
-    :func:`_resolve_workspace_from_source` reads to pair workspace_id
-    correctly (issue #115): if the api_key came from ``.kagura.json``,
-    the workspace_id must come from the same ``.kagura.json``.
-    """
-    cfg_key = (config.get("api_key") or "").strip()
-    if cfg_key:
-        return _StaticAuth(
-            api_key=cfg_key,
-            mcp_url=(config.get("mcp_url") or _DEFAULT_MCP_URL),
-            source="config",
-        )
-    # No config api_key — walk the rest of the resolver chain
-    # (env → OAuth profile → terminal raise). ``api_key=None`` keeps
-    # priority 1 unused; priority 4 (.kagura.json fallback inside
-    # _resolve_auth) is dead code here because we just confirmed
-    # config has no api_key.
-    return _resolve_auth(
-        api_key=None,
-        mcp_url=config.get("mcp_url") or None,
-        profile=os.getenv("KAGURA_PROFILE"),
-    )
-
-
 def _bound_workspace_for_hint(auth: _StaticAuth | _OAuthAuth, config: dict[str, Any]) -> str | None:
     """The workspace BOUND to the api_key source — for 403 hint display only.
 
@@ -1683,17 +1652,22 @@ def _run_files_command(
 ) -> None:
     """Execute a FilesClient operation with standard boilerplate.
 
-    When ``needs_context=True`` (the default), credential and
-    workspace_id are resolved together so they come from the same
-    source via :func:`_resolve_files_auth` +
-    :func:`_resolve_workspace_from_source`. When ``needs_context=False``
-    (file-id-based operations like ``download-url`` / ``delete``) only
-    the client is built; ``ctx_id`` is the empty string and operations
-    must ignore it.
+    Resolves credentials via :func:`_resolve_auth` (the canonical SDK
+    chain ``env > OAuth profile > .kagura.json``). When
+    ``needs_context=True`` (the default), workspace_id is resolved
+    from the same source via :func:`_resolve_workspace_from_source`.
+    When ``needs_context=False`` (file-id-based operations like
+    ``download-url`` / ``delete``) only the client is built; ``ctx_id``
+    is the empty string and operations must ignore it.
     """
     try:
         config = load_config()
-        auth = _resolve_files_auth(config)
+        auth = _resolve_auth(
+            api_key=None,
+            mcp_url=config.get("mcp_url") or None,
+            profile=os.getenv("KAGURA_PROFILE"),
+            config=config,
+        )
 
         ctx_id = ""
         if needs_context:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1052,22 +1052,24 @@ def _get_resource_client() -> ResourceClient:
     """Load config and create ResourceClient via the canonical SDK chain.
 
     Walks :func:`_resolve_auth`'s precedence (``env > OAuth profile >
-    .kagura.json``), matching the Files CLI (#118) and :class:`KaguraClient`.
-    OAuth-only operators can now run ``kagura resource ...`` end-to-end
-    except for ``kagura resource setup``, which currently requires a
-    static api_key (see :meth:`ResourceClient.setup_resource`).
+    .kagura.json``), matching :class:`FilesClient` and :class:`KaguraClient`.
+    OAuth-only operators can run all ``kagura resource`` commands except
+    ``kagura resource setup``, which currently requires a static api_key
+    (see :meth:`ResourceClient.setup_resource`).
     """
     from .exceptions import KaguraAuthError
 
     config = load_config()
     try:
-        return ResourceClient.from_mcp_url(
+        resolved = _resolve_auth(
             api_key=None,
             mcp_url=config.get("mcp_url") or None,
             profile=os.getenv("KAGURA_PROFILE"),
+            config=config,
         )
     except KaguraAuthError as e:
         raise click.ClickException(str(e)) from e
+    return ResourceClient._from_resolved_auth(resolved)
 
 
 def _get_kagura_client() -> KaguraClient:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1060,9 +1060,15 @@ def _get_resource_client() -> ResourceClient:
 
     config = load_config()
     try:
+        # mcp_url=None so each resolver branch pairs its credential with
+        # its own URL source (env → KAGURA_MCP_URL, OAuth → profile's
+        # stored mcp_url, config → .kagura.json's mcp_url). Forwarding
+        # ``config.get("mcp_url")`` here would override every branch
+        # with the config / env-default URL — including OAuth profiles
+        # bound to a non-default server (see PR #119 review).
         resolved = _resolve_auth(
             api_key=None,
-            mcp_url=config.get("mcp_url") or None,
+            mcp_url=None,
             profile=None,
             config=config,
         )
@@ -1674,9 +1680,14 @@ def _run_files_command(
     """
     try:
         config = load_config()
+        # mcp_url=None — let the resolver pair each credential source
+        # with its matching URL. Forwarding ``config.get("mcp_url")``
+        # would override OAuth profile's stored mcp_url with the
+        # config / env-default URL, routing OAuth users on a
+        # non-default server to the wrong host (see PR #119 review).
         auth = _resolve_auth(
             api_key=None,
-            mcp_url=config.get("mcp_url") or None,
+            mcp_url=None,
             profile=None,
             config=config,
         )

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1049,14 +1049,25 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
 
 
 def _get_resource_client() -> ResourceClient:
-    """Load config and create ResourceClient."""
+    """Load config and create ResourceClient via the canonical SDK chain.
+
+    Walks :func:`_resolve_auth`'s precedence (``env > OAuth profile >
+    .kagura.json``), matching the Files CLI (#118) and :class:`KaguraClient`.
+    OAuth-only operators can now run ``kagura resource ...`` end-to-end
+    except for ``kagura resource setup``, which currently requires a
+    static api_key (see :meth:`ResourceClient.setup_resource`).
+    """
+    from .exceptions import KaguraAuthError
+
     config = load_config()
-    if not config.get("api_key"):
-        raise click.ClickException("No API key found. Set KAGURA_API_KEY or create .kagura.json")
-    return ResourceClient.from_mcp_url(
-        api_key=config.get("api_key", ""),
-        mcp_url=config.get("mcp_url", "https://memory.kagura-ai.com/mcp"),
-    )
+    try:
+        return ResourceClient.from_mcp_url(
+            api_key=None,
+            mcp_url=config.get("mcp_url") or None,
+            profile=os.getenv("KAGURA_PROFILE"),
+        )
+    except KaguraAuthError as e:
+        raise click.ClickException(str(e)) from e
 
 
 def _get_kagura_client() -> KaguraClient:

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import os
 import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -1064,7 +1063,7 @@ def _get_resource_client() -> ResourceClient:
         resolved = _resolve_auth(
             api_key=None,
             mcp_url=config.get("mcp_url") or None,
-            profile=os.getenv("KAGURA_PROFILE"),
+            profile=None,
             config=config,
         )
     except KaguraAuthError as e:
@@ -1678,7 +1677,7 @@ def _run_files_command(
         auth = _resolve_auth(
             api_key=None,
             mcp_url=config.get("mcp_url") or None,
-            profile=os.getenv("KAGURA_PROFILE"),
+            profile=None,
             config=config,
         )
 

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -45,11 +45,14 @@ from .models import (
 _SETUP_OAUTH_NOT_SUPPORTED_MSG = (
     "setup_resource() is not yet available in OAuth mode. "
     "To run it, switch to a credential source that outranks OAuth: "
-    "set KAGURA_API_KEY (env wins over OAuth) and retry, or remove "
-    "the active OAuth profile (e.g. `kagura auth logout`, or "
-    "`kagura auth logout --profile <name>` for named profiles "
-    "selected via KAGURA_PROFILE) so .kagura.json is consulted. "
-    "The CRUD/ingest endpoints continue to work in OAuth mode."
+    "set KAGURA_API_KEY (and KAGURA_MCP_URL too if your api_key is "
+    "not for the default cloud server — the env branch uses "
+    "KAGURA_MCP_URL or the default URL, not the OAuth profile's "
+    "stored mcp_url) and retry, or remove the active OAuth profile "
+    "(e.g. `kagura auth logout`, or `kagura auth logout --profile <name>` "
+    "for named profiles selected via KAGURA_PROFILE) so .kagura.json "
+    "is consulted. The CRUD/ingest endpoints continue to work in "
+    "OAuth mode."
 )
 
 

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -37,11 +37,18 @@ from .models import (
 # Message surfaced when ``setup_resource`` is called on an OAuth-resolved
 # client. Defined at module scope so the CLI test can assert against the
 # stable constant instead of pinning a substring of the rendered output.
+#
+# The hint MUST point at a credential source that outranks OAuth in the
+# resolver chain (``env > OAuth profile > .kagura.json``). Suggesting
+# ``.kagura.json`` is misleading — it ranks BELOW OAuth and would still
+# be skipped while the OAuth profile is present.
 _SETUP_OAUTH_NOT_SUPPORTED_MSG = (
     "setup_resource() is not yet available in OAuth mode. "
-    "Re-authenticate with a static api_key (set KAGURA_API_KEY "
-    "or run `kagura setup claude` to seed .kagura.json) and "
-    "retry. The CRUD/ingest endpoints work in OAuth mode."
+    "To run it, switch to a credential source that outranks OAuth: "
+    "set KAGURA_API_KEY (env wins over OAuth) and retry, or run "
+    "`kagura auth logout` first to remove the OAuth profile so "
+    ".kagura.json is consulted. The CRUD/ingest endpoints continue "
+    "to work in OAuth mode."
 )
 
 

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -45,10 +45,11 @@ from .models import (
 _SETUP_OAUTH_NOT_SUPPORTED_MSG = (
     "setup_resource() is not yet available in OAuth mode. "
     "To run it, switch to a credential source that outranks OAuth: "
-    "set KAGURA_API_KEY (env wins over OAuth) and retry, or run "
-    "`kagura auth logout` first to remove the OAuth profile so "
-    ".kagura.json is consulted. The CRUD/ingest endpoints continue "
-    "to work in OAuth mode."
+    "set KAGURA_API_KEY (env wins over OAuth) and retry, or remove "
+    "the active OAuth profile (e.g. `kagura auth logout`, or "
+    "`kagura auth logout --profile <name>` for named profiles "
+    "selected via KAGURA_PROFILE) so .kagura.json is consulted. "
+    "The CRUD/ingest endpoints continue to work in OAuth mode."
 )
 
 

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -34,6 +34,16 @@ from .models import (
     ResourceTokenUpdate,
 )
 
+# Message surfaced when ``setup_resource`` is called on an OAuth-resolved
+# client. Defined at module scope so the CLI test can assert against the
+# stable constant instead of pinning a substring of the rendered output.
+_SETUP_OAUTH_NOT_SUPPORTED_MSG = (
+    "setup_resource() is not yet available in OAuth mode. "
+    "Re-authenticate with a static api_key (set KAGURA_API_KEY "
+    "or run `kagura setup claude` to seed .kagura.json) and "
+    "retry. The CRUD/ingest endpoints work in OAuth mode."
+)
+
 
 class ResourceClient:
     """REST API client for Kagura Memory Cloud Resource Tokens.
@@ -153,9 +163,7 @@ class ResourceClient:
                 ``default_profile``).
         """
         resolved = _resolve_auth(api_key=api_key, mcp_url=mcp_url, profile=profile)
-        instance = cls._from_resolved_auth(resolved, timeout=timeout)
-        instance._mcp_url = resolved.mcp_url.rstrip("/")
-        return instance
+        return cls._from_resolved_auth(resolved, timeout=timeout)
 
     @classmethod
     def _from_resolved_auth(
@@ -170,21 +178,28 @@ class ResourceClient:
         :meth:`FilesClient._from_resolved_auth` so the two REST clients
         share one construction shape; downstream code (including the
         CLI's ``_run_resource_command``) can treat them symmetrically.
+
+        Stores ``mcp_url`` on the instance so :meth:`setup_resource` can
+        reach the MCP endpoint — the resolved auth always carries one,
+        whether sourced from the OAuth profile or the priority-4 config.
         """
         base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
         if isinstance(resolved, _StaticAuth):
-            return cls(
+            instance = cls(
                 api_key=resolved.api_key,
                 base_url=base_url,
                 timeout=timeout,
                 _auth_source=resolved.source,
             )
-        return cls(
-            base_url=base_url,
-            timeout=timeout,
-            _oauth=resolved.oauth,
-            _auth_source="oauth",
-        )
+        else:
+            instance = cls(
+                base_url=base_url,
+                timeout=timeout,
+                _oauth=resolved.oauth,
+                _auth_source="oauth",
+            )
+        instance._mcp_url = resolved.mcp_url.rstrip("/")
+        return instance
 
     async def _request(
         self,
@@ -377,17 +392,12 @@ class ResourceClient:
             )
 
         if self._oauth is not None:
-            # OAuth-mode setup is intentionally out of scope for #117 —
             # ``KaguraClient`` does not yet accept the resolved
-            # ``KaguraOAuth`` httpx.Auth, and threading it through is a
-            # larger surface change. Surface an actionable message so
-            # the operator knows the workaround.
-            raise NotImplementedError(
-                "setup_resource() is not yet available in OAuth mode. "
-                "Re-authenticate with a static api_key (set KAGURA_API_KEY "
-                "or run `kagura setup claude` to seed .kagura.json) and "
-                "retry. The CRUD/ingest endpoints work in OAuth mode."
-            )
+            # ``KaguraOAuth`` httpx.Auth, so the underlying MCP call
+            # in this method cannot be authenticated without a static
+            # api_key. Surface the workaround instead of failing with
+            # a header-scraping error a few lines down.
+            raise NotImplementedError(_SETUP_OAUTH_NOT_SUPPORTED_MSG)
 
         auth = self._client.headers.get("authorization", "")
         if not auth.startswith("Bearer "):

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -6,7 +6,9 @@ from typing import Any, Literal
 
 import httpx
 
+from ._auth import _AuthSource, _OAuthAuth, _resolve_auth, _StaticAuth
 from ._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
+from .auth.credentials import KaguraOAuth
 from .client import KaguraClient
 from .exceptions import (
     KaguraAuthError,
@@ -49,52 +51,140 @@ class ResourceClient:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         base_url: str = "https://memory.kagura-ai.com",
         timeout: float = 30.0,
+        *,
+        _oauth: KaguraOAuth | None = None,
+        _auth_source: _AuthSource | None = None,
     ) -> None:
-        """Initialize ResourceClient.
+        """Initialize ResourceClient with a static API key.
+
+        For OAuth profile resolution (the auto chain env → ``~/.kagura/
+        credentials.json`` → ``.kagura.json``), use :meth:`from_mcp_url`
+        which runs the resolver and selects the right transport.
 
         Args:
-            api_key: Kagura API key (Bearer token for CRUD operations).
+            api_key: Kagura API key (Bearer token). Required unless
+                ``_oauth`` is supplied (see ``from_mcp_url``).
             base_url: REST API base URL (without path).
             timeout: Request timeout in seconds.
+            _oauth: Private. ``from_mcp_url`` passes a ``KaguraOAuth``
+                instance for OAuth profile authentication. Public
+                callers should not set this.
+            _auth_source: Private. Provenance tag describing which
+                ``_resolve_auth`` branch produced the credentials.
+                Stored for parity with :class:`FilesClient` so future
+                surfaces (e.g. 403 hints) can reuse the convention.
+
+        Raises:
+            ValueError: If neither ``api_key`` nor ``_oauth`` is given.
+                The OAuth path is intentionally not auto-resolved here
+                so that bare ``ResourceClient()`` does not silently read
+                ``~/.kagura/credentials.json`` — that's the
+                ``from_mcp_url`` factory's job.
         """
+        if api_key is None and _oauth is None:
+            raise ValueError(
+                "ResourceClient requires api_key, or use ResourceClient.from_mcp_url(...) "
+                "to resolve credentials from environment, OAuth profile, or .kagura.json."
+            )
+
         stripped_url = base_url.rstrip("/")
         validate_https_url(stripped_url, label="Base URL")
 
         self.base_url = stripped_url
         self._mcp_url: str | None = None  # Set by from_mcp_url for setup_resource
-        self._client = httpx.AsyncClient(
-            timeout=timeout,
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "User-Agent": f"kagura-memory-sdk/{SDK_VERSION}",
-            },
-        )
+        # ``_oauth`` is stored because :meth:`setup_resource` branches on it
+        # to refuse OAuth mode (constructing a KaguraClient from a static
+        # api_key scraped out of the Authorization header would not work
+        # when the header is absent in the OAuth path).
+        self._oauth: KaguraOAuth | None = _oauth
+        self._auth_source: _AuthSource | None = _auth_source
+        if _oauth is not None:
+            # OAuth path: KaguraOAuth injects a fresh access_token per request
+            # and coordinates refresh via the process-wide credentials lock.
+            self._client = httpx.AsyncClient(
+                timeout=timeout,
+                headers={"User-Agent": f"kagura-memory-sdk/{SDK_VERSION}"},
+                auth=_oauth,
+            )
+        else:
+            # Static path: bake the bearer header once. ``api_key`` is not
+            # stored as an instance attribute (per python.md "Never store
+            # API keys as instance attributes").
+            self._client = httpx.AsyncClient(
+                timeout=timeout,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": f"kagura-memory-sdk/{SDK_VERSION}",
+                },
+            )
 
     @classmethod
     def from_mcp_url(
         cls,
-        api_key: str,
-        mcp_url: str = "https://memory.kagura-ai.com/mcp",
+        api_key: str | None = None,
+        mcp_url: str | None = None,
         timeout: float = 30.0,
+        *,
+        profile: str | None = None,
     ) -> ResourceClient:
-        """Create ResourceClient by deriving base URL from MCP URL.
+        """Create ResourceClient by resolving credentials from the SDK chain.
 
-        Strips ``/mcp`` and everything after it to get the REST API base URL.
-        Handles both ``/mcp`` and ``/mcp/w/{workspace_id}`` formats.
+        Runs :func:`_resolve_auth` with the same precedence chain as
+        :class:`KaguraClient` and :class:`FilesClient`: explicit
+        ``api_key`` > ``KAGURA_API_KEY`` env > OAuth profile from
+        ``~/.kagura/credentials.json`` > ``.kagura.json``. The chosen
+        credential source picks the transport: a static API key bakes
+        the Bearer header once; an OAuth profile installs a
+        ``KaguraOAuth`` httpx.Auth handler with automatic refresh.
+
+        The REST ``base_url`` is derived from the resolved ``mcp_url``
+        (strips ``/mcp`` and any ``/mcp/w/{workspace_id}`` suffix).
 
         Args:
-            api_key: Kagura API key.
-            mcp_url: MCP server URL (e.g. ``https://memory.kagura-ai.com/mcp``).
+            api_key: Explicit Kagura API key. Skips the resolution chain.
+            mcp_url: Explicit MCP URL. When omitted, the OAuth profile's
+                stored ``mcp_url`` is used (or the default).
             timeout: Request timeout in seconds.
+            profile: Named OAuth profile to load (overrides
+                ``KAGURA_PROFILE`` env and the credentials file's
+                ``default_profile``).
         """
-        url = mcp_url.rstrip("/")
-        base_url = base_url_from_mcp(url)
-        instance = cls(api_key=api_key, base_url=base_url, timeout=timeout)
-        instance._mcp_url = mcp_url.rstrip("/")
+        resolved = _resolve_auth(api_key=api_key, mcp_url=mcp_url, profile=profile)
+        instance = cls._from_resolved_auth(resolved, timeout=timeout)
+        instance._mcp_url = resolved.mcp_url.rstrip("/")
         return instance
+
+    @classmethod
+    def _from_resolved_auth(
+        cls,
+        resolved: _StaticAuth | _OAuthAuth,
+        *,
+        timeout: float = 30.0,
+    ) -> ResourceClient:
+        """Construct from a pre-resolved auth — internal CLI helper.
+
+        Shared by :meth:`from_mcp_url` (SDK entry) and the CLI. Mirrors
+        :meth:`FilesClient._from_resolved_auth` so the two REST clients
+        share one construction shape; downstream code (including the
+        CLI's ``_run_resource_command``) can treat them symmetrically.
+        """
+        base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
+        if isinstance(resolved, _StaticAuth):
+            return cls(
+                api_key=resolved.api_key,
+                base_url=base_url,
+                timeout=timeout,
+                _auth_source=resolved.source,
+            )
+        return cls(
+            base_url=base_url,
+            timeout=timeout,
+            _oauth=resolved.oauth,
+            _auth_source="oauth",
+        )
 
     async def _request(
         self,
@@ -267,7 +357,13 @@ class ResourceClient:
 
         Raises:
             RuntimeError: If client was not created via ``from_mcp_url()``.
-            KaguraAuthError: If the stored Authorization header is missing or malformed.
+            NotImplementedError: If the client was constructed via the
+                OAuth resolution path. ``setup_resource`` currently
+                requires a static api_key because the underlying MCP
+                client construction does not yet accept the OAuth
+                httpx.Auth instance. Track follow-up work to lift this.
+            KaguraAuthError: If the stored Authorization header is
+                missing or malformed in the static path.
 
         Note:
             Idempotency for repeated calls with the same ``resource_id`` is
@@ -278,6 +374,19 @@ class ResourceClient:
             raise RuntimeError(
                 "setup_resource() requires MCP URL. "
                 "Create client via ResourceClient.from_mcp_url()."
+            )
+
+        if self._oauth is not None:
+            # OAuth-mode setup is intentionally out of scope for #117 —
+            # ``KaguraClient`` does not yet accept the resolved
+            # ``KaguraOAuth`` httpx.Auth, and threading it through is a
+            # larger surface change. Surface an actionable message so
+            # the operator knows the workaround.
+            raise NotImplementedError(
+                "setup_resource() is not yet available in OAuth mode. "
+                "Re-authenticate with a static api_key (set KAGURA_API_KEY "
+                "or run `kagura setup claude` to seed .kagura.json) and "
+                "retry. The CRUD/ingest endpoints work in OAuth mode."
             )
 
         auth = self._client.headers.get("authorization", "")

--- a/src/kagura_memory/resource_client.py
+++ b/src/kagura_memory/resource_client.py
@@ -242,7 +242,12 @@ class ResourceClient:
         except httpx.HTTPStatusError as e:
             status = e.response.status_code
             if status == 401:
-                raise KaguraAuthError("Authentication failed. Check your API key.") from e
+                hint = (
+                    "Re-run `kagura auth login` or inspect ~/.kagura/credentials.json."
+                    if self._oauth is not None
+                    else "Check your API key."
+                )
+                raise KaguraAuthError(f"Authentication failed. {hint}") from e
             if status == 404:
                 raise KaguraNotFoundError(extract_detail(e.response) or "Not found") from e
             if status == 429:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,41 @@
 """Shared pytest fixtures and helpers."""
 
+from datetime import UTC, datetime, timedelta
+
+from kagura_memory.auth.credentials import OAuthCredentials
+
+
+def make_oauth_creds(
+    workspace_id: str = "00000000-0000-0000-0000-0000000000ff",
+    expires_in_seconds: int = 3600,
+    *,
+    server: str = "https://memory.kagura-ai.com",
+    access_token: str = "atok-test",
+    workspace_name: str = "test-ws",
+    user_email: str = "test@example.com",
+) -> OAuthCredentials:
+    """Build a usable ``OAuthCredentials`` fixture for any client test.
+
+    Defaults match a healthy, non-expired credential bound to a workspace.
+    Tests that need a specific scenario (near-expiry, missing workspace,
+    etc.) override only the field they care about; everything else has
+    sensible neutral defaults shared across client/CLI test suites.
+    """
+    return OAuthCredentials(
+        server=server,
+        mcp_url=f"{server.rstrip('/')}/mcp",
+        client_id="kagura-cli",
+        access_token=access_token,
+        refresh_token="rtok-test",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
+        scope="memory:read memory:write",
+        workspace_id=workspace_id,
+        workspace_name=workspace_name,
+        user_email=user_email,
+        issued_at=datetime.now(UTC),
+    )
+
 
 def sleep_report_summary_dict(report_id: str = "rid-1") -> dict:
     """Build a server-shaped Sleep Maintenance summary dict for tests.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,35 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
+from kagura_memory.auth.credentials import reset_state_cache
 from kagura_memory.cli import _parse_tags, main
 from tests.conftest import sleep_report_summary_dict
+
+
+@pytest.fixture(autouse=True)
+def _isolate_credential_state(tmp_path, monkeypatch):
+    """Isolate every test from real ``~/.kagura/credentials.json`` and env vars.
+
+    Several CLI helpers (``_get_resource_client``, ``_run_files_command``)
+    now walk the canonical SDK chain (``env > OAuth profile > .kagura.json``)
+    via ``_resolve_auth``. Without this isolation, a developer's stored
+    OAuth profile or a stale ``KAGURA_PROFILE`` could pre-empt the
+    config-only fixtures used by the resource / context tests below
+    and make them flaky across machines.
+    """
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "default-credentials.json",
+    )
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    reset_state_cache()
+    yield
+    reset_state_cache()
 
 
 def test_parse_tags():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -485,6 +485,7 @@ def test_resource_stats(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(main, ["resource", "stats", "-r", "products"])
@@ -507,6 +508,7 @@ def test_resource_schema(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(main, ["resource", "schema", "-r", "products"])
@@ -526,6 +528,7 @@ def test_resource_schema_not_registered(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(main, ["resource", "schema", "-r", "no-schema"])
@@ -546,6 +549,7 @@ def test_resource_setup(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(main, ["resource", "setup", "-r", "products", "-s", "catalog"])
@@ -565,6 +569,7 @@ def test_resource_list(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(main, ["resource", "list"])
@@ -587,6 +592,7 @@ def test_resource_indexer_status(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(main, ["resource", "indexer-status", "-r", "products"])
@@ -606,6 +612,7 @@ def test_resource_import_csv(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     csv_content = "name,price\nWidget,9.99\nGadget,19.99\nThing,29.99"
     runner = CliRunner()
@@ -629,6 +636,7 @@ def test_resource_import_jsonl(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     jsonl = '{"name":"A"}\n{"name":"B"}'
     runner = CliRunner()
@@ -688,6 +696,7 @@ def test_resource_import_json(mock_rc_cls, mock_config):
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -372,15 +372,20 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
 
 
 def test_files_upload_oauth_wins_over_config_when_both_present(monkeypatch, tmp_path):
-    """``.kagura.json`` api_key + OAuth profile (no env, no -c) → OAuth wins.
+    """``.kagura.json`` api_key + OAuth profile (no env, no -c) → OAuth wins for credential pairing.
 
     Issue #118 aligned the Files CLI with the SDK chain
     ``env > OAuth > .kagura.json``. When both config api_key and an
-    OAuth profile exist, OAuth wins entirely: the api_key comes from
-    OAuth (Bearer header via ``KaguraOAuth``) and the workspace_id
-    comes from the same OAuth profile — so #115's same-source pairing
-    invariant is preserved structurally rather than via the previous
-    "reject auto sentinel with config api_key" guard.
+    OAuth profile exist, OAuth wins for the **credential pairing**:
+    api_key comes from OAuth (Bearer header via ``KaguraOAuth``) and
+    workspace_id comes from the same OAuth profile, so #115's
+    same-source invariant is preserved structurally.
+
+    Note: ``mcp_url`` follows the project-wide override convention
+    shared with ``KaguraClient`` — if ``config.mcp_url`` were set, it
+    would still win regardless of which credential source applied.
+    This test leaves ``config.mcp_url`` unset, so OAuth's stored
+    ``mcp_url`` reaches the wire as expected.
     """
     fake_creds_path = tmp_path / "credentials.json"
     monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -372,20 +372,19 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
 
 
 def test_files_upload_oauth_wins_over_config_when_both_present(monkeypatch, tmp_path):
-    """``.kagura.json`` api_key + OAuth profile (no env, no -c) → OAuth wins for credential pairing.
+    """``.kagura.json`` api_key + OAuth profile (no env, no -c) → OAuth wins entirely.
 
     Issue #118 aligned the Files CLI with the SDK chain
     ``env > OAuth > .kagura.json``. When both config api_key and an
-    OAuth profile exist, OAuth wins for the **credential pairing**:
-    api_key comes from OAuth (Bearer header via ``KaguraOAuth``) and
-    workspace_id comes from the same OAuth profile, so #115's
-    same-source invariant is preserved structurally.
+    OAuth profile exist, OAuth wins entirely for the credential
+    triple: ``api_key`` (Bearer via ``KaguraOAuth``), ``workspace_id``,
+    and ``mcp_url`` all come from the same OAuth profile (the
+    same-source invariant from #115, preserved structurally).
 
-    Note: ``mcp_url`` follows the project-wide override convention
-    shared with ``KaguraClient`` — if ``config.mcp_url`` were set, it
-    would still win regardless of which credential source applied.
-    This test leaves ``config.mcp_url`` unset, so OAuth's stored
-    ``mcp_url`` reaches the wire as expected.
+    The CLI passes ``mcp_url=None`` to the resolver so each priority
+    branch pairs its credential with its own URL source — see
+    ``test_cli_resource.py::test_resource_list_oauth_profile_mcp_url_not_overridden_by_config``
+    for the dedicated regression test on the URL pairing.
     """
     fake_creds_path = tmp_path / "credentials.json"
     monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -415,6 +415,18 @@ def test_files_upload_oauth_wins_over_config_when_both_present(monkeypatch, tmp_
     assert result.exit_code == 0, result.output
     mock_client.upload.assert_awaited_once()
     assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
+    # Pin the credential source explicitly — an `upload(context_id=…)`
+    # assertion alone could pass even if config silently won the api_key
+    # race, because the OAuth profile and config both target
+    # ``SAMPLE_CTX_ID`` in this fixture. Inspecting the resolved auth
+    # locks "OAuth wins entirely" rather than "the right workspace
+    # happened to be selected" (per PR #119 review feedback).
+    from kagura_memory._auth import _OAuthAuth
+
+    resolved = mock_client_cls._from_resolved_auth.call_args.args[0]
+    assert isinstance(resolved, _OAuthAuth), (
+        f"OAuth profile should win; got {type(resolved).__name__}"
+    )
 
 
 def test_files_upload_env_wins_over_config_api_key(monkeypatch, tmp_path):

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from kagura_memory.auth.credentials import (
@@ -13,6 +14,28 @@ from kagura_memory.auth.credentials import (
 )
 from kagura_memory.cli import main
 from kagura_memory.models import FileListResponse, FileObject
+
+
+@pytest.fixture(autouse=True)
+def _isolate_oauth_state(tmp_path, monkeypatch):
+    """Isolate every test from real ``~/.kagura/credentials.json`` and env.
+
+    Post-issue #118 the Files CLI walks the canonical SDK chain
+    (``env > OAuth profile > .kagura.json``), so any OAuth profile a
+    developer has stored on their machine would otherwise pre-empt the
+    config-only test fixtures and silently change behavior. Each test
+    starts from a clean credentials path and clean env; tests that need
+    OAuth state set it up explicitly.
+    """
+    fake_path = tmp_path / "default-credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    reset_state_cache()
+    yield
+    reset_state_cache()
+
 
 SAMPLE_CTX_ID = "00000000-0000-0000-0000-000000000001"
 SAMPLE_FILE_ID = "10000000-0000-0000-0000-000000000002"
@@ -348,20 +371,19 @@ def test_files_upload_uses_oauth_workspace_id_when_no_context(monkeypatch, tmp_p
     assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
 
 
-def test_files_upload_rejects_auto_sentinel_with_config_api_key(monkeypatch, tmp_path):
-    """``.kagura.json:context_id == "auto"`` + config api_key + OAuth profile → reject.
+def test_files_upload_oauth_wins_over_config_when_both_present(monkeypatch, tmp_path):
+    """``.kagura.json`` api_key + OAuth profile (no env, no -c) → OAuth wins.
 
-    Before issue #115 the CLI silently fell through to the OAuth
-    profile's ``workspace_id`` when ``context_id`` was ``"auto"``,
-    even though the api_key came from a different source. That
-    cross-source pairing is the bug; with #115, this scenario now
-    raises a clear error pointing the operator at ``--context-id`` or
-    ``.kagura.json``'s ``context_id`` field.
+    Issue #118 aligned the Files CLI with the SDK chain
+    ``env > OAuth > .kagura.json``. When both config api_key and an
+    OAuth profile exist, OAuth wins entirely: the api_key comes from
+    OAuth (Bearer header via ``KaguraOAuth``) and the workspace_id
+    comes from the same OAuth profile — so #115's same-source pairing
+    invariant is preserved structurally rather than via the previous
+    "reject auto sentinel with config api_key" guard.
     """
     fake_creds_path = tmp_path / "credentials.json"
     monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_creds_path)
-    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
-    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
 
     cf = CredentialsFile()
     cf.set_profile("default", _oauth_creds_with_workspace(SAMPLE_CTX_ID))
@@ -370,10 +392,15 @@ def test_files_upload_rejects_auto_sentinel_with_config_api_key(monkeypatch, tmp
 
     from kagura_memory.cli import _CONTEXT_ID_AUTO
 
-    with patch(
-        "kagura_memory.cli.load_config",
-        return_value={"api_key": "key", "context_id": _CONTEXT_ID_AUTO},
+    mock_client = _mock_files_client("upload", _file_object())
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={"api_key": "key", "context_id": _CONTEXT_ID_AUTO},
+        ),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
     ):
+        _wire_files_client_mock(mock_client_cls, mock_client)
         p = tmp_path / "hello.txt"
         p.write_text("hi")
         runner = CliRunner()
@@ -381,9 +408,46 @@ def test_files_upload_rejects_auto_sentinel_with_config_api_key(monkeypatch, tmp
 
     reset_state_cache()
 
-    assert result.exit_code != 0, result.output
-    assert "context_id is missing" in result.output or '"auto"' in result.output
-    assert "--context-id" in result.output
+    assert result.exit_code == 0, result.output
+    mock_client.upload.assert_awaited_once()
+    assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
+
+
+def test_files_upload_env_wins_over_config_api_key(monkeypatch, tmp_path):
+    """``KAGURA_API_KEY`` env + ``.kagura.json`` api_key + ``-c`` → env wins (#118 BREAKING).
+
+    Pre-#118 the Files CLI used a ``config > env > OAuth`` precedence,
+    so a session with both env and config api_key set would silently
+    pick config. Post-#118 the Files CLI walks the canonical SDK chain
+    (``env > OAuth > config``), aligning with ``KaguraClient``. The
+    env api_key has no workspace source, so ``-c`` is required —
+    asserting it explicitly threads through and the upload proceeds
+    locks the new precedence in place against a future revert.
+    """
+    monkeypatch.setenv("KAGURA_API_KEY", "env-key")
+
+    mock_client = _mock_files_client("upload", _file_object())
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={"api_key": "config-key", "context_id": "should-be-ignored"},
+        ),
+        patch("kagura_memory.cli.FilesClient") as mock_client_cls,
+    ):
+        _wire_files_client_mock(mock_client_cls, mock_client)
+        p = tmp_path / "hello.txt"
+        p.write_text("hi")
+        runner = CliRunner()
+        result = runner.invoke(main, ["files", "upload", str(p), "-c", SAMPLE_CTX_ID])
+
+    assert result.exit_code == 0, result.output
+    mock_client.upload.assert_awaited_once()
+    assert mock_client.upload.call_args.kwargs["context_id"] == SAMPLE_CTX_ID
+    # FilesClient was constructed via _from_resolved_auth — inspect the
+    # _StaticAuth that flowed through to verify the env path won.
+    resolved = mock_client_cls._from_resolved_auth.call_args.args[0]
+    assert resolved.source == "env"
+    assert resolved.api_key == "env-key"
 
 
 def test_files_upload_rejects_env_api_key_without_context(monkeypatch, tmp_path):

--- a/tests/test_cli_resource.py
+++ b/tests/test_cli_resource.py
@@ -24,10 +24,11 @@ from tests.conftest import make_oauth_creds
 def _isolate_oauth_state(tmp_path, monkeypatch):
     """Isolate every test from real ``~/.kagura/credentials.json`` and env.
 
-    Mirrors the autouse isolation added in ``test_cli_files.py`` for the
-    same reason: the post-#117 resolver consults the OAuth profile before
+    The post-issue-#117 resolver consults the OAuth profile before
     ``.kagura.json``, so a developer's stored profile would otherwise
-    pre-empt config-only fixtures.
+    pre-empt config-only fixtures. Yields the redirected credentials path
+    so tests that need to write an OAuth profile can target it without
+    re-importing the patched module attribute.
     """
     fake_path = tmp_path / "default-credentials.json"
     monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_path)
@@ -35,7 +36,7 @@ def _isolate_oauth_state(tmp_path, monkeypatch):
     monkeypatch.delenv("KAGURA_PROFILE", raising=False)
     monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
     reset_state_cache()
-    yield
+    yield fake_path
     reset_state_cache()
 
 
@@ -86,16 +87,21 @@ def test_resource_list_uses_env_api_key(monkeypatch):
     assert resolved.api_key == "env-key"
 
 
-def test_resource_list_uses_oauth_profile():
-    """OAuth profile on disk + no env + no config → ResourceClient built via OAuth path."""
-    # The autouse fixture redirected DEFAULT_CREDENTIALS_PATH; write the
-    # profile there so the resolver finds it during priority-3.
-    import kagura_memory.auth.credentials as _creds
+def test_resource_list_uses_oauth_profile(_isolate_oauth_state):
+    """OAuth profile on disk + no env + no config → ResourceClient built via OAuth path.
+
+    Pins that api_key + workspace_id come from the OAuth profile (the
+    same-source pairing invariant from #115). The ``mcp_url`` paired
+    with the resolved credential follows the project-wide override
+    convention shared with ``KaguraClient`` (``config.mcp_url`` wins if
+    set; this test leaves it unset, so the OAuth profile's stored
+    ``mcp_url`` is what reaches the wire).
+    """
     from kagura_memory._auth import _OAuthAuth
 
     cf = CredentialsFile()
     cf.set_profile("default", make_oauth_creds())
-    save_credentials_file(cf, _creds.DEFAULT_CREDENTIALS_PATH)
+    save_credentials_file(cf, _isolate_oauth_state)
     reset_state_cache()
 
     mock_client = _mock_resource_client()
@@ -146,20 +152,18 @@ def test_resource_list_no_credentials_errors():
     assert "No credentials" in result.output or "kagura auth login" in result.output
 
 
-def test_resource_setup_in_oauth_mode_errors():
+def test_resource_setup_in_oauth_mode_errors(_isolate_oauth_state):
     """OAuth-mode ``kagura resource setup`` surfaces the NotImplementedError as a clean CLI error.
 
     ``ResourceClient.setup_resource`` raises ``NotImplementedError`` in
-    OAuth mode (intentionally out of scope for #117). ``_run_resource_command``
-    wraps unexpected exceptions in ``ClickException`` so the operator
-    sees a clean error message and an actionable hint instead of a
-    traceback.
+    OAuth mode (the underlying ``KaguraClient`` MCP call does not yet
+    accept an OAuth httpx.Auth). ``_run_resource_command`` wraps
+    unexpected exceptions in ``ClickException`` so the operator sees a
+    clean error message and an actionable hint instead of a traceback.
     """
-    import kagura_memory.auth.credentials as _creds
-
     cf = CredentialsFile()
     cf.set_profile("default", make_oauth_creds())
-    save_credentials_file(cf, _creds.DEFAULT_CREDENTIALS_PATH)
+    save_credentials_file(cf, _isolate_oauth_state)
     reset_state_cache()
 
     with patch("kagura_memory.cli.load_config", return_value={}):

--- a/tests/test_cli_resource.py
+++ b/tests/test_cli_resource.py
@@ -90,12 +90,11 @@ def test_resource_list_uses_env_api_key(monkeypatch):
 def test_resource_list_uses_oauth_profile(_isolate_oauth_state):
     """OAuth profile on disk + no env + no config → ResourceClient built via OAuth path.
 
-    Pins that api_key + workspace_id come from the OAuth profile (the
-    same-source pairing invariant from #115). The ``mcp_url`` paired
-    with the resolved credential follows the project-wide override
-    convention shared with ``KaguraClient`` (``config.mcp_url`` wins if
-    set; this test leaves it unset, so the OAuth profile's stored
-    ``mcp_url`` is what reaches the wire).
+    Pins that api_key + workspace_id + mcp_url all come from the OAuth
+    profile (the same-source pairing invariant from #115). The CLI
+    passes ``mcp_url=None`` to the resolver so each priority branch
+    pairs its credential with its own URL source — for the OAuth
+    branch that's the profile's stored ``mcp_url``.
     """
     from kagura_memory._auth import _OAuthAuth
 
@@ -178,6 +177,52 @@ def test_resource_setup_in_oauth_mode_errors(_isolate_oauth_state):
     # ``_run_resource_command`` wraps exceptions in ``ClickException(str(e))``
     # so the operator sees the full message verbatim in the output.
     assert _SETUP_OAUTH_NOT_SUPPORTED_MSG in result.output
+
+
+def test_resource_list_oauth_profile_mcp_url_not_overridden_by_config(_isolate_oauth_state):
+    """OAuth profile's stored ``mcp_url`` must reach the wire when the
+    OAuth branch resolves the credential, even when ``.kagura.json``
+    (or its env-default fallback) supplies a different ``mcp_url``.
+
+    Regression test for a bug surfaced in PR #119 review: the CLI used
+    to forward ``config.get("mcp_url") or None`` as the explicit
+    ``mcp_url`` argument to ``_resolve_auth``. Because ``load_config()``
+    returns the default cloud URL when ``.kagura.json`` is absent, the
+    override path fired on every OAuth-only invocation — routing
+    OAuth users bound to a non-default server to the default cloud
+    host. The fix passes ``mcp_url=None`` so each resolver branch
+    pairs its credential with its own URL source.
+    """
+    custom_url = "https://custom.example.com/mcp"
+    cf = CredentialsFile()
+    cf.set_profile(
+        "default",
+        make_oauth_creds(server="https://custom.example.com"),
+    )
+    save_credentials_file(cf, _isolate_oauth_state)
+    reset_state_cache()
+
+    mock_client = _mock_resource_client()
+    mock_client.list_resources.return_value = MagicMock(model_dump_json=lambda **_: "{}")
+
+    # Config supplies a DIFFERENT mcp_url to ensure the OAuth branch
+    # wins by URL — not just by api_key.
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={"mcp_url": "https://stale-config.example.com/mcp"},
+        ),
+        patch("kagura_memory.cli.ResourceClient") as mock_cls,
+    ):
+        _wire_resource_client_mock(mock_cls, mock_client)
+        runner = CliRunner()
+        result = runner.invoke(main, ["resource", "list"])
+
+    assert result.exit_code == 0, result.output
+    resolved = _resolved_from_call(mock_cls)
+    assert resolved.mcp_url == custom_url, (
+        f"OAuth profile's stored mcp_url should win, got {resolved.mcp_url}"
+    )
 
 
 def test_resource_list_env_wins_over_config_api_key(monkeypatch):

--- a/tests/test_cli_resource.py
+++ b/tests/test_cli_resource.py
@@ -1,0 +1,222 @@
+"""Tests for `kagura resource ...` CLI commands.
+
+Focused on the post-#117 credential resolution chain: `_get_resource_client`
+now walks `_resolve_auth` (env > OAuth profile > .kagura.json) instead of
+short-circuiting on `.kagura.json` only. Matches the Files CLI matrix
+(post-#118) so an OAuth-only operator can run `kagura resource ...`
+end-to-end, except for `kagura resource setup` which is documented as
+static-api_key-only in #117.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from kagura_memory.auth.credentials import (
+    CredentialsFile,
+    OAuthCredentials,
+    reset_state_cache,
+    save_credentials_file,
+)
+from kagura_memory.cli import main
+
+
+@pytest.fixture(autouse=True)
+def _isolate_oauth_state(tmp_path, monkeypatch):
+    """Isolate every test from real ``~/.kagura/credentials.json`` and env.
+
+    Mirrors the autouse isolation added in ``test_cli_files.py`` for the
+    same reason: the post-#117 resolver consults the OAuth profile before
+    ``.kagura.json``, so a developer's stored profile would otherwise
+    pre-empt config-only fixtures.
+    """
+    fake_path = tmp_path / "default-credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    reset_state_cache()
+    yield
+    reset_state_cache()
+
+
+def _make_oauth_creds(
+    workspace_id: str = "00000000-0000-0000-0000-0000000000ff",
+    expires_in_seconds: int = 3600,
+) -> OAuthCredentials:
+    return OAuthCredentials(
+        server="https://memory.kagura-ai.com",
+        mcp_url="https://memory.kagura-ai.com/mcp",
+        client_id="kagura-cli",
+        access_token="atok-cli-resource-test",
+        refresh_token="rtok-cli-resource-test",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
+        scope="memory:read memory:write",
+        workspace_id=workspace_id,
+        workspace_name="cli-resource-test",
+        user_email="resource@example.com",
+        issued_at=datetime.now(UTC),
+    )
+
+
+def _mock_resource_client() -> MagicMock:
+    """Build an async-context-manager-shaped ResourceClient mock."""
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    return client
+
+
+def _wire_resource_client_mock(mock_cls: MagicMock, mock_client: MagicMock) -> None:
+    """Route every CLI construction path on the patched ResourceClient to mock_client."""
+    mock_cls.return_value = mock_client
+    mock_cls._from_resolved_auth.return_value = mock_client
+    mock_cls.from_mcp_url.return_value = mock_client
+
+
+def test_resource_list_uses_env_api_key(monkeypatch):
+    """KAGURA_API_KEY env → ResourceClient built with the env api_key via SDK chain."""
+    monkeypatch.setenv("KAGURA_API_KEY", "env-key")
+
+    mock_client = _mock_resource_client()
+    mock_client.list_resources.return_value = MagicMock(model_dump_json=lambda **_: "{}")
+
+    with (
+        patch("kagura_memory.cli.load_config", return_value={}),
+        patch("kagura_memory.cli.ResourceClient") as mock_cls,
+    ):
+        _wire_resource_client_mock(mock_cls, mock_client)
+        runner = CliRunner()
+        result = runner.invoke(main, ["resource", "list"])
+
+    assert result.exit_code == 0, result.output
+    # from_mcp_url is the entry point — assert the resolver chain ran.
+    mock_cls.from_mcp_url.assert_called_once()
+    kwargs = mock_cls.from_mcp_url.call_args.kwargs
+    assert kwargs["api_key"] is None  # always None — the chain resolves
+    assert kwargs["mcp_url"] is None  # config had none
+
+
+def test_resource_list_uses_oauth_profile():
+    """OAuth profile on disk + no env + no config → ResourceClient built via OAuth path."""
+    # The autouse fixture redirected DEFAULT_CREDENTIALS_PATH; write the
+    # profile there so the resolver finds it during priority-3.
+    import kagura_memory.auth.credentials as _creds
+
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _creds.DEFAULT_CREDENTIALS_PATH)
+    reset_state_cache()
+
+    mock_client = _mock_resource_client()
+    mock_client.list_resources.return_value = MagicMock(model_dump_json=lambda **_: "{}")
+
+    with (
+        patch("kagura_memory.cli.load_config", return_value={}),
+        patch("kagura_memory.cli.ResourceClient") as mock_cls,
+    ):
+        _wire_resource_client_mock(mock_cls, mock_client)
+        runner = CliRunner()
+        result = runner.invoke(main, ["resource", "list"])
+
+    assert result.exit_code == 0, result.output
+    mock_cls.from_mcp_url.assert_called_once()
+
+
+def test_resource_list_falls_back_to_config_api_key():
+    """No env, no OAuth, only ``.kagura.json`` → resolver priority-4 fires."""
+    mock_client = _mock_resource_client()
+    mock_client.list_resources.return_value = MagicMock(model_dump_json=lambda **_: "{}")
+
+    config_dict = {"api_key": "config-key", "mcp_url": "https://test.com/mcp"}
+    with (
+        patch("kagura_memory.cli.load_config", return_value=config_dict),
+        patch("kagura_memory.cli.ResourceClient") as mock_cls,
+    ):
+        _wire_resource_client_mock(mock_cls, mock_client)
+        runner = CliRunner()
+        result = runner.invoke(main, ["resource", "list"])
+
+    assert result.exit_code == 0, result.output
+    # from_mcp_url is called with api_key=None — the chain finds the
+    # config fallback internally via _resolve_auth priority 4.
+    kwargs = mock_cls.from_mcp_url.call_args.kwargs
+    assert kwargs["api_key"] is None
+    assert kwargs["mcp_url"] == "https://test.com/mcp"
+
+
+def test_resource_list_no_credentials_errors():
+    """No env, no OAuth, no config api_key → resolver raises → ClickException surfaces."""
+    with patch("kagura_memory.cli.load_config", return_value={"api_key": ""}):
+        # Also short-circuit the priority-4 reload inside _resolve_auth.
+        with patch("kagura_memory._auth.load_config", return_value={"api_key": ""}):
+            runner = CliRunner()
+            result = runner.invoke(main, ["resource", "list"])
+
+    assert result.exit_code != 0, result.output
+    assert "No credentials" in result.output or "kagura auth login" in result.output
+
+
+def test_resource_setup_in_oauth_mode_errors():
+    """OAuth-mode ``kagura resource setup`` surfaces the NotImplementedError as a clean CLI error.
+
+    ``ResourceClient.setup_resource`` raises ``NotImplementedError`` in
+    OAuth mode (intentionally out of scope for #117). ``_run_resource_command``
+    wraps unexpected exceptions in ``ClickException`` so the operator
+    sees a clean error message and an actionable hint instead of a
+    traceback.
+    """
+    import kagura_memory.auth.credentials as _creds
+
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _creds.DEFAULT_CREDENTIALS_PATH)
+    reset_state_cache()
+
+    with patch("kagura_memory.cli.load_config", return_value={}):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["resource", "setup", "--resource-id", "demo"],
+        )
+
+    assert result.exit_code != 0, result.output
+    assert "OAuth mode" in result.output
+    assert "static api_key" in result.output or "KAGURA_API_KEY" in result.output
+
+
+def test_resource_list_env_wins_over_config_api_key(monkeypatch):
+    """KAGURA_API_KEY env + ``.kagura.json`` api_key → env wins (mirrors #118 Files CLI).
+
+    The resolver chain is canonical SDK order: ``env > OAuth > config``.
+    ``_get_resource_client`` walks the same chain, so a session with
+    both env and config api_key picks env — same precedence as
+    ``kagura context list`` and (post-#118) ``kagura files list``.
+    """
+    monkeypatch.setenv("KAGURA_API_KEY", "env-key")
+
+    mock_client = _mock_resource_client()
+    mock_client.list_resources.return_value = MagicMock(model_dump_json=lambda **_: "{}")
+
+    with (
+        patch(
+            "kagura_memory.cli.load_config",
+            return_value={"api_key": "config-key", "mcp_url": "https://test.com/mcp"},
+        ),
+        patch("kagura_memory.cli.ResourceClient") as mock_cls,
+    ):
+        _wire_resource_client_mock(mock_cls, mock_client)
+        runner = CliRunner()
+        result = runner.invoke(main, ["resource", "list"])
+
+    assert result.exit_code == 0, result.output
+    # The chain is opaque from the CLI's perspective — we cannot directly
+    # assert env wins without inspecting _resolve_auth internals. But we
+    # can verify the CLI passed api_key=None so the chain (not the CLI)
+    # decides. The env-wins behavior is locked in by test_kagura_api_key_
+    # env_wins in tests/test_client_auth_resolution.py.
+    kwargs = mock_cls.from_mcp_url.call_args.kwargs
+    assert kwargs["api_key"] is None

--- a/tests/test_cli_resource.py
+++ b/tests/test_cli_resource.py
@@ -1,14 +1,10 @@
 """Tests for `kagura resource ...` CLI commands.
 
-Focused on the post-#117 credential resolution chain: `_get_resource_client`
-now walks `_resolve_auth` (env > OAuth profile > .kagura.json) instead of
-short-circuiting on `.kagura.json` only. Matches the Files CLI matrix
-(post-#118) so an OAuth-only operator can run `kagura resource ...`
-end-to-end, except for `kagura resource setup` which is documented as
-static-api_key-only in #117.
+`_get_resource_client` walks `_resolve_auth` (env > OAuth profile >
+.kagura.json), matching `KaguraClient` and `FilesClient`. Tests cover
+the four resolver branches plus the OAuth-mode `setup` guard.
 """
 
-from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,11 +12,12 @@ from click.testing import CliRunner
 
 from kagura_memory.auth.credentials import (
     CredentialsFile,
-    OAuthCredentials,
     reset_state_cache,
     save_credentials_file,
 )
 from kagura_memory.cli import main
+from kagura_memory.resource_client import _SETUP_OAUTH_NOT_SUPPORTED_MSG
+from tests.conftest import make_oauth_creds
 
 
 @pytest.fixture(autouse=True)
@@ -42,26 +39,6 @@ def _isolate_oauth_state(tmp_path, monkeypatch):
     reset_state_cache()
 
 
-def _make_oauth_creds(
-    workspace_id: str = "00000000-0000-0000-0000-0000000000ff",
-    expires_in_seconds: int = 3600,
-) -> OAuthCredentials:
-    return OAuthCredentials(
-        server="https://memory.kagura-ai.com",
-        mcp_url="https://memory.kagura-ai.com/mcp",
-        client_id="kagura-cli",
-        access_token="atok-cli-resource-test",
-        refresh_token="rtok-cli-resource-test",
-        token_type="Bearer",
-        expires_at=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
-        scope="memory:read memory:write",
-        workspace_id=workspace_id,
-        workspace_name="cli-resource-test",
-        user_email="resource@example.com",
-        issued_at=datetime.now(UTC),
-    )
-
-
 def _mock_resource_client() -> MagicMock:
     """Build an async-context-manager-shaped ResourceClient mock."""
     client = AsyncMock()
@@ -75,6 +52,17 @@ def _wire_resource_client_mock(mock_cls: MagicMock, mock_client: MagicMock) -> N
     mock_cls.return_value = mock_client
     mock_cls._from_resolved_auth.return_value = mock_client
     mock_cls.from_mcp_url.return_value = mock_client
+
+
+def _resolved_from_call(mock_cls: MagicMock):
+    """Pull the resolved auth dataclass out of the ``_from_resolved_auth`` call.
+
+    ``_get_resource_client`` constructs via ``ResourceClient._from_resolved_auth``
+    directly, so its first positional argument is the ``_StaticAuth | _OAuthAuth``
+    dataclass produced by ``_resolve_auth``. Tests inspect this to verify which
+    resolver branch fired.
+    """
+    return mock_cls._from_resolved_auth.call_args.args[0]
 
 
 def test_resource_list_uses_env_api_key(monkeypatch):
@@ -93,11 +81,9 @@ def test_resource_list_uses_env_api_key(monkeypatch):
         result = runner.invoke(main, ["resource", "list"])
 
     assert result.exit_code == 0, result.output
-    # from_mcp_url is the entry point — assert the resolver chain ran.
-    mock_cls.from_mcp_url.assert_called_once()
-    kwargs = mock_cls.from_mcp_url.call_args.kwargs
-    assert kwargs["api_key"] is None  # always None — the chain resolves
-    assert kwargs["mcp_url"] is None  # config had none
+    resolved = _resolved_from_call(mock_cls)
+    assert resolved.source == "env"
+    assert resolved.api_key == "env-key"
 
 
 def test_resource_list_uses_oauth_profile():
@@ -105,9 +91,10 @@ def test_resource_list_uses_oauth_profile():
     # The autouse fixture redirected DEFAULT_CREDENTIALS_PATH; write the
     # profile there so the resolver finds it during priority-3.
     import kagura_memory.auth.credentials as _creds
+    from kagura_memory._auth import _OAuthAuth
 
     cf = CredentialsFile()
-    cf.set_profile("default", _make_oauth_creds())
+    cf.set_profile("default", make_oauth_creds())
     save_credentials_file(cf, _creds.DEFAULT_CREDENTIALS_PATH)
     reset_state_cache()
 
@@ -123,7 +110,8 @@ def test_resource_list_uses_oauth_profile():
         result = runner.invoke(main, ["resource", "list"])
 
     assert result.exit_code == 0, result.output
-    mock_cls.from_mcp_url.assert_called_once()
+    resolved = _resolved_from_call(mock_cls)
+    assert isinstance(resolved, _OAuthAuth)
 
 
 def test_resource_list_falls_back_to_config_api_key():
@@ -141,11 +129,9 @@ def test_resource_list_falls_back_to_config_api_key():
         result = runner.invoke(main, ["resource", "list"])
 
     assert result.exit_code == 0, result.output
-    # from_mcp_url is called with api_key=None — the chain finds the
-    # config fallback internally via _resolve_auth priority 4.
-    kwargs = mock_cls.from_mcp_url.call_args.kwargs
-    assert kwargs["api_key"] is None
-    assert kwargs["mcp_url"] == "https://test.com/mcp"
+    resolved = _resolved_from_call(mock_cls)
+    assert resolved.source == "config"
+    assert resolved.api_key == "config-key"
 
 
 def test_resource_list_no_credentials_errors():
@@ -172,7 +158,7 @@ def test_resource_setup_in_oauth_mode_errors():
     import kagura_memory.auth.credentials as _creds
 
     cf = CredentialsFile()
-    cf.set_profile("default", _make_oauth_creds())
+    cf.set_profile("default", make_oauth_creds())
     save_credentials_file(cf, _creds.DEFAULT_CREDENTIALS_PATH)
     reset_state_cache()
 
@@ -184,17 +170,19 @@ def test_resource_setup_in_oauth_mode_errors():
         )
 
     assert result.exit_code != 0, result.output
-    assert "OAuth mode" in result.output
-    assert "static api_key" in result.output or "KAGURA_API_KEY" in result.output
+    # Assert against the canonical message constant rather than substrings —
+    # ``_run_resource_command`` wraps exceptions in ``ClickException(str(e))``
+    # so the operator sees the full message verbatim in the output.
+    assert _SETUP_OAUTH_NOT_SUPPORTED_MSG in result.output
 
 
 def test_resource_list_env_wins_over_config_api_key(monkeypatch):
-    """KAGURA_API_KEY env + ``.kagura.json`` api_key → env wins (mirrors #118 Files CLI).
+    """KAGURA_API_KEY env + ``.kagura.json`` api_key → env wins.
 
     The resolver chain is canonical SDK order: ``env > OAuth > config``.
     ``_get_resource_client`` walks the same chain, so a session with
-    both env and config api_key picks env — same precedence as
-    ``kagura context list`` and (post-#118) ``kagura files list``.
+    both env and config api_key picks env — locked in here against
+    future drift.
     """
     monkeypatch.setenv("KAGURA_API_KEY", "env-key")
 
@@ -213,10 +201,6 @@ def test_resource_list_env_wins_over_config_api_key(monkeypatch):
         result = runner.invoke(main, ["resource", "list"])
 
     assert result.exit_code == 0, result.output
-    # The chain is opaque from the CLI's perspective — we cannot directly
-    # assert env wins without inspecting _resolve_auth internals. But we
-    # can verify the CLI passed api_key=None so the chain (not the CLI)
-    # decides. The env-wins behavior is locked in by test_kagura_api_key_
-    # env_wins in tests/test_client_auth_resolution.py.
-    kwargs = mock_cls.from_mcp_url.call_args.kwargs
-    assert kwargs["api_key"] is None
+    resolved = _resolved_from_call(mock_cls)
+    assert resolved.source == "env"
+    assert resolved.api_key == "env-key"

--- a/tests/test_client_auth_resolution.py
+++ b/tests/test_client_auth_resolution.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from kagura_memory import KaguraClient
+from kagura_memory._auth import _resolve_auth, _StaticAuth
 from kagura_memory.auth.credentials import (
     CredentialsFile,
     KaguraOAuth,
@@ -317,3 +318,30 @@ def test_kagura_json_fallback_static_path(tmp_path: Path, monkeypatch):
     assert client._client.auth is None  # static path, no httpx.Auth attached
     assert client.mcp_url == "https://legacy.example.com/mcp"
     reset_state_cache()
+
+
+def test_resolve_auth_uses_passed_config_without_disk_read(isolated_credentials, monkeypatch):
+    """_resolve_auth(config=...) honors a caller-supplied .kagura.json dict.
+
+    Callers that have already loaded the config (the CLI's
+    ``_run_files_command`` and ``_get_resource_client``) pass it through
+    so the priority-4 fallback never re-reads from disk. Verify the
+    contract directly: stub ``load_config`` to fail loudly, then call
+    ``_resolve_auth`` with an explicit ``config``. If the kwarg is
+    honored, the test passes without the stub firing.
+    """
+    monkeypatch.setattr(
+        "kagura_memory._auth.load_config",
+        lambda: pytest.fail("_resolve_auth must not re-read .kagura.json when config= is passed"),
+    )
+
+    resolved = _resolve_auth(
+        api_key=None,
+        mcp_url=None,
+        profile=None,
+        config={"api_key": "from-passed-config", "mcp_url": "https://passed.example.com/mcp"},
+    )
+    assert isinstance(resolved, _StaticAuth)
+    assert resolved.source == "config"
+    assert resolved.api_key == "from-passed-config"
+    assert resolved.mcp_url == "https://passed.example.com/mcp"

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -19,8 +19,32 @@ import pytest
 from click.testing import CliRunner
 from rich.console import Console
 
+from kagura_memory.auth.credentials import reset_state_cache
 from kagura_memory.cli import _resolve_progress_logger, main
 from kagura_memory.logger import _NULL_LOGGER, VerboseLogger
+
+
+@pytest.fixture(autouse=True)
+def _isolate_credential_state(tmp_path, monkeypatch):
+    """Isolate every test from real ``~/.kagura/credentials.json`` and env vars.
+
+    The ``test_resource_import_*`` tests now route through
+    ``_get_resource_client`` → ``_resolve_auth``, which consults
+    OAuth credentials before the mocked config fallback. Without this
+    isolation, a developer's stored OAuth profile or ``KAGURA_PROFILE``
+    would pre-empt the test fixtures.
+    """
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "default-credentials.json",
+    )
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    reset_state_cache()
+    yield
+    reset_state_cache()
+
 
 # ---------------------------------------------------------------------------
 # _NULL_LOGGER + output_format=none

--- a/tests/test_logger_progress.py
+++ b/tests/test_logger_progress.py
@@ -363,6 +363,7 @@ def test_resource_import_emits_single_terminal_success(mock_rc_cls, mock_config)
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     jsonl = "\n".join(f'{{"name": "row{i}"}}' for i in range(250))
     # Click 8.2+ separates stdout / stderr on CliRunner.invoke by default
@@ -417,6 +418,7 @@ def test_resource_import_emits_terminal_error_on_batch_failure(mock_rc_cls, mock
     mock_rc.__aenter__ = AsyncMock(return_value=mock_rc)
     mock_rc.__aexit__ = AsyncMock(return_value=None)
     mock_rc_cls.from_mcp_url.return_value = mock_rc
+    mock_rc_cls._from_resolved_auth.return_value = mock_rc
 
     jsonl = "\n".join(f'{{"name": "row{i}"}}' for i in range(200))
     runner = CliRunner()

--- a/tests/test_resource_client.py
+++ b/tests/test_resource_client.py
@@ -1,6 +1,5 @@
 """Tests for ResourceClient."""
 
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,10 +17,11 @@ from kagura_memory import (
 from kagura_memory.auth.credentials import (
     CredentialsFile,
     KaguraOAuth,
-    OAuthCredentials,
     reset_state_cache,
     save_credentials_file,
 )
+from kagura_memory.resource_client import _SETUP_OAUTH_NOT_SUPPORTED_MSG
+from tests.conftest import make_oauth_creds
 
 # ============================================================================
 # HTTPS enforcement (C-3)
@@ -980,29 +980,8 @@ async def test_context_manager():
 
 
 # ============================================================================
-# OAuth credential resolution (#117 — feat(cli/resource))
+# OAuth credential resolution
 # ============================================================================
-
-
-def _make_oauth_creds(
-    workspace_id: str = "00000000-0000-0000-0000-0000000000ff",
-    expires_in_seconds: int = 3600,
-) -> OAuthCredentials:
-    """Build an OAuthCredentials fixture for from_mcp_url tests."""
-    return OAuthCredentials(
-        server="https://oauth.example.com",
-        mcp_url="https://oauth.example.com/mcp",
-        client_id="kagura-cli",
-        access_token="atok-resource-test",
-        refresh_token="rtok-resource-test",
-        token_type="Bearer",
-        expires_at=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
-        scope="memory:read memory:write",
-        workspace_id=workspace_id,
-        workspace_name="resource-test-ws",
-        user_email="resource@example.com",
-        issued_at=datetime.now(UTC),
-    )
 
 
 @pytest.fixture
@@ -1025,39 +1004,46 @@ def test_init_requires_api_key_or_oauth():
         ResourceClient()
 
 
-def test_from_mcp_url_static_path_unchanged(_isolated_credentials):
+@pytest.mark.asyncio
+async def test_from_mcp_url_static_path_unchanged(_isolated_credentials):
     """from_mcp_url(api_key=...) keeps the static-bearer behavior intact."""
     client = ResourceClient.from_mcp_url(
         api_key="kagura_explicit",
         mcp_url="https://memory.kagura-ai.com/mcp",
     )
-    assert client._client.headers.get("Authorization") == "Bearer kagura_explicit"
-    assert client._client.auth is None
-    assert client._oauth is None
-    assert client._auth_source == "explicit"
+    try:
+        assert client._client.headers.get("Authorization") == "Bearer kagura_explicit"
+        assert client._client.auth is None
+        assert client._oauth is None
+        assert client._auth_source == "explicit"
+    finally:
+        await client.close()
 
 
-def test_from_mcp_url_resolves_oauth_profile(_isolated_credentials):
+@pytest.mark.asyncio
+async def test_from_mcp_url_resolves_oauth_profile(_isolated_credentials):
     """With api_key=None and a profile on disk, from_mcp_url uses KaguraOAuth."""
     cf = CredentialsFile()
-    cf.set_profile("default", _make_oauth_creds())
+    cf.set_profile("default", make_oauth_creds(server="https://oauth.example.com"))
     save_credentials_file(cf, _isolated_credentials)
 
     client = ResourceClient.from_mcp_url(api_key=None, profile="default")
-
-    # OAuth path: no static Authorization header; httpx.Auth installed instead.
-    assert "Authorization" not in client._client.headers
-    assert isinstance(client._client.auth, KaguraOAuth)
-    assert client._oauth is client._client.auth
-    assert client._auth_source == "oauth"
-    # base_url is derived from the profile's stored mcp_url.
-    assert client.base_url == "https://oauth.example.com"
+    try:
+        # OAuth path: no static Authorization header; httpx.Auth installed instead.
+        assert "Authorization" not in client._client.headers
+        assert isinstance(client._client.auth, KaguraOAuth)
+        assert client._oauth is client._client.auth
+        assert client._auth_source == "oauth"
+        # base_url is derived from the profile's stored mcp_url.
+        assert client.base_url == "https://oauth.example.com"
+    finally:
+        await client.close()
 
 
 def test_from_mcp_url_missing_profile_raises_loud(_isolated_credentials):
     """Explicit profile arg with no matching credentials.json entry raises."""
     cf = CredentialsFile()
-    cf.set_profile("default", _make_oauth_creds())
+    cf.set_profile("default", make_oauth_creds(server="https://oauth.example.com"))
     save_credentials_file(cf, _isolated_credentials)
     with pytest.raises(KaguraAuthError, match="Profile 'nonexistent'"):
         ResourceClient.from_mcp_url(api_key=None, profile="nonexistent")
@@ -1065,19 +1051,21 @@ def test_from_mcp_url_missing_profile_raises_loud(_isolated_credentials):
 
 @pytest.mark.asyncio
 async def test_setup_resource_refuses_oauth_mode(_isolated_credentials):
-    """setup_resource() in OAuth mode raises NotImplementedError with a hint.
+    """setup_resource() in OAuth mode raises NotImplementedError with the canonical hint.
 
-    OAuth-mode setup is intentionally deferred for #117. The CRUD/ingest
-    endpoints work end-to-end via OAuth; only the bootstrap-time MCP
-    setup currently requires a static api_key.
+    The CRUD/ingest endpoints work end-to-end via OAuth; only the
+    bootstrap-time MCP ``setup`` step currently requires a static
+    api_key. Assert against the module-level constant so future wording
+    tweaks in one place don't silently drift this test.
     """
     cf = CredentialsFile()
-    cf.set_profile("default", _make_oauth_creds())
+    cf.set_profile("default", make_oauth_creds(server="https://oauth.example.com"))
     save_credentials_file(cf, _isolated_credentials)
 
     client = ResourceClient.from_mcp_url(api_key=None, profile="default")
     try:
-        with pytest.raises(NotImplementedError, match="OAuth mode"):
+        with pytest.raises(NotImplementedError) as excinfo:
             await client.setup_resource(resource_id="any")
+        assert str(excinfo.value) == _SETUP_OAUTH_NOT_SUPPORTED_MSG
     finally:
         await client.close()

--- a/tests/test_resource_client.py
+++ b/tests/test_resource_client.py
@@ -1,5 +1,7 @@
 """Tests for ResourceClient."""
 
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -12,6 +14,13 @@ from kagura_memory import (
     KaguraQuotaError,
     ResourceClient,
     ResourceEventRequest,
+)
+from kagura_memory.auth.credentials import (
+    CredentialsFile,
+    KaguraOAuth,
+    OAuthCredentials,
+    reset_state_cache,
+    save_credentials_file,
 )
 
 # ============================================================================
@@ -968,3 +977,107 @@ async def test_context_manager():
     """async with should work correctly."""
     async with ResourceClient(api_key="test", base_url="https://test.com") as client:
         assert isinstance(client, ResourceClient)
+
+
+# ============================================================================
+# OAuth credential resolution (#117 — feat(cli/resource))
+# ============================================================================
+
+
+def _make_oauth_creds(
+    workspace_id: str = "00000000-0000-0000-0000-0000000000ff",
+    expires_in_seconds: int = 3600,
+) -> OAuthCredentials:
+    """Build an OAuthCredentials fixture for from_mcp_url tests."""
+    return OAuthCredentials(
+        server="https://oauth.example.com",
+        mcp_url="https://oauth.example.com/mcp",
+        client_id="kagura-cli",
+        access_token="atok-resource-test",
+        refresh_token="rtok-resource-test",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(seconds=expires_in_seconds),
+        scope="memory:read memory:write",
+        workspace_id=workspace_id,
+        workspace_name="resource-test-ws",
+        user_email="resource@example.com",
+        issued_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def _isolated_credentials(tmp_path: Path, monkeypatch):
+    """Redirect credentials.json to tmp_path and clear all credential env vars."""
+    fake_path = tmp_path / "credentials.json"
+    monkeypatch.setattr("kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH", fake_path)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {"api_key": ""})
+    reset_state_cache()
+    yield fake_path
+    reset_state_cache()
+
+
+def test_init_requires_api_key_or_oauth():
+    """Bare ResourceClient() with neither api_key nor _oauth must raise ValueError."""
+    with pytest.raises(ValueError, match="requires api_key"):
+        ResourceClient()
+
+
+def test_from_mcp_url_static_path_unchanged(_isolated_credentials):
+    """from_mcp_url(api_key=...) keeps the static-bearer behavior intact."""
+    client = ResourceClient.from_mcp_url(
+        api_key="kagura_explicit",
+        mcp_url="https://memory.kagura-ai.com/mcp",
+    )
+    assert client._client.headers.get("Authorization") == "Bearer kagura_explicit"
+    assert client._client.auth is None
+    assert client._oauth is None
+    assert client._auth_source == "explicit"
+
+
+def test_from_mcp_url_resolves_oauth_profile(_isolated_credentials):
+    """With api_key=None and a profile on disk, from_mcp_url uses KaguraOAuth."""
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _isolated_credentials)
+
+    client = ResourceClient.from_mcp_url(api_key=None, profile="default")
+
+    # OAuth path: no static Authorization header; httpx.Auth installed instead.
+    assert "Authorization" not in client._client.headers
+    assert isinstance(client._client.auth, KaguraOAuth)
+    assert client._oauth is client._client.auth
+    assert client._auth_source == "oauth"
+    # base_url is derived from the profile's stored mcp_url.
+    assert client.base_url == "https://oauth.example.com"
+
+
+def test_from_mcp_url_missing_profile_raises_loud(_isolated_credentials):
+    """Explicit profile arg with no matching credentials.json entry raises."""
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _isolated_credentials)
+    with pytest.raises(KaguraAuthError, match="Profile 'nonexistent'"):
+        ResourceClient.from_mcp_url(api_key=None, profile="nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_setup_resource_refuses_oauth_mode(_isolated_credentials):
+    """setup_resource() in OAuth mode raises NotImplementedError with a hint.
+
+    OAuth-mode setup is intentionally deferred for #117. The CRUD/ingest
+    endpoints work end-to-end via OAuth; only the bootstrap-time MCP
+    setup currently requires a static api_key.
+    """
+    cf = CredentialsFile()
+    cf.set_profile("default", _make_oauth_creds())
+    save_credentials_file(cf, _isolated_credentials)
+
+    client = ResourceClient.from_mcp_url(api_key=None, profile="default")
+    try:
+        with pytest.raises(NotImplementedError, match="OAuth mode"):
+            await client.setup_resource(resource_id="any")
+    finally:
+        await client.close()


### PR DESCRIPTION
Closes #117
Closes #118

## Summary

- Unify credential resolution across all SDK REST clients (`FilesClient`, `ResourceClient`) and the CLI around the canonical chain `env > OAuth profile > .kagura.json` — matching `KaguraClient`.
- `ResourceClient` gains OAuth support via the same `_from_resolved_auth` factory pattern as `FilesClient`; OAuth-only operators (set up via `kagura auth login`) can now run `kagura resource ...` end-to-end.
- `_resolve_auth` gains an optional `config: dict[str, Any] | None = None` kwarg so callers that already loaded `.kagura.json` (the CLI) avoid a redundant disk read for the priority-4 fallback.

## Breaking change

The Files CLI's credential precedence has flipped:

| Source                           | Before | After |
| -------------------------------- | ------ | ----- |
| explicit `--api-key` arg         | 1      | 1     |
| `.kagura.json` `api_key`         | **2**  | 4     |
| `KAGURA_API_KEY` env             | 3      | **2** |
| OAuth profile                    | 4      | 3     |

**Who is affected**: operators with BOTH `KAGURA_API_KEY` env AND a non-empty `api_key` in `.kagura.json`. Previously `.kagura.json` won; now `KAGURA_API_KEY` wins for `kagura files *`.

**Migration**: unset whichever credential you don't want active. The Files CLI now uses the same chain as `KaguraClient` and `kagura context *`, so a session that worked correctly for `kagura context list` will pick the same credential for `kagura files list`.

## Implementation notes

- `_resolve_files_auth` wrapper deleted; `_run_files_command` calls `_resolve_auth(api_key=None, config=config)` directly. The `source="config"` tag is preserved naturally by `_resolve_auth` priority 4.
- `ResourceClient.__init__` mirrors `FilesClient.__init__`: `api_key: str | None = None` + private `_oauth` / `_auth_source` kwargs; httpx.AsyncClient construction branches on `_oauth is not None`.
- `ResourceClient._from_resolved_auth(resolved: _StaticAuth | _OAuthAuth)` is the single construction factory shared by `from_mcp_url` (SDK entry) and the CLI's `_get_resource_client`.
- `ResourceClient.setup_resource` raises `NotImplementedError` in OAuth mode with an actionable hint (`KaguraClient` does not yet accept `KaguraOAuth` — tracked as follow-up; CRUD / ingest endpoints work end-to-end via OAuth).
- HTTPS enforcement (`validate_https_url`) sits before the OAuth/static branch in `__init__` so both paths are protected; no bypass.
- `python.md` "Never store API keys as instance attributes" preserved — `self._oauth` holds an httpx.Auth subclass, not a raw token, and is also reachable via `self._client.auth` (no new attack surface).

## Test changes

- New `tests/test_cli_resource.py` (6 tests): env / OAuth / config-fallback / no-credentials / OAuth-mode-setup-error / env-wins-over-config.
- `tests/test_resource_client.py` +5 tests: constructor guard, static path, OAuth profile resolution, missing-profile loud raise, `setup_resource` OAuth refusal pinned to module constant.
- `tests/test_cli_files.py` rewrite: `test_files_upload_oauth_wins_over_config_when_both_present` (renamed from `_rejects_auto_sentinel_with_config_api_key` — same #115 same-source invariant, now preserved structurally by OAuth winning entirely) + new `test_files_upload_env_wins_over_config_api_key` pinning the breaking precedence.
- `tests/test_client_auth_resolution.py` +1 test: direct unit coverage for the new `_resolve_auth(config=...)` kwarg (stubs `load_config` to fail loudly).
- Autouse `_isolate_oauth_state` fixture in both Files / Resource CLI test modules redirects `DEFAULT_CREDENTIALS_PATH` and clears credential env vars — post-#118 a developer's local OAuth profile would otherwise pre-empt config-only fixtures.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (single lens, batch coherence review — CTO)
- review provider: copilot

Full reviews are saved in the plugin cache:

- `~/.claude/cache/gh-issue-driven/117-batch-117-118.gate1.md`
- `~/.claude/cache/gh-issue-driven/117-batch-117-118.gate2.md`

## Release plan

Recommended bump: **v0.17.0** (MINOR). Per `.claude/rules/versioning.md`, breaking changes in `0.x` bump MINOR (not MAJOR). The migration note above should appear verbatim in the GitHub Release body for v0.17.0.

🤖 Generated via /gh-issue-driven:ship
