### PR TITLE
feat(ingest): browser-rendered URL fetch for JS-heavy pages (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --dev --extra ingest-all --python ${{ matrix.python-version }}
 
       - name: Test with coverage
-        run: uv run pytest tests/ -v -m "not integration and not eval" --cov=src/kagura_memory --cov-report=xml --cov-report=term
+        run: uv run pytest tests/ -v -m "not integration and not eval and not browser and not youtube and not audio" --cov=src/kagura_memory --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ### Added
 
+- **Browser-rendered URL fetch** (#145): opt-in `render=True` on
+  `FileIngestor.ingest()` / `estimate_cost()` (and `kagura ingest --render`)
+  drives a headless Chromium via Playwright to load and render JS-heavy / SPA
+  pages, then hands the rendered HTML to the existing HTML extractor → chunker
+  → provider pipeline. Default off. Requires the new `[ingest-browser]` extra
+  (`pip install 'kagura-memory[ingest-browser]'` + `playwright install
+  chromium`); a missing dependency surfaces as a `step="fetch"` error on the
+  `IngestResult`, not an uncaught exception. SSRF-hardened at the browser
+  layer: every request (navigation, redirect, XHR/fetch, sub-resource) is
+  re-resolved against the same RFC1918/loopback/link-local/IMDS denylist and
+  aborted if it targets an internal IP; `http://` sub-resources are gated by
+  `allow_http`. The rendered-HTML size cap (`max_bytes`) and navigation
+  timeout (`read_timeout`) bound the worst case. See
+  `examples/ingest_rendered_url.py`.
 - **Document ingestion beyond PDF** (#144): structural extractors for plain
   text / Markdown (stdlib, no extra), HTML (`[ingest-html]`), Word `.docx`
   (`[ingest-docx]`), Excel `.xlsx` (`[ingest-xlsx]`), PowerPoint `.pptx`

--- a/examples/ingest_rendered_url.py
+++ b/examples/ingest_rendered_url.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Ingest a JS-heavy / SPA page via browser-rendered fetch (issue #145).
+
+Some pages render their real content client-side with JavaScript, so a plain
+HTTP fetch only sees an empty shell. Passing ``render=True`` drives a headless
+Chromium (via Playwright) to load and render the page first, then hands the
+rendered HTML to the normal HTML extractor → chunker → provider pipeline.
+
+This path is OPT-IN and needs the browser extra plus the Chromium binary:
+
+    pip install 'kagura-memory[ingest-browser]'
+    playwright install chromium                    # one-time browser download
+    export KAGURA_API_KEY="kagura_..."
+    export KAGURA_MCP_URL="http://localhost:8080/mcp/w/{workspace_id}"
+    export ANTHROPIC_API_KEY="sk-ant-..."          # default 'claude' text provider
+    uv run python examples/ingest_rendered_url.py https://spa.example.com/
+
+Security: the browser fetch re-resolves every request the page makes
+(navigation, redirects, XHR/fetch, sub-resources) against the same SSRF
+denylist as the plain fetcher, and enforces the rendered-HTML size cap and
+the navigation timeout. ``render=True`` is ignored for local file paths.
+"""
+
+import asyncio
+import os
+import sys
+
+from kagura_memory import FileIngestor, KaguraClient
+
+
+async def main():
+    api_key = os.getenv("KAGURA_API_KEY")
+    mcp_url = os.getenv("KAGURA_MCP_URL", "http://localhost:8080/mcp")
+    source = sys.argv[1] if len(sys.argv) > 1 else "https://example.com/"
+
+    if not api_key:
+        print("Error: KAGURA_API_KEY required")
+        sys.exit(1)
+
+    async with KaguraClient(api_key=api_key, mcp_url=mcp_url) as client:
+        contexts = await client.list_contexts()
+        if not contexts.get("contexts"):
+            print("No contexts found. Create one first.")
+            return
+        ctx = contexts["contexts"][0]["id"]
+        print(f"Rendering and ingesting {source} into context {ctx}")
+
+        ingestor = FileIngestor(client=client)
+        # render=True drives headless Chromium before extraction.
+        result = await ingestor.ingest(
+            source,
+            context_id=ctx,
+            tags=["example", "ingest", "rendered"],
+            render=True,
+        )
+
+        if not result.success:
+            # A missing [ingest-browser] extra surfaces here as a
+            # step="fetch" error record (not an uncaught exception).
+            print(f"Ingestion failed (no overview created). Errors: {result.errors}")
+            sys.exit(1)
+
+        print(f"Overview memory: {result.overview_id}")
+        print(f"Sections:        {len(result.section_ids)}")
+        if result.errors:
+            print(f"Partial errors:  {len(result.errors)} (see result.errors)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,13 @@ ingest-pptx = [
 ingest-epub = [
     "kagura-memory[ingest-pdf]",
 ]
+# Browser-rendered URL fetch for JS-heavy / SPA pages (Issue #145).
+# Opt-in: after install, run `playwright install chromium` to fetch the
+# headless browser binary.
+ingest-browser = [
+    "kagura-memory[ingest]",
+    "playwright>=1.40",
+]
 # Plain text / Markdown need no extra (stdlib) — covered by base [ingest].
 ingest-all = [
     "kagura-memory[ingest-pdf]",
@@ -84,6 +91,7 @@ ingest-all = [
     "kagura-memory[ingest-xlsx]",
     "kagura-memory[ingest-pptx]",
     "kagura-memory[ingest-epub]",
+    "kagura-memory[ingest-browser]",
 ]
 
 [project.scripts]
@@ -118,6 +126,7 @@ asyncio_mode = "strict"
 markers = [
     "integration: requires a live memory-cloud backend (gated by KAGURA_INTEGRATION_URL, KAGURA_API_KEY, and KAGURA_INTEGRATION_CONTEXT_ID env vars)",
     "eval: ingestion quality eval against real LLMs (gated by ANTHROPIC_API_KEY / GEMINI_API_KEY env vars; default-skipped, run with `pytest -m eval`)",
+    "browser: requires a real Chromium via `playwright install`; default-skipped, run with `pytest -m browser`",
 ]
 
 [tool.ruff]

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -362,6 +362,16 @@ def explore(context_id, memory_id, depth, min_weight):
     help="Allow ingesting paths under /etc, /proc, /root, ~/.ssh, etc.",
 )
 @click.option(
+    "--render/--no-render",
+    "render",
+    default=False,
+    help=(
+        "Render the URL in a headless browser before ingesting (for JS-heavy "
+        "/ SPA pages). Requires the [ingest-browser] extra plus "
+        "`playwright install chromium`. Ignored for local files."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     default=False,
@@ -407,6 +417,7 @@ def ingest_file(
     timeout_read,
     allow_http,
     allow_system_paths,
+    render,
     dry_run,
     as_json,
     verbose,
@@ -485,6 +496,7 @@ def ingest_file(
                             read_timeout=timeout_read,
                             allow_http=allow_http,
                             allow_system_paths=allow_system_paths,
+                            render=render,
                         )
                     return await ingestor.ingest(
                         source,
@@ -496,6 +508,7 @@ def ingest_file(
                         read_timeout=timeout_read,
                         allow_http=allow_http,
                         allow_system_paths=allow_system_paths,
+                        render=render,
                         archive_original=archive,
                         logger=_resolve_progress_logger(verbose, progress),
                     )

--- a/src/kagura_memory/ingest/_browser.py
+++ b/src/kagura_memory/ingest/_browser.py
@@ -196,11 +196,21 @@ class BrowserFetcher:
         try:
             await page.route("**/*", self._route_handler)
             try:
-                await page.goto(url, wait_until=self.wait_until, timeout=self.nav_timeout_ms)
+                response = await page.goto(
+                    url, wait_until=self.wait_until, timeout=self.nav_timeout_ms
+                )
             except KaguraFetchError:
                 raise
             except Exception as e:  # noqa: BLE001 - normalized to a domain error below
                 raise KaguraFetchError(f"browser navigation failed: {e}", url=url) from e
+
+            # Reject rendered error pages (4xx/5xx) the way Fetcher does via
+            # raise_for_status(). A None response (about:blank, data: URLs)
+            # carries no status and is left to flow through.
+            if response is not None and isinstance(response.status, int) and response.status >= 400:
+                raise KaguraFetchError(
+                    f"browser navigation returned HTTP {response.status}", url=url
+                )
 
             html = await page.content()
             body = html.encode("utf-8")
@@ -256,9 +266,12 @@ class BrowserFetcher:
     async def _host_is_blocked(self, hostname: str) -> bool:
         """True iff ``hostname`` resolves to any blocked IP (cached per fetch).
 
-        A resolution failure is treated as blocked (fail-closed), matching
-        the conservative posture of :func:`is_blocked_ip` for malformed
-        addresses.
+        Any resolution failure is treated as blocked (fail-closed): besides
+        :class:`socket.gaierror`, :func:`socket.getaddrinfo` can raise
+        :class:`UnicodeError` for a malformed IDN host or other
+        :class:`OSError` subclasses. All of these are conservatively treated
+        as "blocked", matching the posture of :func:`is_blocked_ip` for
+        malformed addresses.
         """
         cached = self._resolve_cache.get(hostname)
         if cached is not None:
@@ -267,7 +280,7 @@ class BrowserFetcher:
             addrs = await asyncio.to_thread(
                 socket.getaddrinfo, hostname, None, 0, socket.SOCK_STREAM
             )
-        except socket.gaierror:
+        except (socket.gaierror, UnicodeError, OSError):
             self._resolve_cache[hostname] = True
             return True
         ips = {str(info[4][0]) for info in addrs}
@@ -282,22 +295,37 @@ class BrowserFetcher:
         redirects, XHR/fetch, and sub-resources to internal addresses) and
         ``http://`` requests when ``allow_http`` is False; otherwise lets the
         request continue.
+
+        A route must be resolved exactly once. Any unexpected exception while
+        deciding is treated fail-closed: the request is aborted rather than
+        left dangling (which would hang navigation until the timeout). If
+        resolving the route itself raises — e.g. the context is closing — that
+        is swallowed, since the route can no longer be acted upon.
         """
-        request_url = route.request.url
-        parsed = urlsplit(request_url)
-        scheme = parsed.scheme.lower()
-        # Non-network schemes (data:, blob:, about:) are harmless for SSRF.
-        if scheme not in _ALLOWED_SCHEMES:
+        try:
+            request_url = route.request.url
+            parsed = urlsplit(request_url)
+            scheme = parsed.scheme.lower()
+            # Non-network schemes (data:, blob:, about:) are harmless for SSRF.
+            if scheme not in _ALLOWED_SCHEMES:
+                await route.continue_()
+                return
+            if scheme == "http" and not self.allow_http:
+                await route.abort()
+                return
+            hostname = parsed.hostname
+            if not hostname or await self._host_is_blocked(hostname):
+                await route.abort()
+                return
             await route.continue_()
-            return
-        if scheme == "http" and not self.allow_http:
-            await route.abort()
-            return
-        hostname = parsed.hostname
-        if not hostname or await self._host_is_blocked(hostname):
-            await route.abort()
-            return
-        await route.continue_()
+        except Exception:  # noqa: BLE001 - fail closed, never let a route dangle
+            # Any unexpected error -> abort (fail-closed). Swallow a secondary
+            # error from abort() itself (e.g. the context is tearing down) so
+            # the route handler never propagates into Playwright's callback.
+            try:
+                await route.abort()
+            except Exception:  # noqa: BLE001 - route already resolved / closing
+                pass
 
 
 __all__ = ["BrowserFetcher"]

--- a/src/kagura_memory/ingest/_browser.py
+++ b/src/kagura_memory/ingest/_browser.py
@@ -43,7 +43,7 @@ from .fetcher import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from playwright.async_api import Route
+    from playwright.async_api import Route  # type: ignore[import-not-found]
 
 _ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
 _DEFAULT_WAIT_UNTIL: str = "networkidle"
@@ -65,14 +65,14 @@ def _load_async_playwright() -> Any:
             required ``playwright install chromium`` browser download.
     """
     try:
-        from playwright.async_api import async_playwright
+        from playwright.async_api import async_playwright  # type: ignore[import-not-found]
     except ImportError as e:
         raise KaguraIngestError(
             "playwright is not installed. Install with: "
             "pip install 'kagura-memory[ingest-browser]' then run: "
             "playwright install chromium"
         ) from e
-    return async_playwright
+    return async_playwright  # pragma: no cover - requires playwright installed
 
 
 class BrowserFetcher:

--- a/src/kagura_memory/ingest/_browser.py
+++ b/src/kagura_memory/ingest/_browser.py
@@ -1,0 +1,303 @@
+"""Browser-rendered URL fetch for JS-heavy / SPA pages (issue #145).
+
+An OPT-IN counterpart to :class:`kagura_memory.ingest.fetcher.Fetcher`.
+When the ingest pipeline is asked to render a URL, :class:`BrowserFetcher`
+drives a headless Chromium (via Playwright's async API), waits for the page
+to settle, captures the rendered DOM HTML, and returns it as a
+:class:`FetchResult` with ``content_type="text/html"`` so it flows through
+the existing HTML extractor → chunker → provider pipeline unchanged.
+
+Playwright is a heavy optional dependency: it is lazily imported inside
+:func:`_load_async_playwright` and surfaces as a :class:`KaguraIngestError`
+pointing at the ``[ingest-browser]`` extra (plus the required
+``playwright install chromium`` step) when missing.
+
+Security
+--------
+Chromium performs its own DNS resolution, redirect following, and
+sub-resource (XHR/fetch/image/script) loading entirely outside the Python
+process, which would bypass a one-shot pre-flight SSRF check. To close that
+gap, every request the browser makes is intercepted via ``page.route`` and
+its host is re-resolved against the same RFC1918/loopback/link-local/IMDS
+denylist used by :class:`Fetcher` (see
+:func:`kagura_memory.ingest._safety.is_blocked_ip`). Requests resolving to a
+blocked IP — including redirect targets and sub-resources — are aborted.
+http(s) sub-resources are also gated by ``allow_http``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+from ..exceptions import KaguraFetchError, KaguraIngestError
+from ._safety import is_blocked_ip
+from .fetcher import (
+    DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_MAX_BYTES,
+    DEFAULT_READ_TIMEOUT,
+    MAX_URL_LENGTH,
+    FetchResult,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from playwright.async_api import Route
+
+_ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+_DEFAULT_WAIT_UNTIL: str = "networkidle"
+
+
+def _load_async_playwright() -> Any:
+    """Lazily import Playwright's ``async_playwright`` factory.
+
+    This is the single import seam the browser fetcher depends on; tests
+    monkeypatch it to inject a fake Playwright chain so no real Chromium is
+    required.
+
+    Returns:
+        The ``playwright.async_api.async_playwright`` callable.
+
+    Raises:
+        KaguraIngestError: If Playwright is not installed. The message
+            points the user at the ``[ingest-browser]`` extra and the
+            required ``playwright install chromium`` browser download.
+    """
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as e:
+        raise KaguraIngestError(
+            "playwright is not installed. Install with: "
+            "pip install 'kagura-memory[ingest-browser]' then run: "
+            "playwright install chromium"
+        ) from e
+    return async_playwright
+
+
+class BrowserFetcher:
+    """Headless-Chromium fetcher for JS-rendered pages.
+
+    Use as an async context manager::
+
+        async with BrowserFetcher() as fetcher:
+            result = await fetcher.fetch("https://spa.example.com/")
+
+    The Playwright browser lifecycle is lazy: Chromium is launched on the
+    first :meth:`fetch` call (or eagerly via :meth:`__aenter__` /
+    :meth:`_ensure_browser`) and torn down in :meth:`close`.
+
+    The returned :class:`FetchResult` always has ``content_type="text/html"``
+    so the rendered DOM routes to the HTML extractor.
+
+    Args:
+        max_bytes: Maximum size of the *rendered* HTML (UTF-8 encoded).
+            Exceeding this raises :class:`KaguraFetchError`. Note this caps
+            the serialized DOM only; the total weight of sub-resources
+            (images, scripts) fetched during rendering is not separately
+            metered in this version.
+        connect_timeout: Reserved for parity with :class:`Fetcher`; the
+            browser uses ``read_timeout`` as the navigation deadline.
+        read_timeout: Navigation timeout (seconds). With
+            ``wait_until="networkidle"`` a page that never goes idle would
+            otherwise hang forever, so this deadline is the backstop — on
+            expiry the fetch fails with :class:`KaguraFetchError`.
+        allow_http: When False (default), ``http://`` navigation targets and
+            ``http://`` sub-resource requests are rejected/aborted.
+        wait_until: Playwright ``goto`` wait condition. Default
+            ``"networkidle"`` waits until the network is quiet, which is the
+            best heuristic for single-page apps that hydrate after load; the
+            navigation timeout above bounds the worst case.
+    """
+
+    def __init__(
+        self,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+        allow_http: bool = False,
+        wait_until: str = _DEFAULT_WAIT_UNTIL,
+    ):
+        self.max_bytes = max_bytes
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.allow_http = allow_http
+        self.wait_until = wait_until
+        # Navigation timeout in milliseconds (Playwright uses ms).
+        self.nav_timeout_ms = int(read_timeout * 1000)
+
+        self._playwright: Any = None
+        self._browser: Any = None
+        # Per-fetch DNS cache for the route handler so a page with many
+        # sub-resources to the same host resolves each host once.
+        self._resolve_cache: dict[str, bool] = {}
+
+    async def __aenter__(self) -> BrowserFetcher:
+        await self._ensure_browser()
+        return self
+
+    async def __aexit__(self, _exc_type: Any, _exc_val: Any, _exc_tb: Any) -> None:
+        await self.close()
+
+    async def _ensure_browser(self) -> None:
+        """Launch Chromium on first use (idempotent)."""
+        if self._browser is not None:
+            return
+        async_playwright = _load_async_playwright()
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=True)
+
+    async def close(self) -> None:
+        """Tear down the browser and Playwright driver (idempotent)."""
+        if self._browser is not None:
+            try:
+                await self._browser.close()
+            finally:
+                self._browser = None
+        if self._playwright is not None:
+            try:
+                await self._playwright.stop()
+            finally:
+                self._playwright = None
+
+    # --- Public API ----------------------------------------------------------
+
+    async def fetch(self, url: str) -> FetchResult:
+        """Render ``url`` in headless Chromium and return its HTML.
+
+        Args:
+            url: An ``http`` / ``https`` URL. Local file paths and other
+                schemes are rejected — browser rendering only applies to
+                URLs.
+
+        Returns:
+            A :class:`FetchResult` with ``content_type="text/html"`` whose
+            ``body`` is the rendered DOM serialized as UTF-8.
+
+        Raises:
+            KaguraFetchError: For any URL-safety violation (bad scheme,
+                http when disallowed, embedded credentials, missing
+                hostname, oversize URL), an initial host resolving to a
+                blocked IP, navigation timeout/error, or rendered HTML
+                exceeding ``max_bytes``.
+            KaguraIngestError: If Playwright is not installed.
+        """
+        self._validate_url(url)
+        parsed = urlsplit(url)
+        hostname = parsed.hostname
+        assert hostname is not None  # guaranteed by _validate_url
+        await self._reject_blocked_host(hostname, url)
+
+        await self._ensure_browser()
+        self._resolve_cache = {}
+
+        context = await self._browser.new_context()
+        page = await context.new_page()
+        try:
+            await page.route("**/*", self._route_handler)
+            try:
+                await page.goto(url, wait_until=self.wait_until, timeout=self.nav_timeout_ms)
+            except KaguraFetchError:
+                raise
+            except Exception as e:  # noqa: BLE001 - normalized to a domain error below
+                raise KaguraFetchError(f"browser navigation failed: {e}", url=url) from e
+
+            html = await page.content()
+            body = html.encode("utf-8")
+            if len(body) > self.max_bytes:
+                raise KaguraFetchError(
+                    f"rendered HTML {len(body)} bytes exceeds max_bytes {self.max_bytes}",
+                    url=url,
+                )
+            final_url = page.url or url
+        finally:
+            await context.close()
+
+        return FetchResult(
+            body=body,
+            content_type="text/html",
+            source_uri=url,
+            source_type="url",
+            final_url=final_url,
+            bytes_read=len(body),
+        )
+
+    # --- Internals -----------------------------------------------------------
+
+    def _validate_url(self, url: str) -> None:
+        """Mirror :class:`Fetcher`'s URL safety checks (raises on violation)."""
+        if not url or not isinstance(url, str):
+            raise KaguraFetchError("url must be a non-empty string", url=url or None)
+        if len(url) > MAX_URL_LENGTH:
+            raise KaguraFetchError(f"URL exceeds {MAX_URL_LENGTH} chars (got {len(url)})", url=url)
+        parsed = urlsplit(url)
+        scheme = parsed.scheme.lower()
+        if scheme not in _ALLOWED_SCHEMES:
+            raise KaguraFetchError(
+                f"unsupported scheme {parsed.scheme!r}; only http(s) is allowed", url=url
+            )
+        if scheme == "http" and not self.allow_http:
+            raise KaguraFetchError(
+                "http:// is disabled; use https:// or pass allow_http=True", url=url
+            )
+        if parsed.username or parsed.password:
+            raise KaguraFetchError(
+                "URL credentials (user:pass@host) are not allowed; pass auth via headers",
+                url=url,
+            )
+        if not parsed.hostname:
+            raise KaguraFetchError("URL has no hostname", url=url)
+
+    async def _reject_blocked_host(self, hostname: str, url: str) -> None:
+        """Resolve ``hostname`` and raise if any IP is in the denylist."""
+        if await self._host_is_blocked(hostname):
+            raise KaguraFetchError(f"hostname {hostname!r} resolved to a blocked IP", url=url)
+
+    async def _host_is_blocked(self, hostname: str) -> bool:
+        """True iff ``hostname`` resolves to any blocked IP (cached per fetch).
+
+        A resolution failure is treated as blocked (fail-closed), matching
+        the conservative posture of :func:`is_blocked_ip` for malformed
+        addresses.
+        """
+        cached = self._resolve_cache.get(hostname)
+        if cached is not None:
+            return cached
+        try:
+            addrs = await asyncio.to_thread(
+                socket.getaddrinfo, hostname, None, 0, socket.SOCK_STREAM
+            )
+        except socket.gaierror:
+            self._resolve_cache[hostname] = True
+            return True
+        ips = {str(info[4][0]) for info in addrs}
+        blocked = not ips or any(is_blocked_ip(ip) for ip in ips)
+        self._resolve_cache[hostname] = blocked
+        return blocked
+
+    async def _route_handler(self, route: Route) -> None:
+        """Intercept every browser request and SSRF-gate it.
+
+        Aborts requests whose host resolves to a blocked IP (covering
+        redirects, XHR/fetch, and sub-resources to internal addresses) and
+        ``http://`` requests when ``allow_http`` is False; otherwise lets the
+        request continue.
+        """
+        request_url = route.request.url
+        parsed = urlsplit(request_url)
+        scheme = parsed.scheme.lower()
+        # Non-network schemes (data:, blob:, about:) are harmless for SSRF.
+        if scheme not in _ALLOWED_SCHEMES:
+            await route.continue_()
+            return
+        if scheme == "http" and not self.allow_http:
+            await route.abort()
+            return
+        hostname = parsed.hostname
+        if not hostname or await self._host_is_blocked(hostname):
+            await route.abort()
+            return
+        await route.continue_()
+
+
+__all__ = ["BrowserFetcher"]

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -139,6 +139,7 @@ class FileIngestor:
         read_timeout: float = 60.0,
         allow_http: bool = False,
         allow_system_paths: bool = False,
+        render: bool = False,
         archive_original: bool = True,
         details_extra: dict[str, Any] | None = None,
         logger: VerboseLogger | None = None,
@@ -146,6 +147,13 @@ class FileIngestor:
         """Run a full ingestion against ``source``.
 
         Args:
+            render: Route URL fetches through a headless browser (requires
+                the ``[ingest-browser]`` extra plus ``playwright install
+                chromium``). Use for JS-heavy / SPA pages whose content is
+                rendered client-side. Ignored for local file paths. When the
+                Playwright dependency is missing, the run surfaces a
+                ``step="fetch"`` error on the :class:`IngestResult` rather
+                than raising.
             archive_original: When True and a :class:`FilesClient` was
                 supplied at construction time, the source bytes are
                 uploaded to the workspace's object store and the
@@ -220,6 +228,17 @@ class FileIngestor:
                 read_timeout=read_timeout,
                 allow_http=allow_http,
                 allow_system_paths=allow_system_paths,
+                render=render,
+            )
+        except KaguraIngestError as e:
+            # render=True but Playwright is not installed (lazy import in
+            # BrowserFetcher). Surface as a fetch-step failure (mirroring the
+            # KaguraFetchError path below) rather than crashing uncaught, so
+            # --json output stays machine-readable. Wrap as KaguraFetchError
+            # so _fetch_failure_result (which reads .url) can render it.
+            log.error(f"Fetch failed: {e}", stage="complete", detail={"source": source})
+            return _fetch_failure_result(
+                source, KaguraFetchError(str(e), url=source), is_dry_run=False, ingestor=self
             )
         except KaguraFetchError as e:
             # Best-effort contract: surface fetch failures via IngestResult
@@ -273,6 +292,7 @@ class FileIngestor:
         read_timeout: float = 60.0,
         allow_http: bool = False,
         allow_system_paths: bool = False,
+        render: bool = False,
     ) -> IngestResult:
         """Local-only token + page count estimate (``--dry-run``).
 
@@ -283,6 +303,12 @@ class FileIngestor:
         Fetch failures are also surfaced as a dry-run IngestResult with a
         ``step="fetch"`` error record, never as a raised exception, so
         ``kagura ingest --dry-run --json`` stays machine-readable.
+
+        Args:
+            render: Route URL fetches through a headless browser (requires
+                the ``[ingest-browser]`` extra). Ignored for local file
+                paths. A missing Playwright dependency is surfaced as a
+                ``step="fetch"`` error record, not a raised exception.
         """
         try:
             fetched = await self._fetch(
@@ -292,6 +318,11 @@ class FileIngestor:
                 read_timeout=read_timeout,
                 allow_http=allow_http,
                 allow_system_paths=allow_system_paths,
+                render=render,
+            )
+        except KaguraIngestError as e:
+            return _fetch_failure_result(
+                source, KaguraFetchError(str(e), url=source), is_dry_run=True, ingestor=self
             )
         except KaguraFetchError as e:
             return _fetch_failure_result(source, e, is_dry_run=True, ingestor=self)
@@ -358,7 +389,21 @@ class FileIngestor:
         read_timeout: float,
         allow_http: bool,
         allow_system_paths: bool,
+        render: bool = False,
     ) -> FetchResult:
+        # render only affects URL sources. A local file path with
+        # render=True silently falls back to the standard Fetcher.
+        if render and urlsplit(source).scheme in ("http", "https"):
+            from ._browser import BrowserFetcher
+
+            async with BrowserFetcher(
+                max_bytes=max_bytes,
+                connect_timeout=connect_timeout,
+                read_timeout=read_timeout,
+                allow_http=allow_http,
+            ) as browser:
+                return await browser.fetch(source)
+
         async with Fetcher(
             max_bytes=max_bytes,
             connect_timeout=connect_timeout,

--- a/tests/test_ingest_browser.py
+++ b/tests/test_ingest_browser.py
@@ -222,6 +222,43 @@ async def test_route_handler_fails_closed_on_unexpected_error(
     route.continue_.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_host_is_blocked_uses_per_fetch_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second lookup of the same host hits the cache (no re-resolution)."""
+    calls = {"n": 0}
+
+    def counting_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+        calls["n"] += 1
+        return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(_browser.socket, "getaddrinfo", counting_getaddrinfo)
+
+    fetcher = BrowserFetcher()
+    assert await fetcher._host_is_blocked("example.com") is False
+    assert await fetcher._host_is_blocked("example.com") is False
+    assert calls["n"] == 1  # second call served from cache
+
+
+@pytest.mark.asyncio
+async def test_route_handler_swallows_abort_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If abort() itself raises during fail-closed handling, the secondary
+    error is swallowed so the handler never propagates into Playwright."""
+
+    def boom_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("resolver exploded")
+
+    monkeypatch.setattr(_browser.socket, "getaddrinfo", boom_getaddrinfo)
+
+    fetcher = BrowserFetcher()
+    route = _FakeRoute("https://example.com/app.js")
+    route.abort = AsyncMock(side_effect=RuntimeError("context closing"))
+
+    # Must not raise even though both the resolver and abort() fail.
+    await fetcher._route_handler(route)  # type: ignore[arg-type]
+
+    route.abort.assert_awaited_once()
+
+
 # --- Missing dependency ------------------------------------------------------
 
 
@@ -302,6 +339,22 @@ async def test_navigation_timeout_rejected(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_navigation_reraises_kagura_fetch_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A KaguraFetchError raised during goto (e.g. from the route handler) is
+    re-raised unchanged, not wrapped as a generic navigation failure."""
+    _patch_unblocked_resolver(monkeypatch)
+    factory, _page, _ctx = _make_fake_playwright(
+        goto_side_effect=KaguraFetchError("blocked sub-resource", url="https://example.com/")
+    )
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="blocked sub-resource"):
+        await fetcher.fetch("https://example.com/")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
 async def test_http_error_status_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
     """A rendered 404 page must raise instead of being ingested as content."""
     _patch_unblocked_resolver(monkeypatch)
@@ -328,6 +381,22 @@ async def test_none_response_status_does_not_crash(monkeypatch: pytest.MonkeyPat
 
 
 # --- URL validation ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejects_empty_url() -> None:
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="non-empty string"):
+        await fetcher.fetch("")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_rejects_url_without_hostname() -> None:
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="no hostname"):
+        await fetcher.fetch("https:///path-only")
+    await fetcher.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_browser.py
+++ b/tests/test_ingest_browser.py
@@ -1,0 +1,357 @@
+"""Tests for the opt-in browser-rendered URL fetch (issue #145).
+
+Playwright is fully mocked here — no real Chromium is launched. A fake
+``async_playwright`` chain is injected via the
+``kagura_memory.ingest._browser._load_async_playwright`` seam.
+
+One integration test (``test_browser_render_real_chromium``) is gated behind
+the ``browser`` marker AND ``importorskip`` so it is default-skipped in CI
+and only runs manually with a real ``playwright install``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kagura_memory.exceptions import KaguraFetchError, KaguraIngestError
+from kagura_memory.ingest import _browser
+from kagura_memory.ingest._browser import BrowserFetcher
+
+
+class _FakeRequest:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class _FakeRoute:
+    """Minimal Playwright ``Route`` stand-in for the route handler."""
+
+    def __init__(self, url: str) -> None:
+        self.request = _FakeRequest(url)
+        self.abort = AsyncMock()
+        self.continue_ = AsyncMock()
+
+
+def _make_fake_playwright(
+    *,
+    html: str = "<html><body><h1>Hi</h1></body></html>",
+    final_url: str = "https://example.com/",
+    goto_side_effect: Exception | None = None,
+) -> tuple[Any, MagicMock, MagicMock]:
+    """Build a fake ``async_playwright`` factory and its page/context mocks.
+
+    Returns ``(factory, page, context)`` so tests can assert on the page's
+    ``route``/``goto`` calls.
+    """
+    page = MagicMock()
+    page.route = AsyncMock()
+    page.goto = AsyncMock(side_effect=goto_side_effect)
+    page.content = AsyncMock(return_value=html)
+    page.url = final_url
+
+    context = MagicMock()
+    context.new_page = AsyncMock(return_value=page)
+    context.close = AsyncMock()
+
+    browser = MagicMock()
+    browser.new_context = AsyncMock(return_value=context)
+    browser.close = AsyncMock()
+
+    chromium = MagicMock()
+    chromium.launch = AsyncMock(return_value=browser)
+
+    pw = MagicMock()
+    pw.chromium = chromium
+    pw.stop = AsyncMock()
+
+    manager = MagicMock()
+    manager.start = AsyncMock(return_value=pw)
+
+    def factory() -> MagicMock:
+        return manager
+
+    return factory, page, context
+
+
+def _patch_unblocked_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every hostname resolve to a public, non-blocked IP."""
+
+    def fake_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+        return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+    monkeypatch.setattr(_browser.socket, "getaddrinfo", fake_getaddrinfo)
+
+
+def _patch_blocked_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every hostname resolve to a blocked (loopback) IP."""
+
+    def fake_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+        return [(2, 1, 6, "", ("127.0.0.1", 0))]
+
+    monkeypatch.setattr(_browser.socket, "getaddrinfo", fake_getaddrinfo)
+
+
+# --- Happy path --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_returns_rendered_html(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_unblocked_resolver(monkeypatch)
+    html = "<html><body><article>rendered</article></body></html>"
+    factory, page, _ctx = _make_fake_playwright(html=html, final_url="https://example.com/final")
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    async with BrowserFetcher() as fetcher:
+        result = await fetcher.fetch("https://example.com/")
+
+    assert result.content_type == "text/html"
+    assert result.body == html.encode("utf-8")
+    assert result.source_type == "url"
+    assert result.source_uri == "https://example.com/"
+    assert result.final_url == "https://example.com/final"
+    assert result.bytes_read == len(html.encode("utf-8"))
+    page.goto.assert_awaited_once()
+    page.route.assert_awaited_once()
+
+
+# --- SSRF guards -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initial_blocked_ip_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_blocked_resolver(monkeypatch)
+    factory, _page, _ctx = _make_fake_playwright()
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="blocked IP"):
+        await fetcher.fetch("https://internal.example.com/")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_route_handler_aborts_blocked_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_blocked_resolver(monkeypatch)
+    fetcher = BrowserFetcher()
+    route = _FakeRoute("https://metadata.internal/latest")
+
+    await fetcher._route_handler(route)  # type: ignore[arg-type]
+
+    route.abort.assert_awaited_once()
+    route.continue_.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_handler_continues_public_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_unblocked_resolver(monkeypatch)
+    fetcher = BrowserFetcher()
+    route = _FakeRoute("https://cdn.example.com/app.js")
+
+    await fetcher._route_handler(route)  # type: ignore[arg-type]
+
+    route.continue_.assert_awaited_once()
+    route.abort.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_handler_aborts_http_when_disallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_unblocked_resolver(monkeypatch)
+    fetcher = BrowserFetcher(allow_http=False)
+    route = _FakeRoute("http://cdn.example.com/app.js")
+
+    await fetcher._route_handler(route)  # type: ignore[arg-type]
+
+    route.abort.assert_awaited_once()
+    route.continue_.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_handler_allows_data_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetcher = BrowserFetcher()
+    route = _FakeRoute("data:text/html,<p>x</p>")
+
+    await fetcher._route_handler(route)  # type: ignore[arg-type]
+
+    route.continue_.assert_awaited_once()
+
+
+# --- Missing dependency ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_playwright_raises_ingest_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # _load_async_playwright raising ImportError → fetch() surfaces a
+    # KaguraIngestError pointing at the extra (tested here by simulating the
+    # ImportError branch directly).
+    def boom() -> Any:
+        raise KaguraIngestError(
+            "playwright is not installed. Install with: "
+            "pip install 'kagura-memory[ingest-browser]' then run: "
+            "playwright install chromium"
+        )
+
+    _patch_unblocked_resolver(monkeypatch)
+    monkeypatch.setattr(_browser, "_load_async_playwright", boom)
+
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraIngestError, match=r"ingest-browser"):
+        await fetcher.fetch("https://example.com/")
+
+
+@pytest.mark.asyncio
+async def test_load_async_playwright_import_error_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name.startswith("playwright"):
+            raise ImportError("nope")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(KaguraIngestError) as exc:
+        _browser._load_async_playwright()
+    assert "playwright install chromium" in str(exc.value)
+
+
+# --- Oversize ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oversize_rendered_html_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_unblocked_resolver(monkeypatch)
+    big_html = "<html>" + ("x" * 5000) + "</html>"
+    factory, _page, _ctx = _make_fake_playwright(html=big_html)
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    fetcher = BrowserFetcher(max_bytes=1000)
+    with pytest.raises(KaguraFetchError, match="exceeds max_bytes"):
+        await fetcher.fetch("https://example.com/")
+    await fetcher.close()
+
+
+# --- Navigation errors -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_navigation_timeout_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_unblocked_resolver(monkeypatch)
+
+    class _PlaywrightTimeoutError(Exception):
+        pass
+
+    factory, _page, _ctx = _make_fake_playwright(
+        goto_side_effect=_PlaywrightTimeoutError("Timeout 60000ms exceeded")
+    )
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="navigation failed"):
+        await fetcher.fetch("https://example.com/")
+    await fetcher.close()
+
+
+# --- URL validation ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_http_scheme() -> None:
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="unsupported scheme"):
+        await fetcher.fetch("ftp://example.com/x")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_rejects_http_when_not_allowed() -> None:
+    fetcher = BrowserFetcher(allow_http=False)
+    with pytest.raises(KaguraFetchError, match="http:// is disabled"):
+        await fetcher.fetch("http://example.com/")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_rejects_embedded_credentials() -> None:
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="credentials"):
+        await fetcher.fetch("https://user:pass@example.com/")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_rejects_oversized_url() -> None:
+    fetcher = BrowserFetcher()
+    long_url = "https://example.com/" + ("a" * 9000)
+    with pytest.raises(KaguraFetchError, match="exceeds"):
+        await fetcher.fetch(long_url)
+    await fetcher.close()
+
+
+# --- Orchestrator missing-dependency path ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_render_without_playwright_yields_fetch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FileIngestor.ingest(render=True) without playwright → IngestResult.
+
+    The missing optional dependency must surface as a ``step="fetch"`` error
+    record on the result, never an uncaught exception.
+    """
+    from kagura_memory.ingest.ingestor import FileIngestor
+
+    # Force the BrowserFetcher's lazy loader to raise as if playwright is
+    # absent, regardless of whether it happens to be installed.
+    def boom() -> Any:
+        raise KaguraIngestError(
+            "playwright is not installed. Install with: pip install 'kagura-memory[ingest-browser]'"
+        )
+
+    monkeypatch.setattr(_browser, "_load_async_playwright", boom)
+
+    fake_client = MagicMock()
+    fake_text = MagicMock()
+    fake_text.name = "claude"
+    ingestor = FileIngestor(
+        client=fake_client,
+        text_provider=fake_text,
+        vision_provider=None,
+        vision_provider_name=None,
+    )
+
+    result = await ingestor.ingest(
+        "https://spa.example.com/",
+        context_id="ctx-1",
+        render=True,
+    )
+
+    assert not result.success
+    assert any(e.step == "fetch" for e in result.errors)
+    assert any("playwright" in e.message.lower() for e in result.errors)
+
+
+# --- Integration (default-skipped) -------------------------------------------
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_browser_render_real_chromium() -> None:
+    """End-to-end render against a real Chromium (manual only).
+
+    Default-skipped: requires `playwright install chromium` plus network
+    access to example.com. Run with ``pytest -m browser``.
+    """
+    pytest.importorskip("playwright", reason="playwright not installed")
+
+    async with BrowserFetcher() as fetcher:
+        result = await fetcher.fetch("https://example.com/")
+
+    assert result.content_type == "text/html"
+    assert b"<html" in result.body.lower() or b"<!doctype" in result.body.lower()

--- a/tests/test_ingest_browser.py
+++ b/tests/test_ingest_browser.py
@@ -40,15 +40,25 @@ def _make_fake_playwright(
     html: str = "<html><body><h1>Hi</h1></body></html>",
     final_url: str = "https://example.com/",
     goto_side_effect: Exception | None = None,
+    status: int | None = 200,
 ) -> tuple[Any, MagicMock, MagicMock]:
     """Build a fake ``async_playwright`` factory and its page/context mocks.
 
     Returns ``(factory, page, context)`` so tests can assert on the page's
-    ``route``/``goto`` calls.
+    ``route``/``goto`` calls. ``page.goto`` returns a fake response whose
+    ``status`` is ``status`` (pass ``status=None`` to model a response-less
+    navigation such as ``about:blank``/``data:`` URLs).
     """
+    response: MagicMock | None
+    if status is None:
+        response = None
+    else:
+        response = MagicMock()
+        response.status = status
+
     page = MagicMock()
     page.route = AsyncMock()
-    page.goto = AsyncMock(side_effect=goto_side_effect)
+    page.goto = AsyncMock(side_effect=goto_side_effect, return_value=response)
     page.content = AsyncMock(return_value=html)
     page.url = final_url
 
@@ -178,6 +188,40 @@ async def test_route_handler_allows_data_scheme(monkeypatch: pytest.MonkeyPatch)
     route.continue_.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_host_is_blocked_on_unicode_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resolver raising UnicodeError (malformed IDN) is treated as blocked."""
+
+    def boom_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+        raise UnicodeError("malformed IDN host")
+
+    monkeypatch.setattr(_browser.socket, "getaddrinfo", boom_getaddrinfo)
+
+    fetcher = BrowserFetcher()
+    assert await fetcher._host_is_blocked("xn--bad..host") is True
+
+
+@pytest.mark.asyncio
+async def test_route_handler_fails_closed_on_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unexpected resolution error aborts the route (never propagates)."""
+
+    def boom_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("resolver exploded")
+
+    monkeypatch.setattr(_browser.socket, "getaddrinfo", boom_getaddrinfo)
+
+    fetcher = BrowserFetcher()
+    route = _FakeRoute("https://example.com/app.js")
+
+    # Must not raise — the handler swallows and fails closed by aborting.
+    await fetcher._route_handler(route)  # type: ignore[arg-type]
+
+    route.abort.assert_awaited_once()
+    route.continue_.assert_not_awaited()
+
+
 # --- Missing dependency ------------------------------------------------------
 
 
@@ -255,6 +299,32 @@ async def test_navigation_timeout_rejected(monkeypatch: pytest.MonkeyPatch) -> N
     with pytest.raises(KaguraFetchError, match="navigation failed"):
         await fetcher.fetch("https://example.com/")
     await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_http_error_status_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rendered 404 page must raise instead of being ingested as content."""
+    _patch_unblocked_resolver(monkeypatch)
+    factory, _page, _ctx = _make_fake_playwright(status=404)
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    fetcher = BrowserFetcher()
+    with pytest.raises(KaguraFetchError, match="404"):
+        await fetcher.fetch("https://example.com/missing")
+    await fetcher.close()
+
+
+@pytest.mark.asyncio
+async def test_none_response_status_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A response-less navigation (status=None) flows through without error."""
+    _patch_unblocked_resolver(monkeypatch)
+    factory, _page, _ctx = _make_fake_playwright(status=None)
+    monkeypatch.setattr(_browser, "_load_async_playwright", lambda: factory)
+
+    async with BrowserFetcher() as fetcher:
+        result = await fetcher.fetch("https://example.com/")
+
+    assert result.content_type == "text/html"
 
 
 # --- URL validation ----------------------------------------------------------


### PR DESCRIPTION
Closes #145

## Summary
- Opt-in `render=True` on `FileIngestor.ingest()` / `estimate_cost()` (and `kagura ingest --render`) drives a headless Chromium via Playwright to load and render JS-heavy / SPA pages, then feeds the rendered HTML into the existing HTML extractor → chunker → provider pipeline. Default off.
- New `BrowserFetcher` is a sibling of the httpx `Fetcher` in the same Fetcher layer — returns a `FetchResult` with `content_type="text/html"`, so nothing downstream changes.
- Heavy browser runtime is an opt-in extra `[ingest-browser]` (`playwright>=1.40`), lazily imported; a missing dependency surfaces as a `step="fetch"` error on the `IngestResult`, not an uncaught exception.

## Implementation notes
- **SSRF hardened at the browser layer**: every request Chromium makes (navigation, redirect, XHR/fetch, sub-resource) is intercepted via `page.route` and re-resolved against the same RFC1918/loopback/link-local/IMDS denylist as `Fetcher` (`_safety.is_blocked_ip`); blocked-IP and disallowed-`http` requests are aborted. The route handler and host resolution are **fail-closed** (any unexpected error → abort / treat host as blocked).
- Rejects 4xx/5xx navigation responses (parity with `Fetcher.raise_for_status`); caps rendered-HTML size (`max_bytes`); navigation bounded by `read_timeout`.
- `_fetch(render=...)` branches to `BrowserFetcher` only for `http(s)` URLs (lazy `import` keeps Playwright off the default path); local files silently fall back to `Fetcher`.
- 21 unit tests with Playwright fully mocked + 1 default-skipped (`@pytest.mark.browser`) integration test. Example: `examples/ingest_rendered_url.py`.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: yellow — SSRF interception sound/fail-closed; WebSocket handshakes are not intercepted by `page.route` (Medium, opt-in → follow-up)
- qa-lead: yellow — security contract well-covered; mocks encode the page.route-intercepts-all assumption, so recommend periodic real-browser CI runs (follow-up)
- cto: yellow — sibling-Fetcher layering is the right depth; extract a shared URL validator to avoid security-validation drift between `Fetcher`/`BrowserFetcher` (follow-up)
- gate1: yellow via /claude-c-suite:ask (CSO lens — SSRF-at-browser-layer requirement, satisfied)
- review provider: code-review

Converging follow-up (non-blocking, all three advisors): a single "browser-fetch hardening" issue covering WebSocket interception, a shared `validate_fetch_url()`, and a nightly real-Chromium integration run.

🤖 Generated via /gh-issue-driven:ship
