### PR TITLE
feat(auth): improve auth login UX — write-default scope, browser fallback (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,6 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ## Unreleased
 
-_No changes yet._
+- `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
+- `kagura auth login` falls back to platform openers (`wslview`/`cmd.exe` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. (#122)
+- Device-flow prompt now nudges the user to sign in to the Kagura web UI in the same browser first, so the consent page renders correctly. (#122)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,5 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 ## Unreleased
 
 - `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
-- `kagura auth login` falls back to platform openers (`wslview`/`cmd.exe` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. (#122)
+- `kagura auth login` falls back to platform openers (`wslview` or `explorer.exe` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122)
 - Device-flow prompt now nudges the user to sign in to the Kagura web UI in the same browser first, so the consent page renders correctly. (#122)

--- a/README.md
+++ b/README.md
@@ -255,9 +255,10 @@ Log in once with `kagura auth login` — the SDK stores credentials at
 `kagura` CLI commands pick them up automatically:
 
 ```bash
-kagura auth login                                    # default scope: memory:read
-kagura auth login --scope "memory:read memory:write" # also request write access
-kagura auth login --no-browser                       # SSH / WSL2 / headless
+kagura auth login                                    # default: memory:read + memory:write
+kagura auth login --read-only                        # read-only profile
+kagura auth login --scope "memory:read profile:read" # custom scope set
+kagura auth login --no-browser                       # SSH / headless
 kagura auth login --profile work                     # named profile for a second workspace
 
 kagura auth status                                   # show profile, server, expiry, scope

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Log in once with `kagura auth login` — the SDK stores credentials at
 
 ```bash
 kagura auth login                                    # default: memory:read + memory:write
-kagura auth login --read-only                        # read-only profile
+kagura auth login --read-only                        # read-only scope
 kagura auth login --scope "memory:read profile:read" # custom scope set
 kagura auth login --no-browser                       # SSH / headless
 kagura auth login --profile work                     # named profile for a second workspace

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -241,6 +241,7 @@ def _try_open_browser(url: str) -> bool:
         if webbrowser.open(url):
             return True
     except (webbrowser.Error, OSError):
+        # Fall through to the platform-specific openers below.
         pass
 
     fallback_commands: list[list[str]] = []

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -240,7 +240,8 @@ def _try_open_browser(url: str) -> bool:
 
     Returns ``True`` if any opener was dispatched successfully.
     """
-    if not _is_wsl():
+    on_wsl = _is_wsl()
+    if not on_wsl:
         try:
             if webbrowser.open(url):
                 return True
@@ -249,7 +250,7 @@ def _try_open_browser(url: str) -> bool:
             pass
 
     fallback_commands: list[list[str]] = []
-    if _is_wsl():
+    if on_wsl:
         if shutil.which("wslview"):
             fallback_commands.append(["wslview", url])
         # explorer.exe is a Windows GUI binary (not a shell); it hands

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
+import subprocess
+import sys
 import webbrowser
 from datetime import UTC, datetime
 from pathlib import Path
@@ -55,7 +58,10 @@ from .device_flow import (
 )
 
 DEFAULT_SERVER = "https://memory.kagura-ai.com"
-DEFAULT_SCOPE = "memory:read"
+_SCOPE_READ = "memory:read"
+_SCOPE_WRITE = "memory:write"
+DEFAULT_SCOPE = f"{_SCOPE_READ} {_SCOPE_WRITE}"
+READ_ONLY_SCOPE = _SCOPE_READ
 
 
 # ---------------------------------------------------------------------------
@@ -97,32 +103,52 @@ def auth():
 )
 @click.option(
     "--scope",
-    default=DEFAULT_SCOPE,
-    help=f"OAuth scope (default: '{DEFAULT_SCOPE}'). "
-    "Pass 'memory:read memory:write' to request write access at login.",
+    default=None,
+    help=f"OAuth scope (default: '{DEFAULT_SCOPE}'). Override only if you need a custom scope set.",
+)
+@click.option(
+    "--read-only",
+    "read_only",
+    is_flag=True,
+    help=f"Request read-only scope ('{READ_ONLY_SCOPE}') instead of the default read+write.",
 )
 @click.option(
     "--no-browser",
     is_flag=True,
     help="Don't try to open a browser — just print the URL and code.",
 )
-def auth_login(profile: str, server: str | None, scope: str, no_browser: bool) -> None:
+def auth_login(
+    profile: str,
+    server: str | None,
+    scope: str | None,
+    read_only: bool,
+    no_browser: bool,
+) -> None:
     """Authenticate via OAuth2 device flow.
 
     \b
     Examples:
-      kagura auth login
-      kagura auth login --scope "memory:read memory:write"
+      kagura auth login                      # read + write (default)
+      kagura auth login --read-only          # read-only
+      kagura auth login --scope "memory:read memory:write profile:read"  # custom
       kagura auth login --profile work
-      kagura auth login --no-browser    # for SSH / WSL2 / headless
+      kagura auth login --no-browser         # for SSH / headless
     """
+    if read_only and scope is not None:
+        raise click.ClickException("--read-only and --scope are mutually exclusive; pick one.")
+    if scope is not None:
+        resolved_scope = scope
+    elif read_only:
+        resolved_scope = READ_ONLY_SCOPE
+    else:
+        resolved_scope = DEFAULT_SCOPE
     resolved_server = _resolve_server(server)
     try:
         asyncio.run(
             _run_login(
                 server=resolved_server,
                 profile=profile,
-                scope=scope,
+                scope=resolved_scope,
                 open_browser=not no_browser,
             )
         )
@@ -169,7 +195,7 @@ async def _run_login(
 
 
 def _print_device_prompt(device: DeviceAuthorizationResponse, *, attempt_browser: bool) -> None:
-    """Print URL + code FIRST, then optionally try webbrowser.open.
+    """Print URL + code FIRST, then optionally try to open a browser.
 
     The URL+code lines come out unconditionally so that even when the
     browser opens silently, the operator can still copy the code by
@@ -180,21 +206,79 @@ def _print_device_prompt(device: DeviceAuthorizationResponse, *, attempt_browser
     click.echo("  Open this URL in your browser to approve:")
     click.echo(f"    {device.verification_uri_complete}")
     click.echo()
+    click.echo(
+        "  Tip: sign in to the Kagura web UI in the same browser first — "
+        "the consent page assumes you're already logged in."
+    )
+    click.echo()
 
     if not attempt_browser:
         click.echo("  (--no-browser: not opening a browser; polling will continue here.)")
         return
 
-    try:
-        opened = webbrowser.open(device.verification_uri_complete)
-    except Exception:
-        opened = False
-
-    if not opened:
+    if not _try_open_browser(device.verification_uri_complete):
         click.echo(
             "  Could not auto-open the browser. Open the URL above manually. "
             "Polling will continue here."
         )
+
+
+def _try_open_browser(url: str) -> bool:
+    """Open ``url`` in the user's default browser.
+
+    Tries the stdlib :mod:`webbrowser` first, then falls back to a
+    platform-specific opener for environments where the stdlib path
+    returns ``True`` but no browser actually launches (WSL2, some
+    minimal Linux setups, macOS via SSH, etc.).
+
+    All fallback commands are invoked with argv (never ``shell=True``)
+    to avoid command-injection if the URL ever carries shell
+    metacharacters from an attacker-controlled server response.
+
+    Returns ``True`` if any opener was dispatched successfully.
+    """
+    try:
+        if webbrowser.open(url):
+            return True
+    except (webbrowser.Error, OSError):
+        pass
+
+    fallback_commands: list[list[str]] = []
+    if _is_wsl():
+        if shutil.which("wslview"):
+            fallback_commands.append(["wslview", url])
+        # cmd.exe `start` needs an empty title positional when the URL is quoted.
+        fallback_commands.append(["cmd.exe", "/c", "start", "", url])
+    elif sys.platform == "darwin":
+        fallback_commands.append(["open", url])
+    elif sys.platform.startswith("linux") and shutil.which("xdg-open"):
+        fallback_commands.append(["xdg-open", url])
+
+    for cmd in fallback_commands:
+        try:
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            return True
+        except OSError:
+            continue
+
+    return False
+
+
+def _is_wsl() -> bool:
+    """Detect Windows Subsystem for Linux (WSL1/WSL2)."""
+    if os.environ.get("WSL_DISTRO_NAME"):
+        return True
+    try:
+        with open("/proc/sys/kernel/osrelease", encoding="ascii", errors="ignore") as f:
+            release = f.read().lower()
+        return "wsl" in release or "microsoft" in release
+    except OSError:
+        return False
 
 
 def _print_login_success(creds: OAuthCredentials, profile: str) -> None:

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -226,19 +225,18 @@ def _print_device_prompt(device: DeviceAuthorizationResponse, *, attempt_browser
 def _try_open_browser(url: str) -> bool:
     """Open ``url`` in the user's default browser.
 
-    On WSL, skip the stdlib :mod:`webbrowser` module entirely and go
-    straight to the Windows-side opener: Python's webbrowser can report
-    success on WSL even when no Windows browser actually launches
-    (the registered handler exists in the Linux env but the redirect
-    never reaches Windows). On other platforms, try the stdlib first
+    On WSL, skip the stdlib :mod:`webbrowser` module entirely and hand
+    the URL to a Windows binary (``wslview`` or ``explorer.exe``):
+    Python's webbrowser can report success on WSL even when no Windows
+    browser actually launches. On other platforms, try the stdlib first
     and fall back if it reports failure.
 
-    All fallback commands are invoked with argv (never ``shell=True``).
-    For ``cmd.exe`` specifically — which is itself a shell and re-parses
-    its arguments — the URL is rejected if it contains characters that
-    cmd.exe treats as metacharacters; current OAuth ``verification_uri``
-    values always satisfy this constraint, but the check is defensive
-    against future server-side changes.
+    All fallback openers are non-shell binaries invoked via argv, so a
+    URL containing shell metacharacters (``&``, ``|``, ``%``, ``!``,
+    etc.) cannot be reinterpreted as command chaining. We intentionally
+    do NOT fall back to ``cmd.exe /c start`` — cmd.exe re-parses its
+    argv as a shell, and an allowlist tight enough to be safe would
+    also reject normal URL characters like ``&``.
 
     Returns ``True`` if any opener was dispatched successfully.
     """
@@ -254,9 +252,10 @@ def _try_open_browser(url: str) -> bool:
     if _is_wsl():
         if shutil.which("wslview"):
             fallback_commands.append(["wslview", url])
-        if _is_url_safe_for_cmd_exe(url):
-            # cmd.exe `start` needs an empty title positional when the URL is quoted.
-            fallback_commands.append(["cmd.exe", "/c", "start", "", url])
+        # explorer.exe is a Windows GUI binary (not a shell); it hands
+        # the URL to the registered protocol handler via ShellExecute,
+        # so shell metacharacters in the URL stay literal.
+        fallback_commands.append(["explorer.exe", url])
     elif sys.platform == "darwin":
         fallback_commands.append(["open", url])
     elif sys.platform.startswith("linux") and shutil.which("xdg-open"):
@@ -275,17 +274,6 @@ def _try_open_browser(url: str) -> bool:
             continue
 
     return False
-
-
-# cmd.exe parses these as command separators / redirection / escapes even when
-# passed as a single argv element. Anything outside the allowed set is rejected
-# so a malicious server-supplied URL can't chain commands via the cmd.exe path.
-_CMD_EXE_URL_ALLOWED = re.compile(r"\A[A-Za-z0-9._~/?:=&+%#@!$*,;()\[\]'-]+\Z")
-
-
-def _is_url_safe_for_cmd_exe(url: str) -> bool:
-    """Return True when ``url`` contains no cmd.exe metacharacters."""
-    return bool(_CMD_EXE_URL_ALLOWED.match(url))
 
 
 def _is_wsl() -> bool:

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -203,13 +204,12 @@ def _print_device_prompt(device: DeviceAuthorizationResponse, *, attempt_browser
     """
     click.echo()
     click.echo(f"! First copy your one-time code: {device.user_code}")
-    click.echo("  Open this URL in your browser to approve:")
-    click.echo(f"    {device.verification_uri_complete}")
-    click.echo()
     click.echo(
         "  Tip: sign in to the Kagura web UI in the same browser first — "
         "the consent page assumes you're already logged in."
     )
+    click.echo("  Open this URL in your browser to approve:")
+    click.echo(f"    {device.verification_uri_complete}")
     click.echo()
 
     if not attempt_browser:
@@ -226,30 +226,37 @@ def _print_device_prompt(device: DeviceAuthorizationResponse, *, attempt_browser
 def _try_open_browser(url: str) -> bool:
     """Open ``url`` in the user's default browser.
 
-    Tries the stdlib :mod:`webbrowser` first, then falls back to a
-    platform-specific opener for environments where the stdlib path
-    returns ``True`` but no browser actually launches (WSL2, some
-    minimal Linux setups, macOS via SSH, etc.).
+    On WSL, skip the stdlib :mod:`webbrowser` module entirely and go
+    straight to the Windows-side opener: Python's webbrowser can report
+    success on WSL even when no Windows browser actually launches
+    (the registered handler exists in the Linux env but the redirect
+    never reaches Windows). On other platforms, try the stdlib first
+    and fall back if it reports failure.
 
-    All fallback commands are invoked with argv (never ``shell=True``)
-    to avoid command-injection if the URL ever carries shell
-    metacharacters from an attacker-controlled server response.
+    All fallback commands are invoked with argv (never ``shell=True``).
+    For ``cmd.exe`` specifically — which is itself a shell and re-parses
+    its arguments — the URL is rejected if it contains characters that
+    cmd.exe treats as metacharacters; current OAuth ``verification_uri``
+    values always satisfy this constraint, but the check is defensive
+    against future server-side changes.
 
     Returns ``True`` if any opener was dispatched successfully.
     """
-    try:
-        if webbrowser.open(url):
-            return True
-    except (webbrowser.Error, OSError):
-        # Fall through to the platform-specific openers below.
-        pass
+    if not _is_wsl():
+        try:
+            if webbrowser.open(url):
+                return True
+        except (webbrowser.Error, OSError):
+            # Fall through to the platform-specific openers below.
+            pass
 
     fallback_commands: list[list[str]] = []
     if _is_wsl():
         if shutil.which("wslview"):
             fallback_commands.append(["wslview", url])
-        # cmd.exe `start` needs an empty title positional when the URL is quoted.
-        fallback_commands.append(["cmd.exe", "/c", "start", "", url])
+        if _is_url_safe_for_cmd_exe(url):
+            # cmd.exe `start` needs an empty title positional when the URL is quoted.
+            fallback_commands.append(["cmd.exe", "/c", "start", "", url])
     elif sys.platform == "darwin":
         fallback_commands.append(["open", url])
     elif sys.platform.startswith("linux") and shutil.which("xdg-open"):
@@ -268,6 +275,17 @@ def _try_open_browser(url: str) -> bool:
             continue
 
     return False
+
+
+# cmd.exe parses these as command separators / redirection / escapes even when
+# passed as a single argv element. Anything outside the allowed set is rejected
+# so a malicious server-supplied URL can't chain commands via the cmd.exe path.
+_CMD_EXE_URL_ALLOWED = re.compile(r"\A[A-Za-z0-9._~/?:=&+%#@!$*,;()\[\]'-]+\Z")
+
+
+def _is_url_safe_for_cmd_exe(url: str) -> bool:
+    """Return True when ``url`` contains no cmd.exe metacharacters."""
+    return bool(_CMD_EXE_URL_ALLOWED.match(url))
 
 
 def _is_wsl() -> bool:

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -305,8 +305,9 @@ def test_try_open_browser_skips_stdlib_on_wsl_even_when_it_would_succeed(monkeyp
     assert popen_calls[0][0] == "wslview"
 
 
-def test_try_open_browser_skips_cmd_exe_for_url_with_shell_metas(monkeypatch):
-    """A URL with cmd.exe metacharacters must not be passed to cmd.exe."""
+def test_try_open_browser_passes_url_with_shell_metas_safely_via_explorer(monkeypatch):
+    """A URL with shell metacharacters is passed to explorer.exe verbatim — argv
+    delivery to a non-shell Windows binary keeps the characters literal."""
     from kagura_memory.auth import cli as cli_mod
 
     monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
@@ -317,32 +318,14 @@ def test_try_open_browser_skips_cmd_exe_for_url_with_shell_metas(monkeypatch):
         popen_calls.append(cmd)
         return MagicMock()
 
-    # URL contains '|' which cmd.exe interprets as a pipe.
-    unsafe_url = "https://example.com/device?user_code=AB|whoami"
+    # URL contains '&' (cmd.exe command chaining) — explorer.exe is not a shell so this is safe.
+    url_with_amp = "https://example.com/device?user_code=AB&next=/foo"
     with (
         patch.object(cli_mod.webbrowser, "open", return_value=False),
         patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
     ):
-        assert cli_mod._try_open_browser(unsafe_url) is False
-    # No cmd.exe (or any other) opener was tried.
-    assert popen_calls == []
-
-
-def test_is_url_safe_for_cmd_exe_accepts_typical_oauth_url():
-    from kagura_memory.auth import cli as cli_mod
-
-    assert (
-        cli_mod._is_url_safe_for_cmd_exe("https://memory.kagura-ai.com/device?user_code=ABCD-1234")
-        is True
-    )
-
-
-def test_is_url_safe_for_cmd_exe_rejects_shell_metas():
-    from kagura_memory.auth import cli as cli_mod
-
-    for meta in ["|", "<", ">", "^", '"', " ", "`"]:
-        url = f"https://example.com/device?u=ABC{meta}whoami"
-        assert cli_mod._is_url_safe_for_cmd_exe(url) is False, f"meta={meta!r} not rejected"
+        assert cli_mod._try_open_browser(url_with_amp) is True
+    assert popen_calls[0] == ["explorer.exe", url_with_amp]
 
 
 def test_try_open_browser_falls_back_to_wsl_opener_when_stdlib_fails(monkeypatch):
@@ -367,7 +350,7 @@ def test_try_open_browser_falls_back_to_wsl_opener_when_stdlib_fails(monkeypatch
     assert "https://example.com/d?u=ABC" in popen_calls[0]
 
 
-def test_try_open_browser_falls_back_to_cmd_exe_when_wslview_missing(monkeypatch):
+def test_try_open_browser_falls_back_to_explorer_when_wslview_missing(monkeypatch):
     from kagura_memory.auth import cli as cli_mod
 
     monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
@@ -383,9 +366,7 @@ def test_try_open_browser_falls_back_to_cmd_exe_when_wslview_missing(monkeypatch
         patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
     ):
         assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
-    assert popen_calls[0][0] == "cmd.exe"
-    assert popen_calls[0][1] == "/c"
-    assert popen_calls[0][2] == "start"
+    assert popen_calls[0] == ["explorer.exe", "https://example.com/d?u=ABC"]
 
 
 def test_try_open_browser_returns_false_when_no_fallback_available(monkeypatch):
@@ -480,8 +461,8 @@ def test_try_open_browser_continues_to_next_fallback_when_popen_fails(monkeypatc
         patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
     ):
         assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
-    # First attempt (wslview) raised; second attempt (cmd.exe) succeeded.
-    assert [c[0] for c in popen_calls] == ["wslview", "cmd.exe"]
+    # First attempt (wslview) raised; second attempt (explorer.exe) succeeded.
+    assert [c[0] for c in popen_calls] == ["wslview", "explorer.exe"]
 
 
 def test_is_wsl_detects_via_env(monkeypatch):

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -150,17 +150,18 @@ def test_login_no_browser_does_not_call_webbrowser(
     assert "ABCD-1234" in result.output
 
 
-@patch("kagura_memory.auth.cli.webbrowser.open", return_value=False)
+@patch("kagura_memory.auth.cli._try_open_browser", return_value=False)
 @patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.make_oauth_client")
-def test_login_falls_back_when_webbrowser_returns_false(
+def test_login_falls_back_when_browser_open_fails(
     mock_client_factory,
     mock_authorize,
     mock_poll,
-    mock_browser,
+    mock_open,
     patched_default_path: Path,
 ):
+    """When every browser-open path fails, print the manual hint."""
     mock_client_factory.return_value = _async_ctx()
     mock_authorize.return_value = _mock_device_response()
     mock_poll.return_value = _mock_token_response()
@@ -168,6 +169,265 @@ def test_login_falls_back_when_webbrowser_returns_false(
     result = CliRunner().invoke(main, ["auth", "login"])
     assert result.exit_code == 0
     assert "Could not auto-open" in result.output
+    mock_open.assert_called_once()
+
+
+@patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.make_oauth_client")
+def test_login_default_scope_is_read_plus_write(
+    mock_client_factory,
+    mock_authorize,
+    mock_poll,
+    patched_default_path: Path,
+):
+    """No flags → request 'memory:read memory:write' (the CLI's main use case)."""
+    mock_client_factory.return_value = _async_ctx()
+    mock_authorize.return_value = _mock_device_response()
+    mock_poll.return_value = _mock_token_response()
+
+    with patch("kagura_memory.auth.cli._try_open_browser", return_value=True):
+        result = CliRunner().invoke(main, ["auth", "login"])
+    assert result.exit_code == 0, result.output
+    # authorize_device was called with the read+write scope.
+    _, kwargs = mock_authorize.call_args
+    assert kwargs.get("scope") == "memory:read memory:write"
+
+
+@patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.make_oauth_client")
+def test_login_read_only_flag_requests_read_scope(
+    mock_client_factory,
+    mock_authorize,
+    mock_poll,
+    patched_default_path: Path,
+):
+    mock_client_factory.return_value = _async_ctx()
+    mock_authorize.return_value = _mock_device_response()
+    mock_poll.return_value = _mock_token_response()
+
+    with patch("kagura_memory.auth.cli._try_open_browser", return_value=True):
+        result = CliRunner().invoke(main, ["auth", "login", "--read-only"])
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_authorize.call_args
+    assert kwargs.get("scope") == "memory:read"
+
+
+def test_login_read_only_and_scope_are_mutually_exclusive(patched_default_path: Path):
+    result = CliRunner().invoke(main, ["auth", "login", "--read-only", "--scope", "memory:read"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+@patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.make_oauth_client")
+def test_login_explicit_scope_is_honored(
+    mock_client_factory,
+    mock_authorize,
+    mock_poll,
+    patched_default_path: Path,
+):
+    mock_client_factory.return_value = _async_ctx()
+    mock_authorize.return_value = _mock_device_response()
+    mock_poll.return_value = _mock_token_response()
+
+    with patch("kagura_memory.auth.cli._try_open_browser", return_value=True):
+        result = CliRunner().invoke(main, ["auth", "login", "--scope", "memory:read profile:read"])
+    assert result.exit_code == 0, result.output
+    _, kwargs = mock_authorize.call_args
+    assert kwargs.get("scope") == "memory:read profile:read"
+
+
+@patch("kagura_memory.auth.cli._try_open_browser", return_value=True)
+@patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
+@patch("kagura_memory.auth.cli.make_oauth_client")
+def test_login_prints_pre_login_tip(
+    mock_client_factory,
+    mock_authorize,
+    mock_poll,
+    mock_open,
+    patched_default_path: Path,
+):
+    """The device prompt nudges the user to sign in to the web UI first."""
+    mock_client_factory.return_value = _async_ctx()
+    mock_authorize.return_value = _mock_device_response()
+    mock_poll.return_value = _mock_token_response()
+
+    result = CliRunner().invoke(main, ["auth", "login"])
+    assert result.exit_code == 0
+    assert "sign in to the Kagura web UI" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _try_open_browser + _is_wsl helpers
+# ---------------------------------------------------------------------------
+
+
+def test_try_open_browser_returns_true_when_stdlib_succeeds():
+    from kagura_memory.auth import cli as cli_mod
+
+    with patch.object(cli_mod.webbrowser, "open", return_value=True) as mock_open:
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    mock_open.assert_called_once()
+
+
+def test_try_open_browser_falls_back_to_wsl_opener_when_stdlib_fails(monkeypatch):
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=False),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    # wslview was the first fallback tried.
+    assert popen_calls[0][0] == "wslview"
+    # URL is passed as a separate argv element — never via shell.
+    assert "https://example.com/d?u=ABC" in popen_calls[0]
+
+
+def test_try_open_browser_falls_back_to_cmd_exe_when_wslview_missing(monkeypatch):
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: None)
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=False),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    assert popen_calls[0][0] == "cmd.exe"
+    assert popen_calls[0][1] == "/c"
+    assert popen_calls[0][2] == "start"
+
+
+def test_try_open_browser_returns_false_when_no_fallback_available(monkeypatch):
+    """Linux native without xdg-open: nothing to fall back to."""
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(cli_mod.sys, "platform", "linux")
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: None)
+
+    with patch.object(cli_mod.webbrowser, "open", return_value=False):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is False
+
+
+def test_try_open_browser_macos_uses_open(monkeypatch):
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(cli_mod.sys, "platform", "darwin")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=False),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    assert popen_calls[0][0] == "open"
+
+
+def test_try_open_browser_linux_uses_xdg_open(monkeypatch):
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(cli_mod.sys, "platform", "linux")
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: "/usr/bin/xdg-open")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=False),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    assert popen_calls[0][0] == "xdg-open"
+
+
+def test_try_open_browser_recovers_when_webbrowser_raises(monkeypatch):
+    """webbrowser.open raising webbrowser.Error must not crash the device flow."""
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: False)
+    monkeypatch.setattr(cli_mod.sys, "platform", "darwin")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    with (
+        patch.object(
+            cli_mod.webbrowser, "open", side_effect=cli_mod.webbrowser.Error("no browser")
+        ),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    assert popen_calls[0][0] == "open"
+
+
+def test_try_open_browser_continues_to_next_fallback_when_popen_fails(monkeypatch):
+    """First fallback raising OSError must not stop the loop — try the next one."""
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        if cmd[0] == "wslview":
+            raise FileNotFoundError("wslview not actually installed")
+        return MagicMock()
+
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=False),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    # First attempt (wslview) raised; second attempt (cmd.exe) succeeded.
+    assert [c[0] for c in popen_calls] == ["wslview", "cmd.exe"]
+
+
+def test_is_wsl_detects_via_env(monkeypatch):
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu-22.04")
+    assert cli_mod._is_wsl() is True
+
+
+def test_is_wsl_returns_false_when_no_signal(monkeypatch):
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    # Force open() to raise so we exit the function via the fallback path.
+    fake_open = MagicMock(side_effect=OSError("no /proc/sys/kernel/osrelease"))
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert cli_mod._is_wsl() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -420,6 +420,44 @@ def test_is_wsl_detects_via_env(monkeypatch):
     assert cli_mod._is_wsl() is True
 
 
+def test_is_wsl_detects_via_proc_osrelease(monkeypatch, tmp_path):
+    """When WSL_DISTRO_NAME is unset, fall back to reading /proc/sys/kernel/osrelease."""
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    fake_release = tmp_path / "osrelease"
+    fake_release.write_text("5.15.167.4-microsoft-standard-WSL2\n")
+
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/sys/kernel/osrelease":
+            return real_open(fake_release, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert cli_mod._is_wsl() is True
+
+
+def test_is_wsl_returns_false_for_native_linux_kernel(monkeypatch, tmp_path):
+    """A native Linux kernel string contains neither 'wsl' nor 'microsoft'."""
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.delenv("WSL_DISTRO_NAME", raising=False)
+    fake_release = tmp_path / "osrelease"
+    fake_release.write_text("6.6.0-generic\n")
+
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/sys/kernel/osrelease":
+            return real_open(fake_release, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+    assert cli_mod._is_wsl() is False
+
+
 def test_is_wsl_returns_false_when_no_signal(monkeypatch):
     from kagura_memory.auth import cli as cli_mod
 

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -98,7 +98,7 @@ def _mock_token_response(**overrides):
     return TokenResponse(**defaults)
 
 
-@patch("kagura_memory.auth.cli.webbrowser.open", return_value=True)
+@patch("kagura_memory.auth.cli._try_open_browser", return_value=True)
 @patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.make_oauth_client")
@@ -127,11 +127,11 @@ def test_login_happy_path(
     assert cf.get_profile("default").access_token == "atok-fresh"
 
 
-@patch("kagura_memory.auth.cli.webbrowser.open")
+@patch("kagura_memory.auth.cli._try_open_browser")
 @patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.make_oauth_client")
-def test_login_no_browser_does_not_call_webbrowser(
+def test_login_no_browser_does_not_call_browser_opener(
     mock_client_factory,
     mock_authorize,
     mock_poll,
@@ -258,7 +258,13 @@ def test_login_prints_pre_login_tip(
 
     result = CliRunner().invoke(main, ["auth", "login"])
     assert result.exit_code == 0
-    assert "sign in to the Kagura web UI" in result.output
+    output = result.output
+    tip_index = output.find("sign in to the Kagura web UI")
+    url_index = output.find("https://test.example.com/device?user_code=")
+    assert tip_index != -1
+    assert url_index != -1
+    # The tip MUST appear before the URL so users see it before clicking.
+    assert tip_index < url_index
 
 
 # ---------------------------------------------------------------------------
@@ -266,12 +272,77 @@ def test_login_prints_pre_login_tip(
 # ---------------------------------------------------------------------------
 
 
-def test_try_open_browser_returns_true_when_stdlib_succeeds():
+def test_try_open_browser_returns_true_when_stdlib_succeeds(monkeypatch):
     from kagura_memory.auth import cli as cli_mod
 
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: False)
     with patch.object(cli_mod.webbrowser, "open", return_value=True) as mock_open:
         assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
     mock_open.assert_called_once()
+
+
+def test_try_open_browser_skips_stdlib_on_wsl_even_when_it_would_succeed(monkeypatch):
+    """Regression: on WSL, webbrowser.open's True return is not trusted —
+    Python sees a registered handler but no Windows browser actually launches.
+    The platform fallback must run regardless.
+    """
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=True) as mock_open,
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
+    mock_open.assert_not_called()
+    assert popen_calls[0][0] == "wslview"
+
+
+def test_try_open_browser_skips_cmd_exe_for_url_with_shell_metas(monkeypatch):
+    """A URL with cmd.exe metacharacters must not be passed to cmd.exe."""
+    from kagura_memory.auth import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
+    monkeypatch.setattr(cli_mod.shutil, "which", lambda name: None)  # no wslview
+    popen_calls: list[list[str]] = []
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append(cmd)
+        return MagicMock()
+
+    # URL contains '|' which cmd.exe interprets as a pipe.
+    unsafe_url = "https://example.com/device?user_code=AB|whoami"
+    with (
+        patch.object(cli_mod.webbrowser, "open", return_value=False),
+        patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
+    ):
+        assert cli_mod._try_open_browser(unsafe_url) is False
+    # No cmd.exe (or any other) opener was tried.
+    assert popen_calls == []
+
+
+def test_is_url_safe_for_cmd_exe_accepts_typical_oauth_url():
+    from kagura_memory.auth import cli as cli_mod
+
+    assert (
+        cli_mod._is_url_safe_for_cmd_exe("https://memory.kagura-ai.com/device?user_code=ABCD-1234")
+        is True
+    )
+
+
+def test_is_url_safe_for_cmd_exe_rejects_shell_metas():
+    from kagura_memory.auth import cli as cli_mod
+
+    for meta in ["|", "<", ">", "^", '"', " ", "`"]:
+        url = f"https://example.com/device?u=ABC{meta}whoami"
+        assert cli_mod._is_url_safe_for_cmd_exe(url) is False, f"meta={meta!r} not rejected"
 
 
 def test_try_open_browser_falls_back_to_wsl_opener_when_stdlib_fails(monkeypatch):
@@ -578,7 +649,7 @@ def test_refresh_rotates_access_token(
 @patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.refresh_access_token", new_callable=AsyncMock)
-@patch("kagura_memory.auth.cli.webbrowser.open", return_value=True)
+@patch("kagura_memory.auth.cli._try_open_browser", return_value=True)
 @patch("kagura_memory.auth.cli.make_oauth_client")
 def test_refresh_scope_widening_triggers_device_flow(
     mock_client_factory,


### PR DESCRIPTION
Closes #122. Companion server-side issue: kagura-ai/memory-cloud#772.

## Summary

- **Default scope is now `memory:read memory:write`** — CLI users want write the vast majority of the time (`kagura remember`, `forget`, `update_context` etc.). Read-only stays available via `--read-only` (mutually exclusive with `--scope`).
- **Browser fallback chain** — `_try_open_browser` tries `webbrowser.open()` first, then platform openers when stdlib doesn't actually launch a browser (WSL2 most notably). Order: WSL → `wslview` then `cmd.exe /c start`; macOS → `open`; Linux → `xdg-open`. All commands use argv (no `shell=True`) so a URL with shell metacharacters can't inject.
- **Pre-login tip** — `_print_device_prompt` nudges users to sign in to the Kagura web UI first, since the `/device` consent page assumes you're already authenticated. Server-side fix tracked in memory-cloud#772; this is a workaround until that lands.

## Files changed

| File | Change |
|---|---|
| `src/kagura_memory/auth/cli.py` | +100 / -16 — new `_try_open_browser`, `_is_wsl`, `--read-only`, scope constants split |
| `tests/test_auth_cli.py` | +338 / -3 — 12 new tests (scope default, `--read-only`, mutual exclusion, browser fallback per platform, exception recovery, `_is_wsl`) |
| `README.md` | updated `kagura auth login` examples |
| `CHANGELOG.md` | unreleased bullets |

## Test plan

- [x] `uv run pytest tests/test_auth_cli.py` — 42 pass
- [x] `uv run pytest --ignore=tests/eval` — 713 pass, 1 skip (eval failure unrelated — invalid Anthropic API key in env)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pyright src/kagura_memory/auth/cli.py` — 0 errors, 0 warnings
- [ ] Manual: `kagura auth login` on WSL2 actually opens the Windows default browser
- [ ] Manual: `kagura auth login --read-only` requests read-only scope
- [ ] Manual: `kagura auth login --read-only --scope memory:read` errors with mutual-exclusion message

🤖 Generated with [Claude Code](https://claude.com/claude-code)