### PR TITLE
docs: add monthly PyPI downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/kagura-memory/"><img src="https://img.shields.io/pypi/v/kagura-memory" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/kagura-memory/"><img src="https://img.shields.io/pypi/dm/kagura-memory" alt="PyPI downloads/month"></a>
   <a href="https://pypi.org/project/kagura-memory/"><img src="https://img.shields.io/pypi/pyversions/kagura-memory" alt="Python versions"></a>
   <a href="https://github.com/kagura-ai/kagura-memory-python-sdk/actions/workflows/ci.yml"><img src="https://github.com/kagura-ai/kagura-memory-python-sdk/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://codecov.io/gh/kagura-ai/kagura-memory-python-sdk"><img src="https://codecov.io/gh/kagura-ai/kagura-memory-python-sdk/graph/badge.svg" alt="codecov"></a>


### PR DESCRIPTION
## Summary

Add a `https://img.shields.io/pypi/dm/kagura-memory` badge to the README header row, next to the existing `pypi/v/kagura-memory` version badge. shields.io's `dm` (downloads/month) endpoint backs onto pypistats / PyPI BigQuery so the number updates roughly daily without any infra on our side.

## Why this matters

The version badge alone communicates "we released something". The downloads badge communicates traction — useful signal for new visitors deciding whether the project is alive and used.

## Notes

- Single shields.io badge, matches the visual style of the surrounding badges (no design drift).
- No code changes, no test changes.
- Number will show as "no data" or "0" for the first few hours/days after the v0.20.0 release until PyPI's stats backend processes the download events.

🤖 Process note: this PR replaces commit \`1a3f3ed\` which was pushed directly to main, then reverted in \`adca7b0\` so the change goes through the standard branch + PR + squash-merge flow per CLAUDE.md.