### PR TITLE
fix(cli) + chore(auth): v0.19.1 batch (#127, #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 - `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
 - `kagura auth login` falls back to platform openers (`wslview` or `rundll32.exe url.dll,FileProtocolHandler` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122, #125)
-- Device-flow prompt now nudges the user to sign in to the Kagura web UI in the same browser first, so the consent page renders correctly. (#122)
+- Removed the pre-login web-UI tip from the device-flow prompt — `memory-cloud#772` shipped a login-gated `/device` page that no longer needs the client-side workaround. (#128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 - `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
 - `kagura auth login` falls back to platform openers (`wslview` or `rundll32.exe url.dll,FileProtocolHandler` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122, #125)
 - Removed the pre-login web-UI tip from the device-flow prompt — `memory-cloud#772` shipped a login-gated `/device` page that no longer needs the client-side workaround. (#128)
+- `kagura setup claude` now falls back to the exception class name when an inner step raises without a message, so the CLI never prints a bare `Setup failed:` (or `Connection failed:`) with nothing after the colon. (#127)

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -203,10 +203,6 @@ def _print_device_prompt(device: DeviceAuthorizationResponse, *, attempt_browser
     """
     click.echo()
     click.echo(f"! First copy your one-time code: {device.user_code}")
-    click.echo(
-        "  Tip: sign in to the Kagura web UI in the same browser first — "
-        "the consent page assumes you're already logged in."
-    )
     click.echo("  Open this URL in your browser to approve:")
     click.echo(f"    {device.verification_uri_complete}")
     click.echo()

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1039,7 +1039,10 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(f"Setup failed: {e}") from e
+        # Fall back to the class name so an unmessaged exception still produces
+        # a non-empty diagnostic — bare "Setup failed:" leaves the user blind.
+        msg = str(e) or e.__class__.__name__
+        raise click.ClickException(f"Setup failed: {msg}") from e
 
 
 # =============================================================================

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1039,8 +1039,6 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
     except click.ClickException:
         raise
     except Exception as e:
-        # Fall back to the class name so an unmessaged exception still produces
-        # a non-empty diagnostic — bare "Setup failed:" leaves the user blind.
         msg = str(e) or e.__class__.__name__
         raise click.ClickException(f"Setup failed: {msg}") from e
 

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1036,7 +1036,9 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
             project_dir=project_dir,
             non_interactive=non_interactive,
         )
-    except click.ClickException:
+    except (click.Abort, click.ClickException):
+        # click.Abort fires on Ctrl+D / explicit abort during prompts — let Click
+        # render its default "Aborted!" UX instead of reporting "Setup failed: Abort".
         raise
     except Exception as e:
         msg = str(e) or e.__class__.__name__

--- a/src/kagura_memory/setup_claude.py
+++ b/src/kagura_memory/setup_claude.py
@@ -343,7 +343,8 @@ def run_setup_claude(
             "  Is the server running? Try: docker compose up -d"
         ) from e
     except Exception as e:
-        raise click.ClickException(f"Connection failed: {e}") from e
+        msg = str(e) or e.__class__.__name__
+        raise click.ClickException(f"Connection failed: {msg}") from e
 
     count = contexts_response.get("count", 0)
     click.echo(f"  Connected! ({count} contexts available)")

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -244,14 +244,14 @@ def test_login_explicit_scope_is_honored(
 @patch("kagura_memory.auth.cli.poll_for_token", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.authorize_device", new_callable=AsyncMock)
 @patch("kagura_memory.auth.cli.make_oauth_client")
-def test_login_prints_pre_login_tip(
+def test_login_does_not_print_pre_login_tip(
     mock_client_factory,
     mock_authorize,
     mock_poll,
     mock_open,
     patched_default_path: Path,
 ):
-    """The device prompt nudges the user to sign in to the web UI first."""
+    # memory-cloud#772 login-gated /device — the client-side workaround must not reappear.
     mock_client_factory.return_value = _async_ctx()
     mock_authorize.return_value = _mock_device_response()
     mock_poll.return_value = _mock_token_response()
@@ -259,12 +259,9 @@ def test_login_prints_pre_login_tip(
     result = CliRunner().invoke(main, ["auth", "login"])
     assert result.exit_code == 0
     output = result.output
-    tip_index = output.find("sign in to the Kagura web UI")
-    url_index = output.find("https://test.example.com/device?user_code=")
-    assert tip_index != -1
-    assert url_index != -1
-    # The tip MUST appear before the URL so users see it before clicking.
-    assert tip_index < url_index
+    assert "sign in to the Kagura web UI" not in output
+    assert "Tip:" not in output
+    assert "https://test.example.com/device?user_code=" in output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -260,7 +260,7 @@ def test_login_does_not_print_pre_login_tip(
     assert result.exit_code == 0
     output = result.output
     assert "sign in to the Kagura web UI" not in output
-    assert "Tip:" not in output
+    assert "the consent page assumes" not in output
     assert "https://test.example.com/device?user_code=" in output
 
 

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -479,6 +479,42 @@ def test_setup_claude_generic_connection_error(
     assert "Connection failed" in result.output
 
 
+@patch("kagura_memory.setup_claude._test_connection")
+def test_setup_claude_connection_failed_unmessaged_exception(
+    mock_conn: AsyncMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    # str(e) is "" for a no-arg exception; the wrapper must still surface a
+    # diagnostic (the class name) instead of "Connection failed: " (#127).
+    mock_conn.side_effect = RuntimeError()
+
+    result = runner.invoke(main, _setup_args(tmp_path))
+
+    assert result.exit_code != 0
+    assert "Connection failed: RuntimeError" in result.output
+    assert "Connection failed: \n" not in result.output
+    assert "Connection failed:\n" not in result.output
+
+
+@patch("kagura_memory.cli.run_setup_claude")
+def test_setup_claude_setup_failed_unmessaged_exception(
+    mock_run: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    # Outer cli.py wrapper: anything run_setup_claude raises without a
+    # message must still print a non-empty "Setup failed: <ClassName>" (#127).
+    mock_run.side_effect = RuntimeError()
+
+    result = runner.invoke(main, _setup_args(tmp_path))
+
+    assert result.exit_code != 0
+    assert "Setup failed: RuntimeError" in result.output
+    assert "Setup failed: \n" not in result.output
+    assert "Setup failed:\n" not in result.output
+
+
 @patch("kagura_memory.setup_claude._create_context")
 @patch("kagura_memory.setup_claude._test_connection")
 def test_setup_claude_config_load_error(

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -513,6 +513,22 @@ def test_setup_claude_setup_failed_unmessaged_exception(
     assert "Setup failed:\n" not in result.output
 
 
+@patch("kagura_memory.cli.run_setup_claude")
+def test_setup_claude_user_abort_propagates_as_aborted(
+    mock_run: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Ctrl+D during a prompt (click.Abort) must yield Click's default 'Aborted!' UX, not 'Setup failed: Abort'."""
+    mock_run.side_effect = click.Abort()
+
+    result = runner.invoke(main, _setup_args(tmp_path))
+
+    assert result.exit_code != 0
+    assert "Setup failed" not in result.output
+    assert "Aborted" in result.output
+
+
 @patch("kagura_memory.setup_claude._create_context")
 @patch("kagura_memory.setup_claude._test_connection")
 def test_setup_claude_config_load_error(

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -485,8 +485,7 @@ def test_setup_claude_connection_failed_unmessaged_exception(
     runner: CliRunner,
     tmp_path: Path,
 ) -> None:
-    # str(e) is "" for a no-arg exception; the wrapper must still surface a
-    # diagnostic (the class name) instead of "Connection failed: " (#127).
+    """Unmessaged exception in _test_connection must surface the class name (#127)."""
     mock_conn.side_effect = RuntimeError()
 
     result = runner.invoke(main, _setup_args(tmp_path))
@@ -503,8 +502,7 @@ def test_setup_claude_setup_failed_unmessaged_exception(
     runner: CliRunner,
     tmp_path: Path,
 ) -> None:
-    # Outer cli.py wrapper: anything run_setup_claude raises without a
-    # message must still print a non-empty "Setup failed: <ClassName>" (#127).
+    """Unmessaged exception escaping run_setup_claude must surface the class name (#127)."""
     mock_run.side_effect = RuntimeError()
 
     result = runner.invoke(main, _setup_args(tmp_path))

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -519,7 +519,7 @@ def test_setup_claude_user_abort_propagates_as_aborted(
     runner: CliRunner,
     tmp_path: Path,
 ) -> None:
-    """Ctrl+D during a prompt (click.Abort) must yield Click's default 'Aborted!' UX, not 'Setup failed: Abort'."""
+    """click.Abort (Ctrl+D) must yield Click's default 'Aborted!' UX, not 'Setup failed: Abort'."""
     mock_run.side_effect = click.Abort()
 
     result = runner.invoke(main, _setup_args(tmp_path))


### PR DESCRIPTION
Closes #127
Closes #128

## Summary

- **#127 — `kagura setup claude` defensive error message**: the outer `setup_claude` Click wrapper (`cli.py:1041`) and the inner `_test_connection` wrapper (`setup_claude.py:345`) both fall back to the exception class name when `str(e)` is empty, so the CLI never prints a bare `Setup failed:` (or `Connection failed:`) with nothing after the colon. The original unmessaged raise has not been pinpointed yet (requires interactive setup reproduction); the class-name fallback at least makes any future occurrence diagnosable instead of silent.
- **#128 — remove pre-login web-UI tip**: the workaround in `_print_device_prompt` is no longer needed now that `memory-cloud#772` ships a login-gated `/device` page. The 4-line tip is deleted; the matching test in `test_auth_cli.py` is flipped from "tip present" to "tip absent" as a defensive guard against accidental reintroduction.

## Implementation notes

- The defensive pattern `msg = str(e) or e.__class__.__name__` is duplicated inline at exactly 2 sites (one per wrapper). A `/code-review` pass identified ~12 additional latent sites in `auth/cli.py`, `client.py`, `files_client.py`, and `resource_client.py` with the same `f"... {e}"` swallow-empty-message pattern. Helper extraction (`_exc_message` in `exceptions.py`) + applying it to all 14 sites is filed as **#130** to keep this PR scoped to the user-reported `setup claude` path.
- New regression tests use the existing `_setup_args(tmp_path)` helper and `runner: CliRunner` fixture — no new test infrastructure. Mock boundaries are at `kagura_memory.setup_claude._test_connection` (inner) and `kagura_memory.cli.run_setup_claude` (outer) to exercise each wrapper independently.
- CHANGELOG `Unreleased` line about adding the tip (originally added in v0.19.0) is replaced by the removal bullet, paired with the new fix bullet for #127. Two other Unreleased entries from v0.19.0 remain stale and will be cleaned up by the next `/release patch` run.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (PM lens — batch coherence approved)
- review provider: code-review

Follow-up issue filed: #130 (extract `_exc_message` helper, apply to 12 remaining sites).

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/127-batch-127-128.gate1.md
- ~/.claude/cache/gh-issue-driven/127-batch-127-128.gate2.md

🤖 Generated via /gh-issue-driven:ship
