### PR TITLE
feat(ollama): support Ollama Cloud — OLLAMA_API_KEY env / ollama_api_key kwarg (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ## Unreleased
 
+- `KaguraAgent` now supports Ollama Cloud: new `ollama_api_key` kwarg defaulting to `OLLAMA_API_KEY` env var; `ollama_base_url` defaults to `OLLAMA_HOST` env (then `http://localhost:11434`); `_call_ollama` injects `Authorization: Bearer <key>` when a key is configured. HTTP 401/403 from Ollama is now mapped to `KaguraAuthError` (was generic `KaguraLLMError`). Explicit `ollama_base_url=""` raises `ValueError` instead of producing a relative URL. (#124)
+- Ingest `OllamaProvider` now uses the `ollama_chat/` litellm prefix so system messages are preserved through the native `/api/chat` route. Explicit `text_model` / `vision_model` values starting with the legacy `ollama/` prefix are auto-rewritten with a `DeprecationWarning`. Existing local-Ollama setups continue to work unchanged; for Ollama Cloud, set `OLLAMA_API_KEY` and `OLLAMA_API_BASE=https://ollama.com` (read by litellm directly). (#124)
 - `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
 - `kagura auth login` falls back to platform openers (`wslview` or `rundll32.exe url.dll,FileProtocolHandler` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122, #125)
 - Removed the pre-login web-UI tip from the device-flow prompt — `memory-cloud#772` shipped a login-gated `/device` page that no longer needs the client-side workaround. (#128)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,35 @@ agent = KaguraAgent(api_key="kagura_...", model="ollama/qwen3:30b")
 
 Smaller models (< 30B parameters) may produce lower quality memory analysis — summaries may lack searchable keywords, and recall query generation may be less precise.
 
+#### Using Ollama Cloud
+
+For [Ollama Cloud](https://ollama.com/cloud) (hosted, Bearer-authenticated), set the API key in the environment (the `ollama signin` CLI flow does this automatically) and point `ollama_base_url` at the cloud endpoint:
+
+```bash
+export OLLAMA_API_KEY="..."          # or run `ollama signin`
+```
+
+```python
+# KaguraAgent — Ollama Cloud
+agent = KaguraAgent(
+    api_key="kagura_...",
+    model="ollama/qwen3:30b",
+    ollama_base_url="https://ollama.com",
+    # ollama_api_key picks up OLLAMA_API_KEY from env by default;
+    # pass it explicitly to override.
+)
+```
+
+For ingestion, `kagura ingest` reads `OLLAMA_API_KEY` and `OLLAMA_API_BASE` from the environment (litellm picks them up directly for the `ollama_chat/` route):
+
+```bash
+export OLLAMA_API_KEY="..."
+export OLLAMA_API_BASE="https://ollama.com"
+kagura ingest report.pdf --text-provider ollama
+```
+
+The ingest provider uses litellm's `ollama_chat/` route (system messages preserved), so cloud and local share the same code path.
+
 ### KaguraClient — Direct Memory Operations
 
 For programmatic control without LLM:

--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -86,7 +86,15 @@ class KaguraAgent:
         self.model = model
         self.context_id = context_id
         self.max_retries = max_retries
-        self._llm_api_key = llm_api_key
+        # Capture llm_api_key in a closure — mirrors the Ollama key handling
+        # below to satisfy .claude/rules/python.md §Security ("Never store API
+        # keys as instance attributes").
+        _captured_llm_api_key = llm_api_key
+
+        def _get_llm_api_key() -> str | None:
+            return _captured_llm_api_key
+
+        self._get_llm_api_key = _get_llm_api_key
         self._is_ollama = model.startswith("ollama/")
         # `is not None` (not `or`) so an explicit empty string from the caller
         # is treated as misconfiguration rather than silently overridden by the
@@ -430,8 +438,9 @@ class KaguraAgent:
             "response_format": {"type": "json_object"},
             "timeout": 30.0,
         }
-        if self._llm_api_key:
-            kwargs["api_key"] = self._llm_api_key
+        llm_api_key = self._get_llm_api_key()
+        if llm_api_key:
+            kwargs["api_key"] = llm_api_key
 
         try:
             response = await litellm.acompletion(**kwargs)

--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -46,9 +46,9 @@ class KaguraAgent:
         max_retries: int = 3,
         llm_api_key: str | None = None,
         ollama_base_url: str | None = None,
-        ollama_api_key: str | None = None,
         ollama_think: bool = False,
         ollama_stream: bool = False,
+        ollama_api_key: str | None = None,
     ):
         """
         Initialize Kagura Agent.
@@ -73,11 +73,15 @@ class KaguraAgent:
                 falls back to ``OLLAMA_HOST`` env var, then to
                 ``http://localhost:11434``. Set to ``https://ollama.com`` for
                 Ollama Cloud.
-            ollama_api_key: Bearer token for Ollama Cloud. When ``None``
-                (default), falls back to ``OLLAMA_API_KEY`` env var. Leave
-                unset for local Ollama (no auth needed).
             ollama_think: Enable thinking mode for Ollama models (default: False)
             ollama_stream: Enable streaming for Ollama models (default: False)
+            ollama_api_key: Bearer token for Ollama Cloud. When ``None``
+                (default), falls back to ``OLLAMA_API_KEY`` env var. Leave
+                unset for local Ollama (no auth needed). The key is captured
+                in a closure (``self._get_ollama_api_key``) rather than as a
+                plain instance attribute, so it does not leak via casual
+                introspection (``vars(agent)`` / ``repr(agent)`` /
+                serialization) — only via explicit closure-cell inspection.
         """
         self.model = model
         self.context_id = context_id
@@ -100,9 +104,17 @@ class KaguraAgent:
                 "use the default, or set OLLAMA_HOST."
             )
         self._ollama_base_url = resolved_base_url.rstrip("/")
-        self._ollama_api_key = (
+        # Capture the Ollama API key in a closure rather than as a plain
+        # instance attribute so it does not leak via casual introspection
+        # (vars / repr / serialization) — see .claude/rules/python.md §Security.
+        _resolved_ollama_api_key = (
             ollama_api_key if ollama_api_key is not None else os.getenv("OLLAMA_API_KEY")
         )
+
+        def _get_ollama_api_key() -> str | None:
+            return _resolved_ollama_api_key
+
+        self._get_ollama_api_key = _get_ollama_api_key
         self._ollama_think = ollama_think
         self._ollama_stream = ollama_stream
         self._ollama_client: httpx.AsyncClient | None = None
@@ -443,15 +455,16 @@ class KaguraAgent:
     async def _call_ollama(self, messages: list[dict], temperature: float) -> tuple[dict, Any]:
         """Call LLM via Ollama API directly (local or Ollama Cloud).
 
-        When ``self._ollama_api_key`` is set (from ``ollama_api_key`` kwarg or
+        When an Ollama API key is configured (from ``ollama_api_key`` kwarg or
         ``OLLAMA_API_KEY`` env var), sends ``Authorization: Bearer <key>`` for
-        Ollama Cloud. Local Ollama (no key) sends no auth header.
+        Ollama Cloud. Local Ollama (no key) sends no auth header. The key is
+        resolved via the closure ``self._get_ollama_api_key()`` so the raw
+        secret is not retained as a named instance attribute.
         """
         model_name = self.model.removeprefix("ollama/")
         client = self._get_ollama_client()
-        headers = (
-            {"Authorization": f"Bearer {self._ollama_api_key}"} if self._ollama_api_key else None
-        )
+        api_key = self._get_ollama_api_key()
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
         try:
             resp = await client.post(
                 f"{self._ollama_base_url}/api/chat",

--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -84,14 +84,21 @@ class KaguraAgent:
         self.max_retries = max_retries
         self._llm_api_key = llm_api_key
         self._is_ollama = model.startswith("ollama/")
-        # Use `is not None` (not `or`) so an explicit empty string from the caller
-        # or environment surfaces as a configuration error at request time rather
-        # than silently falling back to a default.
+        # `is not None` (not `or`) so an explicit empty string from the caller
+        # is treated as misconfiguration rather than silently overridden by the
+        # default. Empty OLLAMA_HOST env collapses to default via the `or`
+        # chain (consistent with how shells often pass unset variables).
         resolved_base_url = (
             ollama_base_url
             if ollama_base_url is not None
             else (os.getenv("OLLAMA_HOST") or "http://localhost:11434")
         )
+        if not resolved_base_url:
+            raise ValueError(
+                "ollama_base_url must be a non-empty URL "
+                "(received empty string). Pass a real URL, omit the kwarg to "
+                "use the default, or set OLLAMA_HOST."
+            )
         self._ollama_base_url = resolved_base_url.rstrip("/")
         self._ollama_api_key = (
             ollama_api_key if ollama_api_key is not None else os.getenv("OLLAMA_API_KEY")

--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -3,6 +3,7 @@
 import asyncio
 import copy
 import json
+import os
 import time
 from collections.abc import Callable
 from typing import Any
@@ -44,7 +45,8 @@ class KaguraAgent:
         timeout: float = 30.0,
         max_retries: int = 3,
         llm_api_key: str | None = None,
-        ollama_base_url: str = "http://localhost:11434",
+        ollama_base_url: str | None = None,
+        ollama_api_key: str | None = None,
         ollama_think: bool = False,
         ollama_stream: bool = False,
     ):
@@ -59,12 +61,21 @@ class KaguraAgent:
             mcp_url: MCP server URL. When None, the underlying
                 ``KaguraClient`` derives it from the resolved
                 credential source.
-            model: LLM model to use (e.g., "gpt-5.4-nano", "ollama/qwen3:30b")
+            model: LLM model to use (e.g., "gpt-5.4-nano", "ollama/qwen3:30b").
+                For Ollama Cloud, pass ``ollama_base_url="https://ollama.com"``
+                and set ``OLLAMA_API_KEY`` in the environment (or pass
+                ``ollama_api_key`` explicitly).
             context_id: Default context ID (None or "auto" for auto-selection)
             timeout: Request timeout in seconds
             max_retries: Maximum LLM retry attempts
             llm_api_key: LLM provider API key (passed explicitly, not via env var)
-            ollama_base_url: Ollama API base URL (only used with ollama/ models)
+            ollama_base_url: Ollama API base URL. When ``None`` (default),
+                falls back to ``OLLAMA_HOST`` env var, then to
+                ``http://localhost:11434``. Set to ``https://ollama.com`` for
+                Ollama Cloud.
+            ollama_api_key: Bearer token for Ollama Cloud. When ``None``
+                (default), falls back to ``OLLAMA_API_KEY`` env var. Leave
+                unset for local Ollama (no auth needed).
             ollama_think: Enable thinking mode for Ollama models (default: False)
             ollama_stream: Enable streaming for Ollama models (default: False)
         """
@@ -73,7 +84,18 @@ class KaguraAgent:
         self.max_retries = max_retries
         self._llm_api_key = llm_api_key
         self._is_ollama = model.startswith("ollama/")
-        self._ollama_base_url = ollama_base_url.rstrip("/")
+        # Use `is not None` (not `or`) so an explicit empty string from the caller
+        # or environment surfaces as a configuration error at request time rather
+        # than silently falling back to a default.
+        resolved_base_url = (
+            ollama_base_url
+            if ollama_base_url is not None
+            else (os.getenv("OLLAMA_HOST") or "http://localhost:11434")
+        )
+        self._ollama_base_url = resolved_base_url.rstrip("/")
+        self._ollama_api_key = (
+            ollama_api_key if ollama_api_key is not None else os.getenv("OLLAMA_API_KEY")
+        )
         self._ollama_think = ollama_think
         self._ollama_stream = ollama_stream
         self._ollama_client: httpx.AsyncClient | None = None
@@ -412,9 +434,17 @@ class KaguraAgent:
         return self._ollama_client
 
     async def _call_ollama(self, messages: list[dict], temperature: float) -> tuple[dict, Any]:
-        """Call LLM via Ollama API directly (local models, thinking disabled for speed)."""
+        """Call LLM via Ollama API directly (local or Ollama Cloud).
+
+        When ``self._ollama_api_key`` is set (from ``ollama_api_key`` kwarg or
+        ``OLLAMA_API_KEY`` env var), sends ``Authorization: Bearer <key>`` for
+        Ollama Cloud. Local Ollama (no key) sends no auth header.
+        """
         model_name = self.model.removeprefix("ollama/")
         client = self._get_ollama_client()
+        headers = (
+            {"Authorization": f"Bearer {self._ollama_api_key}"} if self._ollama_api_key else None
+        )
         try:
             resp = await client.post(
                 f"{self._ollama_base_url}/api/chat",
@@ -426,11 +456,17 @@ class KaguraAgent:
                     "think": self._ollama_think,
                     "options": {"temperature": temperature},
                 },
+                headers=headers,
             )
             resp.raise_for_status()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 429:
                 raise KaguraRateLimitError("Ollama rate limit exceeded") from e
+            if e.response.status_code in (401, 403):
+                raise KaguraAuthError(
+                    f"Ollama auth failed: HTTP {e.response.status_code} "
+                    "(check OLLAMA_API_KEY or ollama_api_key)"
+                ) from e
             raise KaguraLLMError(f"Ollama API error: HTTP {e.response.status_code}") from e
         except httpx.RequestError as e:
             raise KaguraLLMError(f"Ollama connection failed: {e}") from e

--- a/src/kagura_memory/ingest/providers/ollama.py
+++ b/src/kagura_memory/ingest/providers/ollama.py
@@ -1,22 +1,70 @@
-"""Local Ollama provider via litellm.
+"""Ollama provider via litellm (local or Ollama Cloud).
 
-Uses ``qwen3:30b`` by default for text and ``qwen2.5vl:7b`` for vision —
-both well-supported in Ollama and capable of multilingual OCR. The
-``OLLAMA_HOST`` environment variable controls the base URL (default
-``http://localhost:11434``); litellm reads it directly.
+Uses ``qwen3:30b`` by default for text and ``qwen2.5vl:7b`` for vision.
+Model names use the ``ollama_chat/`` prefix so litellm dispatches via the
+native ``/api/chat`` endpoint (system messages preserved as-is). The
+legacy ``ollama/`` prefix routes through ``/api/generate``, which flattens
+system + user into a single prompt — explicit callers passing the legacy
+prefix are auto-migrated with a ``DeprecationWarning``.
 
-This is the recommended provider for sensitive documents: nothing leaves
-the user's machine.
+Environment variables read by litellm directly:
+
+- ``OLLAMA_API_BASE`` — base URL. Defaults to ``http://localhost:11434``;
+  set to ``https://ollama.com`` for Ollama Cloud.
+- ``OLLAMA_API_KEY`` — Bearer token for Ollama Cloud. Leave unset for
+  local Ollama (no auth needed).
+
+Two-step recipe for Ollama Cloud::
+
+    export OLLAMA_API_KEY="..."          # or use `ollama signin`
+    export OLLAMA_API_BASE="https://ollama.com"
+    kagura ingest --text-provider ollama ...
+
+For sensitive documents, leave both unset — nothing leaves the machine.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import ClassVar
 
 from ._litellm import LiteLLMProvider
 
 
+def _migrate_legacy_ollama_prefix(model: str | None) -> str | None:
+    """Rewrite ``ollama/<tag>`` to ``ollama_chat/<tag>`` with a DeprecationWarning.
+
+    The legacy ``ollama/`` prefix flattens system + user prompts via litellm's
+    ``/api/generate`` path; ``ollama_chat/`` preserves the message structure
+    through ``/api/chat``. Callers passing the legacy form are auto-migrated
+    so summarization quality is consistent.
+    """
+    if model and model.startswith("ollama/"):
+        new_model = "ollama_chat/" + model.removeprefix("ollama/")
+        warnings.warn(
+            (
+                f"OllamaProvider: model prefix 'ollama/' is deprecated — "
+                f"auto-rewriting '{model}' to '{new_model}'. Pass "
+                "'ollama_chat/...' explicitly to silence this warning."
+            ),
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return new_model
+    return model
+
+
 class OllamaProvider(LiteLLMProvider):
     name: ClassVar[str] = "ollama"
-    default_text_model: ClassVar[str] = "ollama/qwen3:30b"
-    default_vision_model: ClassVar[str | None] = "ollama/qwen2.5vl:7b"
+    default_text_model: ClassVar[str] = "ollama_chat/qwen3:30b"
+    default_vision_model: ClassVar[str | None] = "ollama_chat/qwen2.5vl:7b"
+
+    def __init__(
+        self,
+        text_model: str | None = None,
+        vision_model: str | None = None,
+    ):
+        super().__init__(
+            text_model=_migrate_legacy_ollama_prefix(text_model),
+            vision_model=_migrate_legacy_ollama_prefix(vision_model),
+        )

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -494,6 +494,128 @@ async def test_call_ollama_connection_error():
     await agent.close()
 
 
+# =============================================================================
+# Ollama Cloud auth tests (issue #124)
+# =============================================================================
+
+
+def _build_ollama_mock_client() -> AsyncMock:
+    """Helper: build an AsyncMock client returning a benign Ollama-shaped response."""
+    mock_client = AsyncMock()
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "message": {"role": "assistant", "content": '{"should_remember": false}'},
+        "prompt_eval_count": 10,
+        "eval_count": 5,
+    }
+    mock_resp.raise_for_status = MagicMock()
+    mock_client.post.return_value = mock_resp
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_call_ollama_sends_bearer_header_when_api_key_kwarg(monkeypatch):
+    """Explicit ollama_api_key kwarg should produce Authorization: Bearer header."""
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b", ollama_api_key="cloud-key-kwarg")
+    mock_client = _build_ollama_mock_client()
+    agent._ollama_client = mock_client
+
+    await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+
+    headers = mock_client.post.call_args.kwargs["headers"]
+    assert headers == {"Authorization": "Bearer cloud-key-kwarg"}
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_call_ollama_sends_bearer_header_from_env(monkeypatch):
+    """OLLAMA_API_KEY env var should be picked up when no kwarg is provided."""
+    monkeypatch.setenv("OLLAMA_API_KEY", "cloud-key-env")
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
+    mock_client = _build_ollama_mock_client()
+    agent._ollama_client = mock_client
+
+    await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+
+    headers = mock_client.post.call_args.kwargs["headers"]
+    assert headers == {"Authorization": "Bearer cloud-key-env"}
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_call_ollama_no_auth_header_when_no_key(monkeypatch):
+    """Local Ollama path (no kwarg, no env) sends no Authorization header."""
+    monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
+    mock_client = _build_ollama_mock_client()
+    agent._ollama_client = mock_client
+
+    await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+
+    # When no key is available, headers=None is passed (httpx treats it as no extra headers).
+    assert mock_client.post.call_args.kwargs["headers"] is None
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_call_ollama_kwarg_overrides_env(monkeypatch):
+    """Explicit ollama_api_key kwarg must win over OLLAMA_API_KEY env var."""
+    monkeypatch.setenv("OLLAMA_API_KEY", "env-key-should-lose")
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b", ollama_api_key="kwarg-key-wins")
+    mock_client = _build_ollama_mock_client()
+    agent._ollama_client = mock_client
+
+    await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+
+    assert mock_client.post.call_args.kwargs["headers"]["Authorization"] == "Bearer kwarg-key-wins"
+    await agent.close()
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@pytest.mark.asyncio
+async def test_call_ollama_auth_status_raises_auth_error(monkeypatch, status_code):
+    """HTTP 401/403 from Ollama Cloud must raise KaguraAuthError (not generic LLMError)."""
+    import httpx
+
+    monkeypatch.setenv("OLLAMA_API_KEY", "rejected-key")
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
+    mock_client = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        f"{status_code} auth", request=MagicMock(), response=mock_response
+    )
+    mock_client.post.return_value = mock_response
+    agent._ollama_client = mock_client
+
+    with pytest.raises(KaguraAuthError, match="Ollama auth failed"):
+        await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_ollama_base_url_falls_back_to_ollama_host_env(monkeypatch):
+    """OLLAMA_HOST env should be used when ollama_base_url kwarg is unset."""
+    monkeypatch.setenv("OLLAMA_HOST", "https://my-ollama.example.com")
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
+    assert agent._ollama_base_url == "https://my-ollama.example.com"
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_ollama_base_url_kwarg_overrides_ollama_host_env(monkeypatch):
+    """Explicit ollama_base_url kwarg must win over OLLAMA_HOST env."""
+    monkeypatch.setenv("OLLAMA_HOST", "https://env-host.example.com")
+    agent = KaguraAgent(
+        api_key="test",
+        model="ollama/qwen3:30b",
+        ollama_base_url="https://kwarg-host.example.com",
+    )
+    assert agent._ollama_base_url == "https://kwarg-host.example.com"
+    await agent.close()
+
+
 @pytest.mark.asyncio
 async def test_execute_recalls_explore_auth_error():
     """_execute_recalls should propagate KaguraAuthError from explore."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -360,8 +360,12 @@ async def test_call_litellm_passes_api_key():
 
 
 @pytest.mark.asyncio
-async def test_ollama_model_detection():
+async def test_ollama_model_detection(monkeypatch):
     """Agent should detect ollama/ prefix and set _is_ollama flag."""
+    # KaguraAgent.__init__ now reads OLLAMA_HOST as a fallback for
+    # ollama_base_url, so dev/CI machines with that env var set would
+    # break the default-URL assertion below. Clear it for this test.
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
     assert agent._is_ollama is True
     assert agent._ollama_base_url == "http://localhost:11434"
@@ -517,6 +521,7 @@ def _build_ollama_mock_client() -> AsyncMock:
 async def test_call_ollama_sends_bearer_header_when_api_key_kwarg(monkeypatch):
     """Explicit ollama_api_key kwarg should produce Authorization: Bearer header."""
     monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b", ollama_api_key="cloud-key-kwarg")
     mock_client = _build_ollama_mock_client()
     agent._ollama_client = mock_client
@@ -532,6 +537,7 @@ async def test_call_ollama_sends_bearer_header_when_api_key_kwarg(monkeypatch):
 async def test_call_ollama_sends_bearer_header_from_env(monkeypatch):
     """OLLAMA_API_KEY env var should be picked up when no kwarg is provided."""
     monkeypatch.setenv("OLLAMA_API_KEY", "cloud-key-env")
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
     mock_client = _build_ollama_mock_client()
     agent._ollama_client = mock_client
@@ -547,6 +553,7 @@ async def test_call_ollama_sends_bearer_header_from_env(monkeypatch):
 async def test_call_ollama_no_auth_header_when_no_key(monkeypatch):
     """Local Ollama path (no kwarg, no env) sends no Authorization header."""
     monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
     mock_client = _build_ollama_mock_client()
     agent._ollama_client = mock_client
@@ -562,6 +569,7 @@ async def test_call_ollama_no_auth_header_when_no_key(monkeypatch):
 async def test_call_ollama_kwarg_overrides_env(monkeypatch):
     """Explicit ollama_api_key kwarg must win over OLLAMA_API_KEY env var."""
     monkeypatch.setenv("OLLAMA_API_KEY", "env-key-should-lose")
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b", ollama_api_key="kwarg-key-wins")
     mock_client = _build_ollama_mock_client()
     agent._ollama_client = mock_client
@@ -572,13 +580,14 @@ async def test_call_ollama_kwarg_overrides_env(monkeypatch):
     await agent.close()
 
 
-@pytest.mark.parametrize("status_code", [401, 403])
 @pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403])
 async def test_call_ollama_auth_status_raises_auth_error(monkeypatch, status_code):
     """HTTP 401/403 from Ollama Cloud must raise KaguraAuthError (not generic LLMError)."""
     import httpx
 
     monkeypatch.setenv("OLLAMA_API_KEY", "rejected-key")
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")
     mock_client = AsyncMock()
     mock_response = MagicMock()
@@ -589,9 +598,11 @@ async def test_call_ollama_auth_status_raises_auth_error(monkeypatch, status_cod
     mock_client.post.return_value = mock_response
     agent._ollama_client = mock_client
 
-    with pytest.raises(KaguraAuthError, match="Ollama auth failed"):
-        await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
-    await agent.close()
+    try:
+        with pytest.raises(KaguraAuthError, match="Ollama auth failed"):
+            await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+    finally:
+        await agent.close()
 
 
 @pytest.mark.asyncio
@@ -614,6 +625,14 @@ async def test_ollama_base_url_kwarg_overrides_ollama_host_env(monkeypatch):
     )
     assert agent._ollama_base_url == "https://kwarg-host.example.com"
     await agent.close()
+
+
+def test_ollama_base_url_empty_string_raises_value_error(monkeypatch):
+    """Explicit ollama_base_url='' must raise ValueError, not silently degrade
+    to a relative '/api/chat' URL that surfaces as a cryptic connection error."""
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    with pytest.raises(ValueError, match="ollama_base_url must be a non-empty"):
+        KaguraAgent(api_key="test", model="ollama/qwen3:30b", ollama_base_url="")
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_litellm_provider.py
+++ b/tests/test_ingest_litellm_provider.py
@@ -80,6 +80,27 @@ def test_ollama_provider_migrates_legacy_vision_prefix_with_warning() -> None:
     assert p.vision_model == "ollama_chat/qwen2.5vl:7b"
 
 
+def test_ollama_provider_migration_warning_stacklevel_points_to_caller() -> None:
+    """DeprecationWarning must attribute to the user's OllamaProvider(...) call site,
+    not to the internal __init__ or _migrate_legacy_ollama_prefix helper.
+
+    Regression guard: empirical proof that stacklevel=3 is correct given the
+    call chain (helper -> __init__ -> user). If anyone adds an extra wrapper
+    layer, this test will fail and signal the need to bump stacklevel.
+    """
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        # The next line is the user call site — the warning MUST point here:
+        OllamaProvider(text_model="ollama/qwen3:30b")  # capture this lineno
+
+    assert len(record) == 1
+    assert record[0].category is DeprecationWarning
+    # The warning's filename must be this test file (not agent.py / ollama.py).
+    assert record[0].filename == __file__
+
+
 def test_ollama_provider_no_warning_for_chat_prefix() -> None:
     """Explicit ollama_chat/ prefix passes through without a kagura DeprecationWarning."""
     import warnings

--- a/tests/test_ingest_litellm_provider.py
+++ b/tests/test_ingest_litellm_provider.py
@@ -57,6 +57,39 @@ def test_ollama_provider_presets_are_set() -> None:
     assert isinstance(OllamaProvider(), Provider)
 
 
+def test_ollama_provider_uses_ollama_chat_prefix() -> None:
+    """OllamaProvider must use ollama_chat/ so litellm routes via /api/chat
+    (system messages preserved). The legacy ollama/ prefix flattens system +
+    user into a single prompt via /api/generate."""
+    assert OllamaProvider.default_text_model.startswith("ollama_chat/")
+    assert OllamaProvider.default_vision_model is not None
+    assert OllamaProvider.default_vision_model.startswith("ollama_chat/")
+
+
+def test_ollama_provider_migrates_legacy_prefix_with_warning() -> None:
+    """Explicit text_model='ollama/...' auto-rewrites to 'ollama_chat/...' + warns."""
+    with pytest.warns(DeprecationWarning, match="ollama/' is deprecated"):
+        p = OllamaProvider(text_model="ollama/qwen3:30b")
+    assert p.text_model == "ollama_chat/qwen3:30b"
+
+
+def test_ollama_provider_migrates_legacy_vision_prefix_with_warning() -> None:
+    """vision_model='ollama/...' is also rewritten with a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="ollama/' is deprecated"):
+        p = OllamaProvider(vision_model="ollama/qwen2.5vl:7b")
+    assert p.vision_model == "ollama_chat/qwen2.5vl:7b"
+
+
+def test_ollama_provider_no_warning_for_chat_prefix() -> None:
+    """Explicit ollama_chat/ prefix passes through silently."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        p = OllamaProvider(text_model="ollama_chat/llama3:8b")
+    assert p.text_model == "ollama_chat/llama3:8b"
+
+
 # ---------------------------------------------------------------------------
 # get_provider() factory
 # ---------------------------------------------------------------------------

--- a/tests/test_ingest_litellm_provider.py
+++ b/tests/test_ingest_litellm_provider.py
@@ -81,11 +81,15 @@ def test_ollama_provider_migrates_legacy_vision_prefix_with_warning() -> None:
 
 
 def test_ollama_provider_no_warning_for_chat_prefix() -> None:
-    """Explicit ollama_chat/ prefix passes through silently."""
+    """Explicit ollama_chat/ prefix passes through without a kagura DeprecationWarning."""
     import warnings
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        # Promote only SDK-emitted DeprecationWarnings to errors so an
+        # unrelated warning from litellm or another dep doesn't fail this test.
+        warnings.filterwarnings(
+            "error", category=DeprecationWarning, module=r"kagura_memory(\..*)?"
+        )
         p = OllamaProvider(text_model="ollama_chat/llama3:8b")
     assert p.text_model == "ollama_chat/llama3:8b"
 


### PR DESCRIPTION
Closes #124

## Summary
- Add Ollama Cloud Bearer-token auth to `KaguraAgent`'s raw httpx `/api/chat` path. `OLLAMA_API_KEY` env var is read by default; explicit `ollama_api_key` kwarg overrides.
- Honor `OLLAMA_HOST` env var as a fallback for `ollama_base_url` (matches litellm's well-known behavior and the AC spec).
- Map HTTP 401/403 on the Ollama path to `KaguraAuthError` so the existing `_call_llm` retry loop correctly skips retry for auth failures.
- Switch ingest `OllamaProvider` default to `ollama_chat/qwen3:30b` (litellm `/api/chat` route preserves system messages). Explicit legacy `ollama/` prefixes are auto-rewritten with a `DeprecationWarning` — existing local-Ollama setups continue to work.

## Implementation notes
- `KaguraAgent.__init__` (`agent.py:38-91`): new `ollama_api_key` kwarg, `ollama_base_url` defaults to `None` and falls back through `os.getenv("OLLAMA_HOST")` → `http://localhost:11434`. Uses `is not None` (not `or`) so explicit `""` raises `ValueError` rather than silently producing a relative URL.
- `_call_ollama` (`agent.py:441-481`): injects `Authorization: Bearer <key>` header per-request when a key is configured; sends no auth header for local Ollama. New 401/403 → `KaguraAuthError` branch precedes the generic `KaguraLLMError`.
- `ingest/providers/ollama.py`: new `__init__` override + `_migrate_legacy_ollama_prefix` helper. Default text/vision models use `ollama_chat/` prefix. Ingest reads `OLLAMA_API_KEY` / `OLLAMA_API_BASE` via litellm (env-only, no `LiteLLMProvider` changes — matches claude/gemini precedent).
- 13 new tests: 9 in `test_agent.py` (Bearer kwarg/env, kwarg-over-env, no-key, 401/403 parametrize, `OLLAMA_HOST` fallback + override, empty-string `ValueError`), 4 in `test_ingest_litellm_provider.py` (`ollama_chat/` prefix, text + vision migration, chat-prefix passthrough).
- CHANGELOG entries cover both Cloud features and the legacy-prefix migration.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask → CTO lens
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/124-feat-feat-ollama-support-ollama-cloud-ollama.gate1.md
- ~/.claude/cache/gh-issue-driven/124-feat-feat-ollama-support-ollama-cloud-ollama.gate2.md

🤖 Generated via /gh-issue-driven:ship
