### PR TITLE
docs: clear stale CHANGELOG `Unreleased` + refresh CLAUDE.md CLI list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,4 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ## Unreleased
 
-- `KaguraAgent` now supports Ollama Cloud: new `ollama_api_key` kwarg defaulting to `OLLAMA_API_KEY` env var; `ollama_base_url` defaults to `OLLAMA_HOST` env (then `http://localhost:11434`); `_call_ollama` injects `Authorization: Bearer <key>` when a key is configured. HTTP 401/403 from Ollama is now mapped to `KaguraAuthError` (was generic `KaguraLLMError`). Explicit `ollama_base_url=""` raises `ValueError` instead of producing a relative URL. (#124)
-- Ingest `OllamaProvider` now uses the `ollama_chat/` litellm prefix so system messages are preserved through the native `/api/chat` route. Explicit `text_model` / `vision_model` values starting with the legacy `ollama/` prefix are auto-rewritten with a `DeprecationWarning`. Existing local-Ollama setups continue to work unchanged; for Ollama Cloud, set `OLLAMA_API_KEY` and `OLLAMA_API_BASE=https://ollama.com` (read by litellm directly). (#124)
-- `kagura auth login` now requests `memory:read memory:write` by default; pass `--read-only` for read-only scope. `--scope` still accepts a custom set. (#122)
-- `kagura auth login` falls back to platform openers (`wslview` or `rundll32.exe url.dll,FileProtocolHandler` on WSL, `open` on macOS, `xdg-open` on Linux) when `webbrowser.open()` doesn't actually launch a browser. On WSL the stdlib path is skipped entirely because it can report success without launching a browser. (#122, #125)
-- Removed the pre-login web-UI tip from the device-flow prompt — `memory-cloud#772` shipped a login-gated `/device` page that no longer needs the client-side workaround. (#128)
-- `kagura setup claude` now falls back to the exception class name when an inner step raises without a message, so the CLI never prints a bare `Setup failed:` (or `Connection failed:`) with nothing after the colon. (#127)
-- Extracted the defensive `str(e) or e.__class__.__name__` pattern into a shared `_exc_message` helper and applied it to every `ClickException` and `KaguraConnectionError` wrapper across the SDK (`auth/cli.py`, `auth/device_flow.py`, `cli.py`, `client.py`, `files_client.py`, `resource_client.py`, `setup_claude.py`). Unmessaged exceptions now consistently surface the class name instead of stranding a bare `<prefix>:` in user-facing output. (#130)
+_(no changes yet)_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ uv run pyright src/              # Type check
 - **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs
-- CLI: `kagura setup claude`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura context search-config`
+- CLI: `kagura auth login/refresh/status`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura context search-config`, `kagura sleep history/report/rollback`
 
 ## Branch Strategy
 


### PR DESCRIPTION
## Summary

- Empty `CHANGELOG.md`'s `## Unreleased` block — all six bullets shipped in **v0.19.1** (2026-05-21) and **v0.20.0** (2026-05-23); current HEAD is **v0.20.1**. The file's own line 3 already points readers at [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/releases) as the source of truth, so the duplicated log was misleading.
- Refresh `CLAUDE.md` "Key SDK Features → CLI" bullet to include OAuth device flow (`kagura auth login/refresh/status`), document ingestion (`kagura ingest`), and sleep maintenance (`kagura sleep …`) commands added in v0.18–v0.20.

## What was already shipped

| Unreleased entry | Issue | Released in |
|---|---|---|
| Ollama Cloud (`OLLAMA_API_KEY` / `ollama_api_key`) | #124 | v0.20.0 |
| `kagura auth login` write-default scope | #122 | v0.19.1 |
| WSL/macOS/Linux browser fallback | #122, #125 | v0.19.1 |
| Removed pre-login web-UI tip | #128 | v0.19.1 |
| `kagura setup claude` empty-message bug fix | #127 | v0.19.1 |
| `_exc_message` helper extraction | #130 | v0.19.1 |

## Test plan

- [x] `git diff` reviewed — docs-only, 2 files, +2/-8
- [x] No code or behaviour change → ruff / pyright / pytest unaffected
- [x] Each removed CHANGELOG bullet cross-checked against `gh release view` and `gh issue view` for shipped status
- [ ] CI green (Python 3.11/3.12/3.13 + codecov)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)