### PR TITLE
fix(auth): WSL fallback opens File Explorer instead of browser (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,5 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 ## Unreleased
 
 - `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
-- `kagura auth login` falls back to platform openers (`wslview` or `explorer.exe` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122)
+- `kagura auth login` falls back to platform openers (`wslview` or `rundll32.exe url.dll,FileProtocolHandler` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122, #125)
 - Device-flow prompt now nudges the user to sign in to the Kagura web UI in the same browser first, so the consent page renders correctly. (#122)

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -226,10 +226,12 @@ def _try_open_browser(url: str) -> bool:
     """Open ``url`` in the user's default browser.
 
     On WSL, skip the stdlib :mod:`webbrowser` module entirely and hand
-    the URL to a Windows binary (``wslview`` or ``rundll32.exe``):
-    Python's webbrowser can report success on WSL even when no Windows
-    browser actually launches. On other platforms, try the stdlib first
-    and fall back if it reports failure.
+    the URL to a dedicated opener — either ``wslview`` (a Linux-side
+    helper from the ``wslu`` package, preferred when available) or
+    ``rundll32.exe`` from the Windows side (always available). Python's
+    webbrowser can report success on WSL even when no Windows browser
+    actually launches, so we don't trust it there. On other platforms,
+    try the stdlib first and fall back if it reports failure.
 
     All fallback openers are non-shell binaries invoked via argv, so a
     URL containing shell metacharacters (``&``, ``|``, ``%``, ``!``,

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -226,7 +226,7 @@ def _try_open_browser(url: str) -> bool:
     """Open ``url`` in the user's default browser.
 
     On WSL, skip the stdlib :mod:`webbrowser` module entirely and hand
-    the URL to a Windows binary (``wslview`` or ``explorer.exe``):
+    the URL to a Windows binary (``wslview`` or ``rundll32.exe``):
     Python's webbrowser can report success on WSL even when no Windows
     browser actually launches. On other platforms, try the stdlib first
     and fall back if it reports failure.
@@ -236,7 +236,10 @@ def _try_open_browser(url: str) -> bool:
     etc.) cannot be reinterpreted as command chaining. We intentionally
     do NOT fall back to ``cmd.exe /c start`` — cmd.exe re-parses its
     argv as a shell, and an allowlist tight enough to be safe would
-    also reject normal URL characters like ``&``.
+    also reject normal URL characters like ``&``. We also avoid
+    ``explorer.exe URL`` because Windows Explorer resolves the argument
+    as a path and opens a folder window instead of delegating to the
+    URL handler.
 
     Returns ``True`` if any opener was dispatched successfully.
     """
@@ -253,10 +256,13 @@ def _try_open_browser(url: str) -> bool:
     if on_wsl:
         if shutil.which("wslview"):
             fallback_commands.append(["wslview", url])
-        # explorer.exe is a Windows GUI binary (not a shell); it hands
-        # the URL to the registered protocol handler via ShellExecute,
-        # so shell metacharacters in the URL stay literal.
-        fallback_commands.append(["explorer.exe", url])
+        # rundll32 calls url.dll's FileProtocolHandler, which hands the
+        # URL to ShellExecute — the canonical Windows API for opening
+        # the registered protocol handler. rundll32 is not a shell, so
+        # shell metacharacters in the URL stay literal, and unlike
+        # explorer.exe it never falls back to treating the argument
+        # as a filesystem path.
+        fallback_commands.append(["rundll32.exe", "url.dll,FileProtocolHandler", url])
     elif sys.platform == "darwin":
         fallback_commands.append(["open", url])
     elif sys.platform.startswith("linux") and shutil.which("xdg-open"):

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -305,8 +305,8 @@ def test_try_open_browser_skips_stdlib_on_wsl_even_when_it_would_succeed(monkeyp
     assert popen_calls[0][0] == "wslview"
 
 
-def test_try_open_browser_passes_url_with_shell_metas_safely_via_explorer(monkeypatch):
-    """A URL with shell metacharacters is passed to explorer.exe verbatim — argv
+def test_try_open_browser_passes_url_with_shell_metas_safely_via_rundll32(monkeypatch):
+    """A URL with shell metacharacters is passed to rundll32 verbatim — argv
     delivery to a non-shell Windows binary keeps the characters literal."""
     from kagura_memory.auth import cli as cli_mod
 
@@ -318,14 +318,14 @@ def test_try_open_browser_passes_url_with_shell_metas_safely_via_explorer(monkey
         popen_calls.append(cmd)
         return MagicMock()
 
-    # URL contains '&' (cmd.exe command chaining) — explorer.exe is not a shell so this is safe.
+    # URL contains '&' (cmd.exe command chaining) — rundll32 is not a shell so this is safe.
     url_with_amp = "https://example.com/device?user_code=AB&next=/foo"
     with (
         patch.object(cli_mod.webbrowser, "open", return_value=False),
         patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
     ):
         assert cli_mod._try_open_browser(url_with_amp) is True
-    assert popen_calls[0] == ["explorer.exe", url_with_amp]
+    assert popen_calls[0] == ["rundll32.exe", "url.dll,FileProtocolHandler", url_with_amp]
 
 
 def test_try_open_browser_falls_back_to_wsl_opener_when_stdlib_fails(monkeypatch):
@@ -350,7 +350,7 @@ def test_try_open_browser_falls_back_to_wsl_opener_when_stdlib_fails(monkeypatch
     assert "https://example.com/d?u=ABC" in popen_calls[0]
 
 
-def test_try_open_browser_falls_back_to_explorer_when_wslview_missing(monkeypatch):
+def test_try_open_browser_falls_back_to_rundll32_when_wslview_missing(monkeypatch):
     from kagura_memory.auth import cli as cli_mod
 
     monkeypatch.setattr(cli_mod, "_is_wsl", lambda: True)
@@ -366,7 +366,11 @@ def test_try_open_browser_falls_back_to_explorer_when_wslview_missing(monkeypatc
         patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
     ):
         assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
-    assert popen_calls[0] == ["explorer.exe", "https://example.com/d?u=ABC"]
+    assert popen_calls[0] == [
+        "rundll32.exe",
+        "url.dll,FileProtocolHandler",
+        "https://example.com/d?u=ABC",
+    ]
 
 
 def test_try_open_browser_returns_false_when_no_fallback_available(monkeypatch):
@@ -461,8 +465,8 @@ def test_try_open_browser_continues_to_next_fallback_when_popen_fails(monkeypatc
         patch.object(cli_mod.subprocess, "Popen", side_effect=fake_popen),
     ):
         assert cli_mod._try_open_browser("https://example.com/d?u=ABC") is True
-    # First attempt (wslview) raised; second attempt (explorer.exe) succeeded.
-    assert [c[0] for c in popen_calls] == ["wslview", "explorer.exe"]
+    # First attempt (wslview) raised; second attempt (rundll32.exe) succeeded.
+    assert [c[0] for c in popen_calls] == ["wslview", "rundll32.exe"]
 
 
 def test_is_wsl_detects_via_env(monkeypatch):


### PR DESCRIPTION
Closes #125. Regression from #123 surfaced during local verification.

## Problem

After #123, the WSL second fallback was \`explorer.exe URL\`. Local testing on a real WSL2 setup (no \`wslview\` installed) opened **Windows File Explorer to an empty folder**, not the URL in a browser.

Root cause: \`explorer.exe\` is the Windows shell. Given a string argument, it tries to resolve the argument as a path; only when that resolution fails completely does it delegate to ShellExecute for URL handling. From WSL, the URL's \`/path/\` segments interact poorly with explorer.exe's path resolution and you get a folder window.

## Fix

Replace \`["explorer.exe", url]\` with \`["rundll32.exe", "url.dll,FileProtocolHandler", url]\`. This calls \`url.dll\`'s \`FileProtocolHandler\` entry point, which invokes \`ShellExecute(NULL, "open", URL, ...)\` — the canonical Windows API for opening URLs with the registered protocol handler.

Why rundll32 specifically:
- It's not a shell. After \`,FileProtocolHandler\` the rest of the command line is passed as a single literal string to the entry point. \`&\` / \`|\` / other shell metacharacters in the URL stay literal.
- It never falls back to treating the argument as a filesystem path.
- It respects the user's chosen default browser (Chrome, Edge, Firefox — whichever).

## Test plan

- [x] \`uv run pytest tests/test_auth_cli.py\` — 46 pass
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run pyright src/kagura_memory/auth/cli.py\` — 0 errors
- [ ] Manual on WSL2 without wslview: \`uv run kagura auth login\` opens default Windows browser, not File Explorer
- [ ] Manual on WSL2 with wslview installed: still uses wslview (preferred fallback unchanged)

## Files changed

| File | Change |
|---|---|
| \`src/kagura_memory/auth/cli.py\` | explorer.exe → rundll32 + docstring update |
| \`tests/test_auth_cli.py\` | rename explorer tests, assert rundll32 argv |
| \`CHANGELOG.md\` | update fallback chain description |

🤖 Generated with [Claude Code](https://claude.com/claude-code)