### PR TITLE
docs: switch downloads badge to pepy.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/kagura-memory/"><img src="https://img.shields.io/pypi/v/kagura-memory" alt="PyPI version"></a>
-  <a href="https://pypi.org/project/kagura-memory/"><img src="https://img.shields.io/pypi/dm/kagura-memory" alt="PyPI downloads/month"></a>
+  <a href="https://pepy.tech/project/kagura-memory"><img src="https://static.pepy.tech/badge/kagura-memory/month" alt="Downloads/month"></a>
   <a href="https://pypi.org/project/kagura-memory/"><img src="https://img.shields.io/pypi/pyversions/kagura-memory" alt="Python versions"></a>
   <a href="https://github.com/kagura-ai/kagura-memory-python-sdk/actions/workflows/ci.yml"><img src="https://github.com/kagura-ai/kagura-memory-python-sdk/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://codecov.io/gh/kagura-ai/kagura-memory-python-sdk"><img src="https://codecov.io/gh/kagura-ai/kagura-memory-python-sdk/graph/badge.svg" alt="codecov"></a>


### PR DESCRIPTION
## Summary

Replace the freshly-added shields.io \`pypi/dm\` downloads badge (merged in #135) with the pepy.tech equivalent. shields.io's \`pypi/dm\` proxies to \`pypistats.org\` and routinely renders as **\"rate limited by upstream\"** — a [long-standing known issue](https://github.com/badges/shields/issues/8389) that's been open for years. pepy.tech runs its own caching/aggregation and is not subject to that failure mode.

## Change

\`\`\`diff
- <img src=\"https://img.shields.io/pypi/dm/kagura-memory\" alt=\"PyPI downloads/month\">
+ <img src=\"https://static.pepy.tech/badge/kagura-memory/month\" alt=\"Downloads/month\">
\`\`\`

The badge link also moves to \`pepy.tech/project/kagura-memory\` so the click-through lands on the relevant stats page.

## Notes

- No code/test changes; README header row only.
- Visual style differs slightly from the surrounding shields.io badges (pepy.tech uses its own asset). Acceptable trade-off for reliability.