### PR TITLE
feat(setup-claude): auto-select context by directory-name fuzzy match (#129)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1018,7 +1018,8 @@ def setup():
 @click.option("--context-id", help="Context ID or name (skip prompt)")
 @click.option("--project-dir", default=".", help="Project directory (default: current)")
 @click.option("--non-interactive", "-y", is_flag=True, help="No prompts, use defaults/flags")
-def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
+@click.option("--no-auto-context", is_flag=True, help="Disable auto-select by directory name")
+def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive, no_auto_context):
     """
     Set up Kagura Memory integration for Claude Code.
 
@@ -1028,6 +1029,7 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
       kagura setup claude
       kagura setup claude --api-key kagura_xxx --mcp-url http://localhost:8080/mcp/w/{workspace_id}
       kagura setup claude -y --api-key kagura_xxx --context-id my-project
+      kagura setup claude --no-auto-context  # always show full context list
     """
     try:
         run_setup_claude(
@@ -1036,6 +1038,7 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive):
             context_id=context_id,
             project_dir=project_dir,
             non_interactive=non_interactive,
+            no_auto_context=no_auto_context,
         )
     except (click.Abort, click.ClickException):
         # click.Abort fires on Ctrl+D / explicit abort during prompts — let Click

--- a/src/kagura_memory/setup_claude.py
+++ b/src/kagura_memory/setup_claude.py
@@ -199,10 +199,11 @@ def _select_or_create_context(
     if contexts and not no_auto_context:
         auto = _auto_match_context(contexts, project_dir)
         if auto:
-            click.echo(f"\nAuto-selected context: {auto['name']} ({auto['id'][:8]}...)")
+            auto_id = auto.get("id", "")
+            click.echo(f"\nAuto-selected context: {auto.get('name', '?')} ({auto_id[:8]}...)")
             click.echo("  (use --no-auto-context to disable, or pick a different one below)")
             if click.confirm("Use this context?", default=True):
-                return auto["id"]
+                return auto_id
         # Fall through to manual selection if auto-match declined
 
     if contexts:

--- a/src/kagura_memory/setup_claude.py
+++ b/src/kagura_memory/setup_claude.py
@@ -142,6 +142,30 @@ async def _create_context(
         return await client.create_context(name=name, summary=summary)
 
 
+def _auto_match_context(
+    contexts: list[dict[str, Any]], project_dir: Path, threshold: float = 0.65
+) -> dict[str, Any] | None:
+    """Return the context whose name best matches the project dir name,
+    or None if no candidate clears the threshold."""
+    from difflib import SequenceMatcher
+
+    target = project_dir.name.lower().replace("_", "-")
+    best: tuple[float, dict[str, Any]] | None = None
+    for ctx in contexts:
+        name = (ctx.get("name") or "").lower().replace("_", "-")
+        if not name:
+            continue
+        score = SequenceMatcher(None, target, name).ratio()
+        # Bonus for substring containment in either direction
+        if target in name or name in target:
+            score = max(score, 0.85)
+        if best is None or score > best[0]:
+            best = (score, ctx)
+    if best and best[0] >= threshold:
+        return best[1]
+    return None
+
+
 def _select_or_create_context(
     contexts_response: dict[str, Any],
     api_key: str,
@@ -149,6 +173,7 @@ def _select_or_create_context(
     preselected: str | None,
     project_dir: Path,
     non_interactive: bool,
+    no_auto_context: bool = False,
 ) -> str:
     """Select existing context or create a new one. Returns context_id."""
     contexts = contexts_response.get("contexts", [])
@@ -170,6 +195,15 @@ def _select_or_create_context(
         ctx_id = result.get("context_id") or result.get("id", "")
         click.echo(f"  Created context: {default_name} ({ctx_id[:8]}...)")
         return ctx_id
+
+    if contexts and not no_auto_context:
+        auto = _auto_match_context(contexts, project_dir)
+        if auto:
+            click.echo(f"\nAuto-selected context: {auto['name']} ({auto['id'][:8]}...)")
+            click.echo("  (use --no-auto-context to disable, or pick a different one below)")
+            if click.confirm("Use this context?", default=True):
+                return auto["id"]
+        # Fall through to manual selection if auto-match declined
 
     if contexts:
         click.echo("\nExisting contexts:")
@@ -307,6 +341,7 @@ def run_setup_claude(
     context_id: str | None,
     project_dir: str,
     non_interactive: bool,
+    no_auto_context: bool = False,
 ) -> None:
     """Run the full setup flow for Claude Code integration."""
     project = Path(project_dir).resolve()
@@ -357,6 +392,7 @@ def run_setup_claude(
         effective_context_id,
         project,
         non_interactive,
+        no_auto_context,
     )
 
     # 5. Validate context_id before interpolating into shell commands

--- a/src/kagura_memory/setup_claude.py
+++ b/src/kagura_memory/setup_claude.py
@@ -146,11 +146,16 @@ def _auto_match_context(
     contexts: list[dict[str, Any]], project_dir: Path, threshold: float = 0.65
 ) -> dict[str, Any] | None:
     """Return the context whose name best matches the project dir name,
-    or None if no candidate clears the threshold."""
+    or None if no candidate clears the threshold or there is an ambiguous tie."""
     from difflib import SequenceMatcher
 
     target = project_dir.name.lower().replace("_", "-")
+    if not target:
+        # Empty target (e.g., Path("/") or Path(".") with no resolved name) would
+        # cause `target in name` to be True for every candidate. Bail early.
+        return None
     best: tuple[float, dict[str, Any]] | None = None
+    tied = False
     for ctx in contexts:
         name = (ctx.get("name") or "").lower().replace("_", "-")
         if not name:
@@ -161,7 +166,11 @@ def _auto_match_context(
             score = max(score, 0.85)
         if best is None or score > best[0]:
             best = (score, ctx)
-    if best and best[0] >= threshold:
+            tied = False
+        elif score == best[0]:
+            tied = True
+    # Reject ambiguous matches (top score ties — fall through to manual prompt)
+    if best and best[0] >= threshold and not tied:
         return best[1]
     return None
 
@@ -200,9 +209,9 @@ def _select_or_create_context(
         auto = _auto_match_context(contexts, project_dir)
         if auto:
             auto_id = auto.get("id", "")
-            click.echo(f"\nAuto-selected context: {auto.get('name', '?')} ({auto_id[:8]}...)")
+            click.echo(f"\nSuggested context: {auto.get('name', '?')} ({auto_id[:8]}...)")
             click.echo("  (use --no-auto-context to disable, or pick a different one below)")
-            if click.confirm("Use this context?", default=True):
+            if click.confirm("Use this suggested context?", default=True):
                 return auto_id
         # Fall through to manual selection if auto-match declined
 

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -84,7 +84,7 @@ class TestPromptMcpUrl:
 class TestSelectOrCreateContext:
     @patch("kagura_memory.setup_claude._create_context")
     def test_interactive_select_existing(self, mock_create: AsyncMock) -> None:
-        """Interactive: user selects an existing context."""
+        """Interactive: user selects an existing context (manual list path)."""
         with patch("kagura_memory.setup_claude.click") as mock_click:
             mock_click.prompt.return_value = 1
             mock_click.echo = MagicMock()
@@ -95,6 +95,7 @@ class TestSelectOrCreateContext:
                 None,
                 Path("/tmp/test"),
                 non_interactive=False,
+                no_auto_context=True,
             )
             assert result == "ctx-abc"
 
@@ -113,6 +114,7 @@ class TestSelectOrCreateContext:
                 None,
                 Path("/tmp/test"),
                 non_interactive=False,
+                no_auto_context=True,
             )
             assert result == "ctx-new"
 
@@ -134,8 +136,68 @@ class TestSelectOrCreateContext:
                 None,
                 Path("/tmp/test"),
                 non_interactive=False,
+                no_auto_context=True,
             )
             assert result == "ctx-brand-new"
+
+    def test_auto_match_confirm_true_returns_matched_id(self) -> None:
+        """Interactive: auto-match suggests a context, user confirms → matched id is returned."""
+        with patch("kagura_memory.setup_claude.click") as mock_click:
+            mock_click.confirm.return_value = True
+            mock_click.echo = MagicMock()
+            # Dir name 'kagura-memory' exactly matches context name → ratio == 1.0
+            result = _select_or_create_context(
+                {"contexts": [{"id": "ctx-match", "name": "kagura-memory"}]},
+                "key",
+                "url",
+                None,
+                Path("/tmp/kagura-memory"),
+                non_interactive=False,
+            )
+            assert result == "ctx-match"
+            mock_click.confirm.assert_called_once()
+
+    def test_auto_match_confirm_false_falls_through_to_manual(self) -> None:
+        """Interactive: auto-match suggests, user declines → manual list prompt is shown."""
+        with patch("kagura_memory.setup_claude.click") as mock_click:
+            mock_click.confirm.return_value = False
+            mock_click.prompt.return_value = 1  # pick first item from manual list
+            mock_click.echo = MagicMock()
+            mock_click.IntRange = click.IntRange
+            result = _select_or_create_context(
+                {"contexts": [{"id": "ctx-match", "name": "kagura-memory"}]},
+                "key",
+                "url",
+                None,
+                Path("/tmp/kagura-memory"),
+                non_interactive=False,
+            )
+            # Same id, but via the manual prompt path — verify confirm was asked and prompt followed
+            assert result == "ctx-match"
+            mock_click.confirm.assert_called_once()
+            mock_click.prompt.assert_called_once()
+
+    def test_no_auto_context_skips_auto_match(self) -> None:
+        """Interactive: no_auto_context=True bypasses _auto_match_context entirely."""
+        with (
+            patch("kagura_memory.setup_claude.click") as mock_click,
+            patch("kagura_memory.setup_claude._auto_match_context") as mock_auto_match,
+        ):
+            mock_click.prompt.return_value = 1
+            mock_click.echo = MagicMock()
+            mock_click.IntRange = click.IntRange
+            result = _select_or_create_context(
+                {"contexts": [{"id": "ctx-match", "name": "kagura-memory"}]},
+                "key",
+                "url",
+                None,
+                Path("/tmp/kagura-memory"),
+                non_interactive=False,
+                no_auto_context=True,
+            )
+            assert result == "ctx-match"
+            mock_auto_match.assert_not_called()
+            mock_click.confirm.assert_not_called()
 
 
 # =============================================================================
@@ -660,21 +722,19 @@ class TestAutoMatchContext:
         assert result is not None
         assert result["id"] == "ctx-2"
 
-    def test_tie_first_encountered_wins(self) -> None:
-        """When scores tie, the first candidate encountered wins (strict `>`)."""
+    def test_tie_at_top_score_returns_none(self) -> None:
+        """Ambiguous tie at top score should fall back to manual selection (None)."""
         # Both names are substrings of the dir name → both forced to 0.85 → tie.
-        # The strict `>` comparison in the loop keeps the first one seen.
+        # Per issue #129 spec ("Reject ambiguous matches"), tie must return None.
         contexts = [
             {"id": "ctx-1", "name": "alpha"},
             {"id": "ctx-2", "name": "beta"},
         ]
         result = _auto_match_context(contexts, Path("/tmp/alpha-beta-mix"))
-        assert result is not None
-        assert result["id"] == "ctx-1"
+        assert result is None
 
-    def test_threshold_boundary(self) -> None:
-        """Score exactly at threshold should match."""
-        # Create a scenario where score is close to threshold
+    def test_exact_match_passes_default_threshold(self) -> None:
+        """Exact name match should clear the default 0.65 threshold."""
         contexts = [{"id": "ctx-1", "name": "kagura-mem"}]
         result = _auto_match_context(contexts, Path("/tmp/kagura-mem"), threshold=0.65)
         assert result is not None
@@ -684,4 +744,15 @@ class TestAutoMatchContext:
         contexts = [{"id": "ctx-1", "name": "kagura-mem"}]
         # With very high threshold, even close matches fail
         result = _auto_match_context(contexts, Path("/tmp/kagura-memory"), threshold=0.95)
+        assert result is None
+
+    def test_empty_project_dir_name_returns_none(self) -> None:
+        """An empty project_dir.name must not trigger the substring bonus for every candidate."""
+        # Path("/") has .name == "". Without the guard, `"" in name` would be True
+        # for every context, boosting every candidate to 0.85 and producing arbitrary matches.
+        contexts = [
+            {"id": "ctx-1", "name": "alpha"},
+            {"id": "ctx-2", "name": "beta"},
+        ]
+        result = _auto_match_context(contexts, Path("/"))
         assert result is None

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 from kagura_memory.cli import main
 from kagura_memory.setup_claude import (
     KAGURA_HOOK_MARKER,
+    _auto_match_context,
     _check_gitignore,
     _install_hooks,
     _install_skills,
@@ -591,3 +592,95 @@ def test_setup_claude_reuses_existing_context_id(
     assert result.exit_code == 0, result.output
     data = json.loads((tmp_path / ".kagura.json").read_text())
     assert data["context_id"] == "ctx-from-config"
+
+
+# =============================================================================
+# Auto-Match Context Tests
+# =============================================================================
+
+
+class TestAutoMatchContext:
+    """Tests for _auto_match_context fuzzy matching logic."""
+
+    def test_exact_match(self) -> None:
+        """Exact directory-name match should return high score."""
+        contexts = [{"id": "ctx-1", "name": "kagura-memory-python-sdk"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory-python-sdk"))
+        assert result is not None
+        assert result["id"] == "ctx-1"
+
+    def test_exact_match_with_underscore_normalization(self) -> None:
+        """Underscores should be normalized to dashes."""
+        contexts = [{"id": "ctx-1", "name": "kagura_memory_python_sdk"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory-python-sdk"))
+        assert result is not None
+        assert result["id"] == "ctx-1"
+
+    def test_substring_match_gets_bonus(self) -> None:
+        """Substring containment should boost score to >= 0.85."""
+        # Dir name is a substring of context name
+        contexts = [{"id": "ctx-1", "name": "kagura-memory-python-sdk-dev"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory-python-sdk"))
+        assert result is not None
+        assert result["id"] == "ctx-1"
+
+    def test_context_name_is_substring_of_dir(self) -> None:
+        """Context name as substring of dir name should also get bonus."""
+        contexts = [{"id": "ctx-1", "name": "ai-worker"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-ai-worker-dev"))
+        assert result is not None
+        assert result["id"] == "ctx-1"
+
+    def test_no_match_below_threshold(self) -> None:
+        """No match should return None."""
+        contexts = [{"id": "ctx-1", "name": "completely-unrelated-project"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory-python-sdk"))
+        assert result is None
+
+    def test_empty_context_list(self) -> None:
+        """Empty context list should return None."""
+        result = _auto_match_context([], Path("/tmp/kagura-memory-python-sdk"))
+        assert result is None
+
+    def test_context_with_empty_name(self) -> None:
+        """Context with empty name should be skipped."""
+        contexts = [{"id": "ctx-1", "name": ""}, {"id": "ctx-2", "name": "kagura-memory"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory"))
+        assert result is not None
+        assert result["id"] == "ctx-2"
+
+    def test_multiple_candidates_picks_best(self) -> None:
+        """Should pick the best match among multiple candidates."""
+        contexts = [
+            {"id": "ctx-1", "name": "other-project"},
+            {"id": "ctx-2", "name": "kagura-memory-python-sdk"},
+            {"id": "ctx-3", "name": "kagura-something-else"},
+        ]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory-python-sdk"))
+        assert result is not None
+        assert result["id"] == "ctx-2"
+
+    def test_tie_falls_through_to_highest_score(self) -> None:
+        """When scores tie, first encountered wins (implementation detail)."""
+        contexts = [
+            {"id": "ctx-1", "name": "project-alpha"},
+            {"id": "ctx-2", "name": "project-beta"},
+        ]
+        # Both equally unrelated to 'kagura-memory' - first one with best score wins
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory"))
+        # Just verify it returns one of them (deterministic behavior)
+        assert result is None or result["id"] in ["ctx-1", "ctx-2"]
+
+    def test_threshold_boundary(self) -> None:
+        """Score exactly at threshold should match."""
+        # Create a scenario where score is close to threshold
+        contexts = [{"id": "ctx-1", "name": "kagura-mem"}]
+        result = _auto_match_context(contexts, Path("/tmp/kagura-mem"), threshold=0.65)
+        assert result is not None
+
+    def test_custom_threshold(self) -> None:
+        """Higher threshold should reject marginal matches."""
+        contexts = [{"id": "ctx-1", "name": "kagura-mem"}]
+        # With very high threshold, even close matches fail
+        result = _auto_match_context(contexts, Path("/tmp/kagura-memory"), threshold=0.95)
+        assert result is None

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -660,16 +660,17 @@ class TestAutoMatchContext:
         assert result is not None
         assert result["id"] == "ctx-2"
 
-    def test_tie_falls_through_to_highest_score(self) -> None:
-        """When scores tie, first encountered wins (implementation detail)."""
+    def test_tie_first_encountered_wins(self) -> None:
+        """When scores tie, the first candidate encountered wins (strict `>`)."""
+        # Both names are substrings of the dir name → both forced to 0.85 → tie.
+        # The strict `>` comparison in the loop keeps the first one seen.
         contexts = [
-            {"id": "ctx-1", "name": "project-alpha"},
-            {"id": "ctx-2", "name": "project-beta"},
+            {"id": "ctx-1", "name": "alpha"},
+            {"id": "ctx-2", "name": "beta"},
         ]
-        # Both equally unrelated to 'kagura-memory' - first one with best score wins
-        result = _auto_match_context(contexts, Path("/tmp/kagura-memory"))
-        # Just verify it returns one of them (deterministic behavior)
-        assert result is None or result["id"] in ["ctx-1", "ctx-2"]
+        result = _auto_match_context(contexts, Path("/tmp/alpha-beta-mix"))
+        assert result is not None
+        assert result["id"] == "ctx-1"
 
     def test_threshold_boundary(self) -> None:
         """Score exactly at threshold should match."""


### PR DESCRIPTION
Closes #129

## Summary
- `kagura setup claude` でコンテキスト選択時、プロジェクトディレクトリ名から既存コンテキストへの fuzzy match を試み、信頼度が閾値を超えた場合に `click.confirm` で自動選択を提案する
- マッチには `difflib.SequenceMatcher` の比率(0.65 閾値)を使用し、片方が他方の部分文字列なら 0.85 にブースト
- レガシー挙動を維持したい場合は `--no-auto-context` フラグでオプトアウト可能
- 17+ コンテキストある環境で毎回スクロールメニューに直面する手間を解消(v0.19.0 リリース検証で報告)

## Implementation notes
- 新規ヘルパ `_auto_match_context` を純粋関数として `setup_claude.py:145-166` に追加(stdlib `difflib` のみに依存、新規依存ゼロ)
- 結線部は `_select_or_create_context` に 4 行の `if` ブロックを挿入(`setup_claude.py:199-206`)— `preselected` / `non_interactive` の早期 return より後、手動リスト選択の前
- CLI 配線: `setup_claude` コマンドに `--no-auto-context` flag を追加し、`run_setup_claude` 経由で伝搬
- ユニットテスト 11 ケース追加(`TestAutoMatchContext`): exact match、underscore 正規化、両方向の部分文字列、空リスト、空名前、複数候補、tie、閾値境界、カスタム閾値

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: not run (ship-only mode — no prior /gh-issue-driven:start state)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/129-feat-setup-claude-auto-context.gate2.md

🤖 Generated via /gh-issue-driven:ship
