### PR TITLE
docs(auth-cli): show scope examples and defaults in `auth login/refresh --help`

### DIFF
--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -136,9 +136,11 @@ def auth_login(
       kagura auth login --no-browser         # for SSH / headless
 
     \b
-    Known scopes:
+    Memory scopes:
       memory:read   — read memories, contexts, files
       memory:write  — create/update/delete memories, contexts, files
+      (additional scopes like profile:read may be accepted server-side;
+      pass them through --scope.)
     """
     if read_only and scope is not None:
         raise click.ClickException("--read-only and --scope are mutually exclusive; pick one.")
@@ -479,9 +481,11 @@ def auth_refresh(profile: str | None, scope: str | None) -> None:
       kagura auth refresh --profile work
 
     \b
-    Known scopes:
+    Memory scopes:
       memory:read   — read memories, contexts, files
       memory:write  — create/update/delete memories, contexts, files
+      (additional scopes like profile:read may be accepted server-side;
+      pass them through --scope.)
     """
     cf = load_credentials_file()
     target = profile or cf.default_profile

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -134,6 +134,11 @@ def auth_login(
       kagura auth login --scope "memory:read memory:write profile:read"  # custom
       kagura auth login --profile work
       kagura auth login --no-browser         # for SSH / headless
+
+    \b
+    Known scopes:
+      memory:read   — read memories, contexts, files
+      memory:write  — create/update/delete memories, contexts, files
     """
     if read_only and scope is not None:
         raise click.ClickException("--read-only and --scope are mutually exclusive; pick one.")
@@ -456,10 +461,28 @@ async def _revoke_all_best_effort(cf: CredentialsFile) -> None:
 @click.option(
     "--scope",
     default=None,
-    help="Request this scope. If wider than the current grant, re-runs the device flow.",
+    help=(
+        "Request this scope (default: keep the current grant unchanged). "
+        "Pass space-separated values to ask for multiple "
+        "(e.g. 'memory:read memory:write'). "
+        "If wider than the current grant, re-runs the device flow."
+    ),
 )
 def auth_refresh(profile: str | None, scope: str | None) -> None:
-    """Rotate ``access_token`` (optionally requesting a new scope)."""
+    """Rotate ``access_token`` (optionally requesting a new scope).
+
+    \b
+    Examples:
+      kagura auth refresh
+      kagura auth refresh --scope "memory:read"                       # narrow to read-only
+      kagura auth refresh --scope "memory:read memory:write"          # widen (triggers device flow)
+      kagura auth refresh --profile work
+
+    \b
+    Known scopes:
+      memory:read   — read memories, contexts, files
+      memory:write  — create/update/delete memories, contexts, files
+    """
     cf = load_credentials_file()
     target = profile or cf.default_profile
     creds = cf.get_profile(target)


### PR DESCRIPTION
## Summary
- Add `Examples:` and `Known scopes:` sections to `kagura auth refresh --help` (parity with `auth login`).
- Clarify the `auth refresh --scope` default in `--help`: omitting it keeps the current grant unchanged.
- Add `Known scopes:` section to `auth login --help` so `memory:read` / `memory:write` are visible without docs.

## Why
A user typed `--scope "memroy:write memory:read"` (typo) and saw only `memory:read` granted — the server silently drops unknown scopes, but the CLI gave no hint that the request didn't match what was typed. Listing the known scopes inline catches typos at the `--help` step.

Closes #139

## Test plan
- [x] `kagura auth refresh --help` shows the new Examples and Known scopes sections
- [x] `kagura auth login --help` shows the new Known scopes section after existing examples
- [x] `--scope` help on `auth refresh` mentions `(default: keep the current grant unchanged)`
- [x] `uv run pytest tests/test_auth_cli.py` — 53 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)