### PR TITLE
feat(client): add list_memories() with optional q substring filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,10 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ## Unreleased
 
-_(no changes yet)_
+### Added
+
+- `KaguraClient.list_memories()` — paginated, newest-first memory listing
+  (`GET /api/v1/memory/list`) with optional `context_id`, `q` substring filter,
+  `scope`, `type`, `limit`, and `offset`. `q` is stripped and whitespace-only
+  values are treated as no filter, matching the server (memory-cloud #580).
+  New `MemoryListItem` / `MemoryListResponse` models. (#143)

--- a/src/kagura_memory/__init__.py
+++ b/src/kagura_memory/__init__.py
@@ -48,6 +48,8 @@ from .models import (
     LLMUsage,
     Memory,
     MemoryInfo,
+    MemoryListItem,
+    MemoryListResponse,
     MemoryStatItem,
     MemoryStatsResponse,
     MemoryToStore,
@@ -125,6 +127,9 @@ __all__ = [
     # Embedding status (v0.6.1)
     "EmbeddingStatus",
     "FailedMemoryInfo",
+    # Memory list (SDK issue #143)
+    "MemoryListItem",
+    "MemoryListResponse",
     # Memory stats & duplicates (v0.6.1)
     "MemoryStatItem",
     "MemoryStatsResponse",

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -24,6 +24,7 @@ from .models import (
     EmbeddingModelsResponse,
     EmbeddingStatus,
     ListTagsResponse,
+    MemoryListResponse,
     MemoryStatsResponse,
     RollbackResult,
     ServerInfo,
@@ -1150,6 +1151,62 @@ class KaguraClient:
         return await self._rest_get(
             f"/api/v1/contexts/{context_id}/duplicates", DuplicatesResponse, params=params
         )
+
+    async def list_memories(
+        self,
+        context_id: str | None = None,
+        q: str | None = None,
+        scope: Literal["working", "persistent"] | None = None,
+        type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> MemoryListResponse:
+        """List memories newest-first, with optional substring and facet filters.
+
+        Calls ``GET /api/v1/memory/list``. Without ``context_id`` this returns
+        the caller's own memories across all contexts; with ``context_id`` it
+        returns every memory in a shared context, or only the caller's own in a
+        private one (the server enforces this scoping).
+
+        Args:
+            context_id: Optional context UUID to scope results to one context.
+                Omit for the caller's cross-context "my memories" view.
+            q: Optional case-insensitive substring filter on memory summaries.
+                Surrounding whitespace is stripped and whitespace-only values
+                are treated as ``None`` (no filter), mirroring the server and
+                avoiding a wasted request. Matching targets ``summary`` only —
+                ``content`` and ``context_summary`` are deliberately not
+                searched (memory-cloud #580); use :meth:`recall` for semantic
+                or full-text search.
+            scope: Filter by scope — ``"working"`` or ``"persistent"``.
+            type: Filter by memory type. Server validates against its own
+                vocabulary; the SDK passes through.
+            limit: Maximum results (server accepts 1-500, default: 50).
+            offset: Pagination offset (default: 0).
+
+        Returns:
+            :class:`MemoryListResponse` with ``memories`` (newest-first),
+            ``total`` (matching rows across all pages), and ``has_more``.
+
+        Raises:
+            KaguraAuthError: Authentication failed.
+            KaguraConnectionError: Network failure or non-2xx response — e.g. a
+                ``context_id`` that does not exist or is not accessible
+                surfaces as ``HTTP 404``.
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if context_id is not None:
+            params["context_id"] = context_id
+        # Normalize like the server/frontend: strip and drop whitespace-only so
+        # an empty search box doesn't pin results to summaries containing spaces.
+        q_normalized = (q or "").strip()
+        if q_normalized:
+            params["q"] = q_normalized
+        if scope is not None:
+            params["scope"] = scope
+        if type is not None:
+            params["type"] = type
+        return await self._rest_get("/api/v1/memory/list", MemoryListResponse, params=params)
 
     @staticmethod
     def _raise_for_mcp_error(result: dict[str, Any], operation: str) -> None:

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -274,6 +274,40 @@ class MemoryStatsResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Memory list (SDK issue #143; server origin memory-cloud #580)
+# ---------------------------------------------------------------------------
+
+
+class MemoryListItem(BaseModel):
+    """A single memory row in a paginated ``list_memories`` response.
+
+    Mirrors the server's ``MemoryListItem`` wire shape. ``created_at`` /
+    ``updated_at`` arrive as ISO 8601 strings (``Z``-tagged) and are parsed
+    into ``datetime``, consistent with the other list models in this module.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    summary: str
+    type: str
+    scope: str
+    importance: float
+    created_at: datetime
+    updated_at: datetime
+
+
+class MemoryListResponse(BaseModel):
+    """Paginated response from ``list_memories`` (``GET /api/v1/memory/list``)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    memories: list[MemoryListItem] = Field(default_factory=list)
+    total: int
+    has_more: bool
+
+
+# ---------------------------------------------------------------------------
 # Duplicate detection models (v0.6.1)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@ from kagura_memory import (
     KaguraError,
     KaguraNotFoundError,
     KaguraQuotaError,
+    MemoryListResponse,
     MemoryStatsResponse,
     RollbackResult,
     ServerInfo,
@@ -1616,6 +1617,98 @@ async def test_find_duplicates():
             "https://test.com/api/v1/contexts/ctx-1/duplicates",
             params={"threshold": 0.90, "limit": 25},
         )
+
+    await client.close()
+
+
+# ============================================================================
+# list_memories (REST)
+# ============================================================================
+
+
+def _memory_list_response_mock():
+    """A MagicMock httpx response shaped like GET /api/v1/memory/list."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "memories": [
+            {
+                "id": "mem-1",
+                "summary": "first memory",
+                "type": "note",
+                "scope": "persistent",
+                "importance": 0.7,
+                "created_at": "2026-03-01T00:00:00Z",
+                "updated_at": "2026-03-02T00:00:00Z",
+            }
+        ],
+        "total": 1,
+        "has_more": False,
+    }
+    mock_response.raise_for_status = MagicMock()
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_list_memories_with_filters():
+    """list_memories() should return MemoryListResponse and forward filters."""
+    client = _make_initialized_client()
+
+    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _memory_list_response_mock()
+        result = await client.list_memories(
+            context_id="ctx-1", q="foo", scope="persistent", type="note", limit=10, offset=5
+        )
+        assert isinstance(result, MemoryListResponse)
+        assert result.total == 1
+        assert result.has_more is False
+        assert result.memories[0].id == "mem-1"
+        mock_get.assert_called_once_with(
+            "https://test.com/api/v1/memory/list",
+            params={
+                "limit": 10,
+                "offset": 5,
+                "context_id": "ctx-1",
+                "q": "foo",
+                "scope": "persistent",
+                "type": "note",
+            },
+        )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_memories_defaults_omit_optional_params():
+    """With no optional args, only limit/offset are sent."""
+    client = _make_initialized_client()
+
+    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _memory_list_response_mock()
+        await client.list_memories()
+        mock_get.assert_called_once_with(
+            "https://test.com/api/v1/memory/list",
+            params={"limit": 50, "offset": 0},
+        )
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_memories_strips_q_and_omits_when_blank():
+    """q is stripped; whitespace-only q is treated as None (omitted)."""
+    client = _make_initialized_client()
+
+    # Whitespace-only -> omitted entirely.
+    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _memory_list_response_mock()
+        await client.list_memories(q="   ")
+        assert "q" not in mock_get.call_args.kwargs["params"]
+
+    # Surrounding whitespace -> stripped to the trimmed value.
+    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _memory_list_response_mock()
+        await client.list_memories(q="  foo  ")
+        assert mock_get.call_args.kwargs["params"]["q"] == "foo"
 
     await client.close()
 


### PR DESCRIPTION
## Summary

Closes #143. Adds `KaguraClient.list_memories()` for SDK parity with the `GET /api/v1/memory/list` endpoint (memory-cloud #580), including the optional `q` substring filter that was the issue's focus.

The endpoint had **no** SDK surface yet, so this adds the full method plus the response models — not just the `q` kwarg.

## What changed

- **`client.py`** — new async `list_memories(context_id=None, q=None, scope=None, type=None, limit=50, offset=0)`, delegating to the existing `_rest_get` infra like its siblings `get_memory_stats` / `find_duplicates`. Optional params are included only when set.
- **`models.py`** — `MemoryListItem` (`id`, `summary`, `type`, `scope`, `importance`, `created_at`, `updated_at`) and `MemoryListResponse` (`memories`, `total`, `has_more`), mirroring the server wire shape.
- **`__init__.py`** — exports the two new models.
- **`tests/test_client.py`** — 3 tests: full filter forwarding + response parsing, optional-param omission, and `q` normalization (whitespace-only dropped; surrounding whitespace stripped).
- **CHANGELOG** — Unreleased entry.

## Acceptance criteria (#143)

- [x] `list_memories(context_id=..., q="foo")` → `GET /memory/list?...&q=foo`
- [x] `q=None` (default) omits `q`
- [x] Whitespace-only `q` treated as `None` (mirrors server normalization)
- [x] Type annotation + docstring
- [x] Unit test asserting `q=` included only when truthy after strip
- [x] CHANGELOG / docs note
- [x] Out of scope respected: `context_summary` is **not** a search target (documented in the docstring)
- [x] Non-breaking: new keyword-only-friendly kwargs, all defaulted

## Verification

- `ruff check` ✓ · `ruff format --check` ✓ · `pyright src/` → 0 errors ✓
- `pytest` → **750 passed, 13 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)