### PR TITLE
feat(ingest): YouTube video ingestion via transcript/captions (#146)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --dev --extra ingest-all --python ${{ matrix.python-version }}
 
       - name: Test with coverage
-        run: uv run pytest tests/ -v -m "not integration and not eval" --cov=src/kagura_memory --cov-report=xml --cov-report=term
+        run: uv run pytest tests/ -v -m "not integration and not eval and not browser and not youtube and not audio" --cov=src/kagura_memory --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.11'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ### Added
 
+- **YouTube transcript ingestion** (#146): `ingest("https://youtube.com/watch?v=...")`
+  now resolves a single video's captions into a memory graph. YouTube URLs are
+  auto-detected by host (`youtube.com`, `youtu.be`, `m.youtube.com`, including
+  `watch?v=`, `youtu.be/`, and `shorts/` forms) and routed to a transcript
+  source resolver that formats the captions as time-windowed Markdown
+  (`# <title>` + `## [mm:ss]` sections), flowing through the existing
+  chunk → summarize → remember pipeline. Manual captions are preferred,
+  auto-generated captions are the fallback; the video title/channel come from
+  YouTube oEmbed (best-effort — failure degrades the title to the video id, it
+  never fails the ingest). Opt-in via the `[ingest-youtube]` extra
+  (`youtube-transcript-api`, no API key); also bundled in `[ingest-all]`.
+  Playlists/channels, caption-disabled, age-restricted, and unavailable videos
+  raise an actionable error. Chapters are deferred to a follow-up. See
+  `examples/ingest_youtube.py`.
 - **Document ingestion beyond PDF** (#144): structural extractors for plain
   text / Markdown (stdlib, no extra), HTML (`[ingest-html]`), Word `.docx`
   (`[ingest-docx]`), Excel `.xlsx` (`[ingest-xlsx]`), PowerPoint `.pptx`

--- a/examples/ingest_youtube.py
+++ b/examples/ingest_youtube.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""FileIngestor usage — turn a YouTube video's transcript into a memory graph.
+
+A YouTube URL is auto-detected and resolved to its captions (manual preferred,
+auto-generated as fallback), formatted as time-windowed Markdown, then ingested
+as one overview memory plus per-section summaries — the same flow as documents.
+Only the transcript is fetched; the media stream is never downloaded.
+
+Requires the YouTube ingest extra and a text-LLM key:
+
+    pip install 'kagura-memory[ingest-youtube]'
+    export KAGURA_API_KEY="kagura_..."
+    export KAGURA_MCP_URL="http://localhost:8080/mcp/w/{workspace_id}"
+    export ANTHROPIC_API_KEY="sk-ant-..."          # default 'claude' text provider
+    uv run python examples/ingest_youtube.py "https://www.youtube.com/watch?v=jNQXAC9IVRw"
+
+Notes:
+    * Single videos only — playlists / channels are rejected.
+    * Caption-disabled, age-restricted, or unavailable videos raise a clear error.
+"""
+
+import asyncio
+import os
+import sys
+
+from kagura_memory import FileIngestor, KaguraClient
+
+
+async def main() -> None:
+    api_key = os.getenv("KAGURA_API_KEY")
+    mcp_url = os.getenv("KAGURA_MCP_URL", "http://localhost:8080/mcp")
+    url = sys.argv[1] if len(sys.argv) > 1 else "https://www.youtube.com/watch?v=jNQXAC9IVRw"
+
+    if not api_key:
+        print("Error: KAGURA_API_KEY required")
+        sys.exit(1)
+
+    async with KaguraClient(api_key=api_key, mcp_url=mcp_url) as client:
+        contexts = await client.list_contexts()
+        if not contexts.get("contexts"):
+            print("No contexts found. Create one first.")
+            return
+        context_id = contexts["contexts"][0]["id"]
+
+        ingestor = FileIngestor(client=client)
+        result = await ingestor.ingest(url, context_id=context_id)
+
+        if result.success:
+            print(f"Ingested {url}")
+            print(f"  overview memory: {result.overview_id}")
+            print(f"  sections:        {len(result.section_ids)}")
+        else:
+            print(f"Ingest failed for {url}")
+            for err in result.errors:
+                print(f"  [{err.step}] {err.message}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,13 @@ ingest-pptx = [
 ingest-epub = [
     "kagura-memory[ingest-pdf]",
 ]
+# YouTube transcript ingestion (Issue #146) — captions-only, no API key.
+# `youtube-transcript-api` v1.0+ uses an instance-based API; oEmbed (title /
+# channel) goes through the core `httpx` dependency, so no extra dep there.
+ingest-youtube = [
+    "kagura-memory[ingest]",
+    "youtube-transcript-api>=1.0",
+]
 # Plain text / Markdown need no extra (stdlib) — covered by base [ingest].
 ingest-all = [
     "kagura-memory[ingest-pdf]",
@@ -84,6 +91,7 @@ ingest-all = [
     "kagura-memory[ingest-xlsx]",
     "kagura-memory[ingest-pptx]",
     "kagura-memory[ingest-epub]",
+    "kagura-memory[ingest-youtube]",
 ]
 
 [project.scripts]
@@ -118,6 +126,7 @@ asyncio_mode = "strict"
 markers = [
     "integration: requires a live memory-cloud backend (gated by KAGURA_INTEGRATION_URL, KAGURA_API_KEY, and KAGURA_INTEGRATION_CONTEXT_ID env vars)",
     "eval: ingestion quality eval against real LLMs (gated by ANTHROPIC_API_KEY / GEMINI_API_KEY env vars; default-skipped, run with `pytest -m eval`)",
+    "youtube: requires network access to YouTube; default-skipped, run with `pytest -m youtube`",
 ]
 
 [tool.ruff]

--- a/src/kagura_memory/ingest/_youtube.py
+++ b/src/kagura_memory/ingest/_youtube.py
@@ -308,7 +308,7 @@ def _resolve_transcript(transcript_list: Any, languages: tuple[str, ...]) -> Any
     raise no_transcript.__new__(no_transcript)
 
 
-def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...]) -> list[Any]:
+def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...], *, url: str) -> list[Any]:
     """Synchronously resolve and fetch a transcript's snippets.
 
     Runs the blocking ``youtube-transcript-api`` calls; the caller wraps this
@@ -317,6 +317,9 @@ def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...]) -> list[An
     Args:
         video_id: The 11-character YouTube video id.
         languages: Preferred caption languages.
+        url: The original YouTube URL. Used as the ``KaguraFetchError.url`` on
+            failure so the error (and any derived ``IngestResult.source_uri``)
+            surfaces the caller's URL rather than the bare video id.
 
     Returns:
         The list of caption snippets (each with ``.text`` / ``.start``).
@@ -336,17 +339,17 @@ def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...]) -> list[An
     except youtube_transcript_api.TranscriptsDisabled as e:
         raise KaguraFetchError(
             "captions are disabled for this video; no transcript is available",
-            url=video_id,
+            url=url,
         ) from e
     except youtube_transcript_api.NoTranscriptFound as e:
         raise KaguraFetchError(
             "no transcript/captions found for this video in any language",
-            url=video_id,
+            url=url,
         ) from e
     except youtube_transcript_api.AgeRestricted as e:
         raise KaguraFetchError(
             "video is age-restricted; its transcript cannot be retrieved",
-            url=video_id,
+            url=url,
         ) from e
     except (
         youtube_transcript_api.VideoUnavailable,
@@ -355,14 +358,14 @@ def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...]) -> list[An
     ) as e:
         raise KaguraFetchError(
             "video is unavailable (private, removed, or region-locked)",
-            url=video_id,
+            url=url,
         ) from e
     except youtube_transcript_api.CouldNotRetrieveTranscript as e:
         # Catch-all for the library's other retrieval failures (IP blocked,
         # request blocked, members-only, etc.).
         raise KaguraFetchError(
             f"could not retrieve transcript for this video: {e}",
-            url=video_id,
+            url=url,
         ) from e
     return snippets
 
@@ -384,8 +387,13 @@ async def fetch_youtube(
     Args:
         url: A single-video YouTube URL (``watch?v=``, ``youtu.be/``,
             ``shorts/``). Playlist / channel URLs are rejected.
-        max_bytes: Reserved for parity with the byte fetcher; the transcript is
-            additionally capped at :data:`_MAX_TOTAL_TEXT_CHARS` characters.
+        max_bytes: Hard upper bound (in bytes) on the assembled transcript
+            body, enforced for parity with the byte fetcher — an oversize
+            transcript raises :class:`KaguraFetchError` rather than being
+            silently truncated. The body is *also* capped at
+            :data:`_MAX_TOTAL_TEXT_CHARS` bytes inside :func:`_build_markdown`
+            (the ``TextExtractor`` input bound), so the effective limit is the
+            smaller of the two.
         read_timeout: Per-request read timeout (seconds) for the oEmbed call.
         languages: Preferred caption languages, in descending priority.
             Defaults to ``("en",)``.
@@ -408,13 +416,25 @@ async def fetch_youtube(
 
     langs = languages or _DEFAULT_LANGUAGES
 
-    # Run the transcript fetch and the (best-effort) oEmbed fetch.
-    snippets = await asyncio.to_thread(_fetch_transcript_sync, video_id, langs)
+    # Run the transcript fetch and the (best-effort) oEmbed fetch. Thread the
+    # original ``url`` through so transcript-failure errors carry it (not the
+    # bare video id) as their ``.url``.
+    snippets = await asyncio.to_thread(_fetch_transcript_sync, video_id, langs, url=url)
     title, author = await _fetch_oembed(url, read_timeout=read_timeout)
 
     windows = _segment_windows(snippets)
     markdown = _build_markdown(title or video_id, author, windows)
     body = markdown.encode("utf-8")
+
+    # Enforce the caller's byte budget, mirroring the byte fetcher's behavior:
+    # an oversize transcript is a hard failure, not a silent truncation. The
+    # _MAX_TOTAL_TEXT_CHARS cap in _build_markdown is the extractor-input bound;
+    # this is the caller's explicit ingest(..., max_bytes=...) bound.
+    if len(body) > max_bytes:
+        raise KaguraFetchError(
+            f"transcript body {len(body)} bytes exceeds max_bytes {max_bytes}",
+            url=url,
+        )
 
     return FetchResult(
         body=body,

--- a/src/kagura_memory/ingest/_youtube.py
+++ b/src/kagura_memory/ingest/_youtube.py
@@ -293,7 +293,7 @@ def _build_markdown(title: str, author: str | None, windows: list[tuple[float, s
     return markdown
 
 
-def _resolve_transcript(transcript_list: Any, languages: tuple[str, ...]) -> Any:
+def _resolve_transcript(transcript_list: Any, languages: tuple[str, ...]) -> Any | None:
     """Pick a transcript: manual (preferred) → generated → first available.
 
     Args:
@@ -301,11 +301,9 @@ def _resolve_transcript(transcript_list: Any, languages: tuple[str, ...]) -> Any
         languages: Preferred language codes, in descending priority.
 
     Returns:
-        A ``Transcript`` object whose ``.fetch()`` yields snippets.
-
-    Raises:
-        Exception: Re-raises the library's lookup error only when no transcript
-            of any kind is available.
+        A ``Transcript`` object whose ``.fetch()`` yields snippets, or ``None``
+        when the video has no transcript in any language. The caller maps
+        ``None`` to a :class:`KaguraFetchError` carrying the original URL.
     """
     youtube_transcript_api = _load_youtube_transcript_api()
     no_transcript = youtube_transcript_api.NoTranscriptFound
@@ -321,7 +319,10 @@ def _resolve_transcript(transcript_list: Any, languages: tuple[str, ...]) -> Any
     # Fall back to the first available transcript in any language.
     for transcript in transcript_list:
         return transcript
-    raise no_transcript.__new__(no_transcript)
+    # Nothing in any language. Signal "no transcript" to the caller rather than
+    # constructing the library's NoTranscriptFound — its __init__ signature
+    # varies across versions, so building one via __new__ was fragile.
+    return None
 
 
 def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...], *, url: str) -> list[Any]:
@@ -351,15 +352,15 @@ def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...], *, url: st
     try:
         transcript_list = api.list(video_id)
         transcript = _resolve_transcript(transcript_list, languages)
+        if transcript is None:
+            raise KaguraFetchError(
+                "no transcript/captions found for this video in any language",
+                url=url,
+            )
         snippets = list(transcript.fetch())
     except youtube_transcript_api.TranscriptsDisabled as e:
         raise KaguraFetchError(
             "captions are disabled for this video; no transcript is available",
-            url=url,
-        ) from e
-    except youtube_transcript_api.NoTranscriptFound as e:
-        raise KaguraFetchError(
-            "no transcript/captions found for this video in any language",
             url=url,
         ) from e
     except youtube_transcript_api.AgeRestricted as e:

--- a/src/kagura_memory/ingest/_youtube.py
+++ b/src/kagura_memory/ingest/_youtube.py
@@ -1,0 +1,416 @@
+"""YouTube transcript source resolver for the ingestion pipeline (issue #146).
+
+A YouTube video's ingestible content is its *transcript* (captions), not the
+media stream. This module is a **Fetcher-layer source resolver**: it resolves a
+single-video YouTube URL to a timestamped transcript, formats it as Markdown
+(an H1 title + ``## [mm:ss]`` time-window sections), and returns a
+:class:`~kagura_memory.ingest.fetcher.FetchResult` with
+``content_type="text/markdown"``. That flows unchanged through the existing
+``TextExtractor`` (which splits on ``##`` ATX headings and promotes the first
+H1 to the document title) → chunker → provider pipeline, so no orchestrator
+structural change is needed for sections or title.
+
+Dependencies (opt-in ``[ingest-youtube]`` extra):
+
+* ``youtube-transcript-api`` (>=1.0) — captions retrieval, no API key.
+* YouTube **oEmbed** (``https://www.youtube.com/oembed``) — title/channel
+  metadata, no API key. oEmbed is best-effort: a failure degrades the title to
+  the video id rather than failing the whole ingest.
+
+Chapters are deferred to a follow-up (they require yt-dlp / InnerTube). v1 uses
+time-window segmentation of the transcript instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+
+from ..exceptions import KaguraFetchError, KaguraIngestError
+from .extractors._util import MAX_TOTAL_TEXT_CHARS as _MAX_TOTAL_TEXT_CHARS
+from .fetcher import FetchResult
+
+# Hosts that identify a YouTube URL.
+_YOUTUBE_HOSTS: frozenset[str] = frozenset(
+    {"youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be"}
+)
+
+# A YouTube video id is exactly 11 chars of [A-Za-z0-9_-].
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+# Default caption languages, in descending priority.
+_DEFAULT_LANGUAGES: tuple[str, ...] = ("en",)
+
+# Time-window segmentation: group caption snippets into windows of roughly this
+# duration OR this many characters, whichever boundary is hit first. Each window
+# becomes one ``## [mm:ss]`` Markdown section.
+_WINDOW_SECONDS: float = 60.0
+_WINDOW_CHARS: int = 1500
+
+# oEmbed endpoint for title/channel metadata (no API key).
+_OEMBED_URL = "https://www.youtube.com/oembed"
+
+
+def _normalize_host(host: str | None) -> str:
+    """Lowercase a hostname, stripping a leading ``www.`` for comparison."""
+    return (host or "").lower()
+
+
+def is_youtube_url(url: str) -> bool:
+    """Return ``True`` if ``url`` points at a YouTube host.
+
+    Detection is host-based (``youtube.com``, ``www.youtube.com``,
+    ``m.youtube.com``, ``youtu.be``); it does not require a resolvable single
+    video id, so playlist and channel URLs also return ``True`` here (they are
+    rejected later by :func:`fetch_youtube`).
+
+    Args:
+        url: The candidate URL.
+
+    Returns:
+        Whether the URL's host is a known YouTube host.
+    """
+    try:
+        host = _normalize_host(urlsplit(url).hostname)
+    except ValueError:
+        return False
+    return host in _YOUTUBE_HOSTS
+
+
+def extract_video_id(url: str) -> str | None:
+    """Extract the single video id from a YouTube URL, or ``None``.
+
+    Handles ``watch?v=<id>``, ``youtu.be/<id>``, and ``shorts/<id>`` forms,
+    with or without extra query params (e.g. ``&t=``, ``&list=``, ``?si=``).
+    Returns ``None`` for non-YouTube hosts and for pure playlist / channel /
+    handle URLs that carry no single video id.
+
+    Args:
+        url: The candidate URL.
+
+    Returns:
+        The 11-character video id, or ``None`` if the URL is not a resolvable
+        single-video YouTube URL.
+    """
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return None
+    host = _normalize_host(parsed.hostname)
+    if host not in _YOUTUBE_HOSTS:
+        return None
+
+    path = parsed.path or ""
+
+    # youtu.be/<id>
+    if host == "youtu.be":
+        candidate = path.lstrip("/").split("/", 1)[0]
+        return candidate if _VIDEO_ID_RE.match(candidate) else None
+
+    # youtube.com/watch?v=<id>
+    if path == "/watch":
+        values = parse_qs(parsed.query).get("v", [])
+        candidate = values[0] if values else ""
+        return candidate if _VIDEO_ID_RE.match(candidate) else None
+
+    # youtube.com/shorts/<id> or /embed/<id> or /v/<id>
+    for prefix in ("/shorts/", "/embed/", "/v/"):
+        if path.startswith(prefix):
+            candidate = path[len(prefix) :].split("/", 1)[0]
+            return candidate if _VIDEO_ID_RE.match(candidate) else None
+
+    return None
+
+
+def _load_youtube_transcript_api() -> Any:
+    """Lazily import ``youtube_transcript_api``.
+
+    Returns:
+        The imported ``youtube_transcript_api`` module.
+
+    Raises:
+        KaguraIngestError: If the optional dependency is not installed, with a
+            message pointing at the ``[ingest-youtube]`` extra.
+    """
+    try:
+        import youtube_transcript_api  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise KaguraIngestError(
+            "youtube-transcript-api is not installed. Install with: "
+            "pip install 'kagura-memory[ingest-youtube]'"
+        ) from e
+    return youtube_transcript_api
+
+
+async def _fetch_oembed(url: str, *, read_timeout: float) -> tuple[str | None, str | None]:
+    """Fetch ``(title, author_name)`` from YouTube oEmbed; best-effort.
+
+    A failure (network error, non-200, malformed JSON) returns
+    ``(None, None)`` rather than raising — oEmbed metadata must never fail the
+    whole ingest.
+
+    Args:
+        url: The YouTube video URL.
+        read_timeout: Per-request read timeout in seconds.
+
+    Returns:
+        A ``(title, author_name)`` tuple; either element may be ``None``.
+    """
+    timeout = httpx.Timeout(connect=10.0, read=read_timeout, write=10.0, pool=10.0)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(_OEMBED_URL, params={"url": url, "format": "json"})
+            response.raise_for_status()
+            data = response.json()
+    except (httpx.HTTPError, ValueError):
+        # ValueError covers JSON decode failures; httpx.HTTPError covers
+        # network/status errors. Degrade gracefully.
+        return None, None
+    title = data.get("title") if isinstance(data, dict) else None
+    author = data.get("author_name") if isinstance(data, dict) else None
+    return (title or None), (author or None)
+
+
+def _format_timestamp(seconds: float) -> str:
+    """Format ``seconds`` as ``mm:ss`` (or ``h:mm:ss`` past an hour)."""
+    total = int(seconds)
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def _segment_windows(snippets: list[Any]) -> list[tuple[float, str]]:
+    """Group transcript snippets into ``(start_sec, text)`` time windows.
+
+    A new window opens once the accumulated duration exceeds
+    :data:`_WINDOW_SECONDS` or the accumulated text exceeds
+    :data:`_WINDOW_CHARS`, whichever comes first.
+
+    Args:
+        snippets: Caption snippets, each with ``.text`` and ``.start``.
+
+    Returns:
+        A list of ``(window_start_seconds, window_text)`` tuples.
+    """
+    windows: list[tuple[float, str]] = []
+    window_start: float | None = None
+    parts: list[str] = []
+    char_count = 0
+
+    def flush() -> None:
+        nonlocal parts, char_count, window_start
+        if window_start is not None and parts:
+            windows.append((window_start, " ".join(parts).strip()))
+        parts = []
+        char_count = 0
+        window_start = None
+
+    for snippet in snippets:
+        text = (getattr(snippet, "text", "") or "").strip()
+        if not text:
+            continue
+        start = float(getattr(snippet, "start", 0.0))
+        # Close the current window BEFORE adding a snippet that would push it
+        # past either window boundary, so the new snippet opens a fresh window
+        # anchored at its own start time.
+        if window_start is not None and (
+            start - window_start >= _WINDOW_SECONDS or char_count >= _WINDOW_CHARS
+        ):
+            flush()
+        if window_start is None:
+            window_start = start
+        parts.append(text)
+        char_count += len(text) + 1
+    flush()
+    return windows
+
+
+def _build_markdown(title: str, author: str | None, windows: list[tuple[float, str]]) -> str:
+    """Assemble the transcript Markdown document.
+
+    The first line is ``# <title>`` (H1) so ``TextExtractor`` promotes it to
+    the overview memory's title. An optional metadata line names the channel.
+    Each window renders as a ``## [mm:ss]`` section.
+
+    Args:
+        title: The video title (H1).
+        author: The channel / author name, or ``None``.
+        windows: ``(start_seconds, text)`` time windows from
+            :func:`_segment_windows`.
+
+    Returns:
+        The UTF-8 Markdown document as a ``str``, capped at
+        :data:`_MAX_TOTAL_TEXT_CHARS` characters (truncated with a marker if
+        the transcript would exceed the cap).
+    """
+    lines: list[str] = [f"# {title}", ""]
+    if author:
+        lines.append(f"Channel: {author}")
+        lines.append("")
+    for start, text in windows:
+        lines.append(f"## [{_format_timestamp(start)}]")
+        lines.append("")
+        lines.append(text)
+        lines.append("")
+    markdown = "\n".join(lines).rstrip() + "\n"
+
+    if len(markdown) > _MAX_TOTAL_TEXT_CHARS:
+        marker = "\n\n[transcript truncated: exceeded length cap]\n"
+        keep = _MAX_TOTAL_TEXT_CHARS - len(marker)
+        markdown = markdown[: max(0, keep)] + marker
+    return markdown
+
+
+def _resolve_transcript(transcript_list: Any, languages: tuple[str, ...]) -> Any:
+    """Pick a transcript: manual (preferred) → generated → first available.
+
+    Args:
+        transcript_list: A ``TranscriptList`` from ``YouTubeTranscriptApi.list``.
+        languages: Preferred language codes, in descending priority.
+
+    Returns:
+        A ``Transcript`` object whose ``.fetch()`` yields snippets.
+
+    Raises:
+        Exception: Re-raises the library's lookup error only when no transcript
+            of any kind is available.
+    """
+    youtube_transcript_api = _load_youtube_transcript_api()
+    no_transcript = youtube_transcript_api.NoTranscriptFound
+
+    try:
+        return transcript_list.find_manually_created_transcript(list(languages))
+    except no_transcript:
+        pass
+    try:
+        return transcript_list.find_generated_transcript(list(languages))
+    except no_transcript:
+        pass
+    # Fall back to the first available transcript in any language.
+    for transcript in transcript_list:
+        return transcript
+    raise no_transcript.__new__(no_transcript)
+
+
+def _fetch_transcript_sync(video_id: str, languages: tuple[str, ...]) -> list[Any]:
+    """Synchronously resolve and fetch a transcript's snippets.
+
+    Runs the blocking ``youtube-transcript-api`` calls; the caller wraps this
+    in :func:`asyncio.to_thread`.
+
+    Args:
+        video_id: The 11-character YouTube video id.
+        languages: Preferred caption languages.
+
+    Returns:
+        The list of caption snippets (each with ``.text`` / ``.start``).
+
+    Raises:
+        KaguraFetchError: For caption-disabled / unavailable / restricted
+            videos, with an actionable message.
+        KaguraIngestError: If the optional dependency is missing.
+    """
+    youtube_transcript_api = _load_youtube_transcript_api()
+    api = youtube_transcript_api.YouTubeTranscriptApi()
+
+    try:
+        transcript_list = api.list(video_id)
+        transcript = _resolve_transcript(transcript_list, languages)
+        snippets = list(transcript.fetch())
+    except youtube_transcript_api.TranscriptsDisabled as e:
+        raise KaguraFetchError(
+            "captions are disabled for this video; no transcript is available",
+            url=video_id,
+        ) from e
+    except youtube_transcript_api.NoTranscriptFound as e:
+        raise KaguraFetchError(
+            "no transcript/captions found for this video in any language",
+            url=video_id,
+        ) from e
+    except youtube_transcript_api.AgeRestricted as e:
+        raise KaguraFetchError(
+            "video is age-restricted; its transcript cannot be retrieved",
+            url=video_id,
+        ) from e
+    except (
+        youtube_transcript_api.VideoUnavailable,
+        youtube_transcript_api.VideoUnplayable,
+        youtube_transcript_api.InvalidVideoId,
+    ) as e:
+        raise KaguraFetchError(
+            "video is unavailable (private, removed, or region-locked)",
+            url=video_id,
+        ) from e
+    except youtube_transcript_api.CouldNotRetrieveTranscript as e:
+        # Catch-all for the library's other retrieval failures (IP blocked,
+        # request blocked, members-only, etc.).
+        raise KaguraFetchError(
+            f"could not retrieve transcript for this video: {e}",
+            url=video_id,
+        ) from e
+    return snippets
+
+
+async def fetch_youtube(
+    url: str,
+    *,
+    max_bytes: int,
+    read_timeout: float,
+    languages: tuple[str, ...] | None = None,
+) -> FetchResult:
+    """Resolve a YouTube video URL to a Markdown transcript ``FetchResult``.
+
+    Manual captions are preferred, auto-generated captions are the fallback,
+    and the first available transcript in any language is the final fallback.
+    The resulting Markdown carries an H1 title (so the overview memory's title
+    is populated) and ``## [mm:ss]`` time-window sections.
+
+    Args:
+        url: A single-video YouTube URL (``watch?v=``, ``youtu.be/``,
+            ``shorts/``). Playlist / channel URLs are rejected.
+        max_bytes: Reserved for parity with the byte fetcher; the transcript is
+            additionally capped at :data:`_MAX_TOTAL_TEXT_CHARS` characters.
+        read_timeout: Per-request read timeout (seconds) for the oEmbed call.
+        languages: Preferred caption languages, in descending priority.
+            Defaults to ``("en",)``.
+
+    Returns:
+        A :class:`FetchResult` with ``content_type="text/markdown"``,
+        ``source_type="url"``, and ``source_uri=url``.
+
+    Raises:
+        KaguraFetchError: For playlist/channel URLs and for caption-disabled,
+            unavailable, age-restricted, or otherwise unretrievable videos.
+        KaguraIngestError: If ``youtube-transcript-api`` is not installed.
+    """
+    video_id = extract_video_id(url)
+    if video_id is None:
+        raise KaguraFetchError(
+            "playlists/channels are not supported; provide a single video URL",
+            url=url,
+        )
+
+    langs = languages or _DEFAULT_LANGUAGES
+
+    # Run the transcript fetch and the (best-effort) oEmbed fetch.
+    snippets = await asyncio.to_thread(_fetch_transcript_sync, video_id, langs)
+    title, author = await _fetch_oembed(url, read_timeout=read_timeout)
+
+    windows = _segment_windows(snippets)
+    markdown = _build_markdown(title or video_id, author, windows)
+    body = markdown.encode("utf-8")
+
+    return FetchResult(
+        body=body,
+        content_type="text/markdown",
+        source_uri=url,
+        source_type="url",
+        final_url=url,
+        bytes_read=len(body),
+    )

--- a/src/kagura_memory/ingest/_youtube.py
+++ b/src/kagura_memory/ingest/_youtube.py
@@ -56,7 +56,11 @@ _OEMBED_URL = "https://www.youtube.com/oembed"
 
 
 def _normalize_host(host: str | None) -> str:
-    """Lowercase a hostname, stripping a leading ``www.`` for comparison."""
+    """Lowercase a hostname for comparison against :data:`_YOUTUBE_HOSTS`.
+
+    The host set already lists both the apex and ``www.`` forms, so no prefix
+    stripping is needed here.
+    """
     return (host or "").lower()
 
 
@@ -260,10 +264,16 @@ def _build_markdown(title: str, author: str | None, windows: list[tuple[float, s
         lines.append("")
     markdown = "\n".join(lines).rstrip() + "\n"
 
-    if len(markdown) > _MAX_TOTAL_TEXT_CHARS:
+    # Cap on encoded BYTES, not characters: TextExtractor bounds its input at
+    # _MAX_TOTAL_TEXT_CHARS *bytes*, so a long multibyte (e.g. Japanese)
+    # transcript capped only by character count could still overflow it. Slice
+    # the UTF-8 bytes and decode with errors="ignore" to drop a partial
+    # trailing multibyte sequence.
+    if len(markdown.encode("utf-8")) > _MAX_TOTAL_TEXT_CHARS:
         marker = "\n\n[transcript truncated: exceeded length cap]\n"
-        keep = _MAX_TOTAL_TEXT_CHARS - len(marker)
-        markdown = markdown[: max(0, keep)] + marker
+        budget = _MAX_TOTAL_TEXT_CHARS - len(marker.encode("utf-8"))
+        truncated = markdown.encode("utf-8")[: max(0, budget)].decode("utf-8", errors="ignore")
+        markdown = truncated + marker
     return markdown
 
 

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -366,7 +366,13 @@ class FileIngestor:
         # [ingest-youtube] dependency surfaces as KaguraIngestError, which the
         # ingest()/estimate_cost() fetch try-blocks already wrap as a
         # step="fetch" IngestResult error (alongside KaguraFetchError).
-        if is_youtube_url(source):
+        #
+        # Gate the YouTube path on the same http(s) policy as the byte Fetcher:
+        # only route an http:// YouTube URL to fetch_youtube when allow_http is
+        # True. Otherwise fall through to the normal Fetcher path, which raises
+        # the canonical "http:// is disabled" KaguraFetchError — keeping the
+        # allow_http contract consistent across every source type.
+        if is_youtube_url(source) and (allow_http or urlsplit(source).scheme.lower() == "https"):
             try:
                 return await fetch_youtube(source, max_bytes=max_bytes, read_timeout=read_timeout)
             except KaguraIngestError as e:

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -24,6 +24,7 @@ from ..files_client import FilesClient
 from ..logger import VerboseLogger, normalize_logger
 from ..models import CostBreakdown, FileObject, IngestErrorRecord, IngestResult
 from ._types import Chunk, ExtractedContent
+from ._youtube import fetch_youtube, is_youtube_url
 from .chunker import chunk as do_chunk
 from .extractors import (
     DOCX_MIME,
@@ -359,6 +360,22 @@ class FileIngestor:
         allow_http: bool,
         allow_system_paths: bool,
     ) -> FetchResult:
+        # YouTube URLs are a transcript-source path, not a byte fetch: detect
+        # them FIRST (by host) and route to the transcript resolver, which
+        # returns a ready-to-extract text/markdown FetchResult. A missing
+        # [ingest-youtube] dependency surfaces as KaguraIngestError, which the
+        # ingest()/estimate_cost() fetch try-blocks already wrap as a
+        # step="fetch" IngestResult error (alongside KaguraFetchError).
+        if is_youtube_url(source):
+            try:
+                return await fetch_youtube(source, max_bytes=max_bytes, read_timeout=read_timeout)
+            except KaguraIngestError as e:
+                # A missing [ingest-youtube] dependency raises KaguraIngestError.
+                # ingest()/estimate_cost() only catch KaguraFetchError around the
+                # fetch call, so re-raise as KaguraFetchError to surface it as a
+                # machine-readable step="fetch" IngestResult error (preserving the
+                # original install hint in the message).
+                raise KaguraFetchError(str(e), url=source) from e
         async with Fetcher(
             max_bytes=max_bytes,
             connect_timeout=connect_timeout,

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -405,20 +405,17 @@ class FileIngestor:
         # the canonical "http:// is disabled" KaguraFetchError — keeping the
         # allow_http contract consistent across every source type.
         if is_youtube_url(source) and (allow_http or urlsplit(source).scheme.lower() == "https"):
-            try:
-                return await fetch_youtube(
-                    source,
-                    max_bytes=max_bytes,
-                    connect_timeout=connect_timeout,
-                    read_timeout=read_timeout,
-                )
-            except KaguraIngestError as e:
-                # A missing [ingest-youtube] dependency raises KaguraIngestError.
-                # ingest()/estimate_cost() only catch KaguraFetchError around the
-                # fetch call, so re-raise as KaguraFetchError to surface it as a
-                # machine-readable step="fetch" IngestResult error (preserving the
-                # original install hint in the message).
-                raise KaguraFetchError(str(e), url=source) from e
+            # A missing [ingest-youtube] dependency raises KaguraIngestError;
+            # ingest()/estimate_cost() already catch it around the _fetch call and
+            # surface it as a machine-readable step="fetch" IngestResult error
+            # (identical handling to the BrowserFetcher path below), so no local
+            # wrap is needed here.
+            return await fetch_youtube(
+                source,
+                max_bytes=max_bytes,
+                connect_timeout=connect_timeout,
+                read_timeout=read_timeout,
+            )
 
         # render only affects URL sources. A local file path with
         # render=True silently falls back to the standard Fetcher.

--- a/tests/test_ingest_ingestor.py
+++ b/tests/test_ingest_ingestor.py
@@ -761,4 +761,70 @@ async def test_youtube_missing_dependency_surfaces_as_fetch_error() -> None:
 
     await client.close()
 
+
+@pytest.mark.asyncio
+async def test_http_youtube_url_not_routed_when_allow_http_false() -> None:
+    """An http:// YouTube URL with allow_http=False bypasses fetch_youtube.
+
+    is_youtube_url() is host-based and true for http:// too. The _fetch gate
+    must NOT route such a URL to the transcript path; it falls through to the
+    byte Fetcher, which raises the canonical 'http:// is disabled' error —
+    keeping the allow_http contract consistent across source types.
+    """
+    from kagura_memory.exceptions import KaguraFetchError
+
+    client = _make_client()
+    provider = FakeProvider()
+    ingestor = FileIngestor(client=client, text_provider=provider)
+
+    url = "http://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with patch("kagura_memory.ingest.ingestor.fetch_youtube", new_callable=AsyncMock) as fake_fetch:
+        with pytest.raises(KaguraFetchError) as ei:
+            await ingestor._fetch(
+                url,
+                max_bytes=10_000_000,
+                connect_timeout=10.0,
+                read_timeout=10.0,
+                allow_http=False,
+                allow_system_paths=False,
+            )
+    fake_fetch.assert_not_called()
+    assert "http" in str(ei.value).lower()
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_http_youtube_url_routed_when_allow_http_true() -> None:
+    """An http:// YouTube URL with allow_http=True DOES route to fetch_youtube."""
+    from kagura_memory.ingest.fetcher import FetchResult
+
+    client = _make_client()
+    provider = FakeProvider()
+    ingestor = FileIngestor(client=client, text_provider=provider)
+
+    url = "http://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    md = b"# Test\n\n## [00:00]\n\nhi\n"
+    fake_fetch = AsyncMock(
+        return_value=FetchResult(
+            body=md,
+            content_type="text/markdown",
+            source_uri=url,
+            source_type="url",
+            final_url=url,
+            bytes_read=len(md),
+        )
+    )
+    with patch("kagura_memory.ingest.ingestor.fetch_youtube", new=fake_fetch):
+        result = await ingestor._fetch(
+            url,
+            max_bytes=10_000_000,
+            connect_timeout=10.0,
+            read_timeout=10.0,
+            allow_http=True,
+            allow_system_paths=False,
+        )
+    fake_fetch.assert_awaited_once()
+    assert result.source_uri == url
+
     await client.close()

--- a/tests/test_ingest_ingestor.py
+++ b/tests/test_ingest_ingestor.py
@@ -684,4 +684,81 @@ async def test_details_extra_non_str_keys_raise_type_error() -> None:
         mock_remember.assert_not_called()
         mock_fetch.assert_not_called()
 
+
+# ---------------------------------------------------------------------------
+# YouTube transcript source routing (issue #146)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_youtube_url_is_routed_to_transcript_path() -> None:
+    """A YouTube URL is detected by host and routed to fetch_youtube()."""
+    from kagura_memory.ingest.fetcher import FetchResult
+
+    client = _make_client()
+    provider = FakeProvider()
+    ingestor = FileIngestor(client=client, text_provider=provider)
+
+    url = "https://youtu.be/dQw4w9WgXcQ"
+    md = b"# Test Video\n\n## [00:00]\n\nhello world\n"
+    fake_fetch = AsyncMock(
+        return_value=FetchResult(
+            body=md,
+            content_type="text/markdown",
+            source_uri=url,
+            source_type="url",
+            final_url=url,
+            bytes_read=len(md),
+        )
+    )
+
+    with (
+        patch("kagura_memory.ingest.ingestor.fetch_youtube", new=fake_fetch),
+        patch.object(client, "remember", new_callable=AsyncMock) as mock_remember,
+    ):
+        mock_remember.return_value = {"memory_id": "mem-1"}
+        result = await ingestor.ingest(url, context_id="ctx-uuid")
+
+    fake_fetch.assert_awaited_once()
+    assert fake_fetch.await_args is not None
+    assert fake_fetch.await_args.args[0] == url
+    assert result.source_uri == url
+    assert result.source_type == "url"
+    # Title flowed from the markdown H1 (TextExtractor promotes it) into the
+    # overview memory's summary.
+    overview_call = mock_remember.await_args_list[0]
+    assert "Test Video" in overview_call.kwargs.get("summary", "")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_youtube_missing_dependency_surfaces_as_fetch_error() -> None:
+    """Without [ingest-youtube], the youtube path yields a step='fetch' error."""
+    client = _make_client()
+    provider = FakeProvider()
+    ingestor = FileIngestor(client=client, text_provider=provider)
+
+    from kagura_memory.exceptions import KaguraIngestError
+
+    with patch(
+        "kagura_memory.ingest.ingestor.fetch_youtube",
+        new=AsyncMock(
+            side_effect=KaguraIngestError(
+                "youtube-transcript-api is not installed. Install with: "
+                "pip install 'kagura-memory[ingest-youtube]'"
+            )
+        ),
+    ):
+        result = await ingestor.ingest(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ", context_id="ctx-uuid"
+        )
+
+    assert result.overview_id is None
+    assert result.errors
+    assert result.errors[0].step == "fetch"
+    assert "ingest-youtube" in result.errors[0].message
+
+    await client.close()
+
     await client.close()

--- a/tests/test_ingest_youtube.py
+++ b/tests/test_ingest_youtube.py
@@ -1,0 +1,326 @@
+"""Tests for the YouTube transcript source resolver (issue #146).
+
+The ``youtube-transcript-api`` client and the oEmbed ``httpx`` call are
+mocked throughout so the unit suite needs no network access. One
+integration test (``@pytest.mark.youtube``) hits a real video and is
+default-skipped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kagura_memory.exceptions import KaguraFetchError, KaguraIngestError
+from kagura_memory.ingest import _youtube
+from kagura_memory.ingest._youtube import (
+    extract_video_id,
+    fetch_youtube,
+    is_youtube_url,
+)
+
+# --- URL parsing -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("http://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s", "dQw4w9WgXcQ"),
+        ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtu.be/dQw4w9WgXcQ?si=abc123", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        # watch?v with a playlist param still resolves the single video.
+        (
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL12345",
+            "dQw4w9WgXcQ",
+        ),
+        # Pure playlist / channel URLs have no single video id.
+        ("https://www.youtube.com/playlist?list=PL12345", None),
+        ("https://www.youtube.com/channel/UC12345", None),
+        ("https://www.youtube.com/@somehandle", None),
+        # Non-YouTube hosts.
+        ("https://example.com/watch?v=dQw4w9WgXcQ", None),
+        ("https://vimeo.com/123456", None),
+    ],
+)
+def test_extract_video_id(url: str, expected: str | None) -> None:
+    assert extract_video_id(url) == expected
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=abc", True),
+        ("https://youtube.com/watch?v=abc", True),
+        ("https://m.youtube.com/watch?v=abc", True),
+        ("https://youtu.be/abc", True),
+        ("https://www.youtube.com/playlist?list=PL1", True),
+        ("https://example.com/watch?v=abc", False),
+        ("https://vimeo.com/123", False),
+        ("not a url", False),
+        ("", False),
+    ],
+)
+def test_is_youtube_url(url: str, expected: bool) -> None:
+    assert is_youtube_url(url) is expected
+
+
+# --- Mock helpers ------------------------------------------------------------
+
+
+def _snippet(text: str, start: float, duration: float) -> SimpleNamespace:
+    return SimpleNamespace(text=text, start=start, duration=duration)
+
+
+def _fake_transcript(snippets: list[SimpleNamespace], *, language_code: str = "en"):
+    """Build a fake ``Transcript`` whose ``.fetch()`` yields ``snippets``."""
+    transcript = MagicMock()
+    transcript.language_code = language_code
+    transcript.is_generated = False
+    transcript.fetch.return_value = snippets
+    return transcript
+
+
+def _fake_api(transcript) -> MagicMock:
+    """Build a fake ``YouTubeTranscriptApi`` whose ``.list()`` finds ``transcript``."""
+    transcript_list = MagicMock()
+    transcript_list.find_manually_created_transcript.return_value = transcript
+    transcript_list.find_generated_transcript.side_effect = AssertionError(
+        "manual transcript should be preferred"
+    )
+    transcript_list.__iter__.return_value = iter([transcript])
+
+    api = MagicMock()
+    api.list.return_value = transcript_list
+    return api
+
+
+def _patch_api(api: MagicMock):
+    """Patch the lazy loader so it returns the real module but with a fake client.
+
+    The implementation references the library's exception classes off the
+    loaded module (e.g. ``module.TranscriptsDisabled``), so the fake must carry
+    the real exception classes — only ``YouTubeTranscriptApi`` is swapped for a
+    constructor that returns the mocked ``api``.
+    """
+    import youtube_transcript_api as real_module
+
+    fake_module = SimpleNamespace(
+        **{
+            name: getattr(real_module, name)
+            for name in dir(real_module)
+            if not name.startswith("_")
+        }
+    )
+    fake_module.YouTubeTranscriptApi = MagicMock(return_value=api)
+    return patch.object(_youtube, "_load_youtube_transcript_api", return_value=fake_module)
+
+
+def _patch_oembed(
+    title: str = "Rick Astley - Never Gonna Give You Up", author: str = "Rick Astley"
+):
+    """Patch the oEmbed fetch to return a title/author."""
+    return patch.object(
+        _youtube,
+        "_fetch_oembed",
+        new=AsyncMock(return_value=(title, author)),
+    )
+
+
+# --- Happy path --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_happy_path() -> None:
+    snippets = [
+        _snippet("Hello there", 0.0, 3.0),
+        _snippet("welcome to the show", 3.0, 4.0),
+        _snippet("this is later content", 75.0, 5.0),
+    ]
+    api = _fake_api(_fake_transcript(snippets))
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    with _patch_api(api), _patch_oembed():
+        result = await fetch_youtube(url, max_bytes=10_000_000, read_timeout=10.0)
+
+    assert result.content_type == "text/markdown"
+    assert result.source_type == "url"
+    assert result.source_uri == url
+    body = result.body.decode("utf-8")
+    # Title flows in as an H1 so TextExtractor promotes it to the title.
+    assert body.startswith("# Rick Astley - Never Gonna Give You Up")
+    assert "Rick Astley" in body  # author in the metadata line
+    # Time-window section headings.
+    assert "## [00:00]" in body
+    assert "## [01:15]" in body
+    assert "Hello there" in body
+    assert "this is later content" in body
+    assert result.bytes_read == len(result.body)
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_falls_back_to_generated_transcript() -> None:
+    snippets = [_snippet("auto caption", 0.0, 2.0)]
+    generated = _fake_transcript(snippets)
+    generated.is_generated = True
+
+    transcript_list = MagicMock()
+    transcript_list.find_manually_created_transcript.side_effect = _no_transcript_found()
+    transcript_list.find_generated_transcript.return_value = generated
+
+    api = MagicMock()
+    api.list.return_value = transcript_list
+
+    with _patch_api(api), _patch_oembed():
+        result = await fetch_youtube(
+            "https://youtu.be/dQw4w9WgXcQ", max_bytes=10_000_000, read_timeout=10.0
+        )
+
+    assert b"auto caption" in result.body
+
+
+# --- Failure modes -----------------------------------------------------------
+
+
+def _no_transcript_found() -> Exception:
+    from youtube_transcript_api import NoTranscriptFound
+
+    # NoTranscriptFound's __init__ signature varies; build a bare instance.
+    exc = NoTranscriptFound.__new__(NoTranscriptFound)
+    Exception.__init__(exc, "no transcript")
+    return exc
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_transcripts_disabled() -> None:
+    from youtube_transcript_api import TranscriptsDisabled
+
+    exc = TranscriptsDisabled.__new__(TranscriptsDisabled)
+    Exception.__init__(exc, "disabled")
+
+    api = MagicMock()
+    api.list.side_effect = exc
+
+    with _patch_api(api), _patch_oembed():
+        with pytest.raises(KaguraFetchError) as ei:
+            await fetch_youtube(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                max_bytes=10_000_000,
+                read_timeout=10.0,
+            )
+    msg = str(ei.value).lower()
+    assert "caption" in msg or "transcript" in msg
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_video_unavailable() -> None:
+    from youtube_transcript_api import VideoUnavailable
+
+    exc = VideoUnavailable.__new__(VideoUnavailable)
+    Exception.__init__(exc, "unavailable")
+
+    api = MagicMock()
+    api.list.side_effect = exc
+
+    with _patch_api(api), _patch_oembed():
+        with pytest.raises(KaguraFetchError):
+            await fetch_youtube(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                max_bytes=10_000_000,
+                read_timeout=10.0,
+            )
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_playlist_rejected() -> None:
+    with pytest.raises(KaguraFetchError) as ei:
+        await fetch_youtube(
+            "https://www.youtube.com/playlist?list=PL12345",
+            max_bytes=10_000_000,
+            read_timeout=10.0,
+        )
+    assert "playlist" in str(ei.value).lower() or "single video" in str(ei.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_missing_dependency() -> None:
+    def _raise() -> Any:
+        raise ImportError("no module")
+
+    with patch.object(
+        _youtube,
+        "_load_youtube_transcript_api",
+        side_effect=KaguraIngestError(
+            "youtube-transcript-api is not installed. Install with: "
+            "pip install 'kagura-memory[ingest-youtube]'"
+        ),
+    ):
+        with pytest.raises(KaguraIngestError) as ei:
+            await fetch_youtube(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                max_bytes=10_000_000,
+                read_timeout=10.0,
+            )
+    assert "ingest-youtube" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_oembed_failure_degrades_gracefully() -> None:
+    """An oEmbed failure must NOT fail the ingest — title falls back to id."""
+    snippets = [_snippet("content here", 0.0, 2.0)]
+    api = _fake_api(_fake_transcript(snippets))
+
+    with (
+        _patch_api(api),
+        patch.object(_youtube, "_fetch_oembed", new=AsyncMock(return_value=(None, None))),
+    ):
+        result = await fetch_youtube(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            max_bytes=10_000_000,
+            read_timeout=10.0,
+        )
+
+    body = result.body.decode("utf-8")
+    # Title falls back to the video id.
+    assert body.startswith("# dQw4w9WgXcQ")
+    assert b"content here" in result.body
+
+
+# --- Real loader (no dep installed → KaguraIngestError) ----------------------
+
+
+def test_load_youtube_transcript_api_importerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name.startswith("youtube_transcript_api"):
+            raise ImportError("simulated missing dep")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(KaguraIngestError) as ei:
+        _youtube._load_youtube_transcript_api()
+    assert "ingest-youtube" in str(ei.value)
+
+
+# --- Integration (default-skipped) ------------------------------------------
+
+
+@pytest.mark.youtube
+@pytest.mark.asyncio
+async def test_fetch_youtube_real_video() -> None:
+    pytest.importorskip("youtube_transcript_api")
+    # "Me at the zoo" — the first YouTube video, stable and captioned.
+    url = "https://www.youtube.com/watch?v=jNQXAC9IVRw"
+    result = await fetch_youtube(url, max_bytes=10_000_000, read_timeout=30.0)
+    assert result.content_type == "text/markdown"
+    assert result.body
+    assert result.body.decode("utf-8").startswith("# ")

--- a/tests/test_ingest_youtube.py
+++ b/tests/test_ingest_youtube.py
@@ -18,7 +18,7 @@ import pytest
 # via the lazy loader (and the test helpers below import them directly), so the
 # whole module must skip cleanly on a bare install without the optional
 # [ingest-youtube] extra — otherwise collection breaks at import time.
-pytest.importorskip("youtube_transcript_api")
+pytest.importorskip("youtube_transcript_api", reason="requires the [ingest-youtube] extra")
 
 from kagura_memory.exceptions import KaguraFetchError, KaguraIngestError  # noqa: E402
 from kagura_memory.ingest import _youtube  # noqa: E402
@@ -611,7 +611,7 @@ async def test_fetch_oembed_threads_connect_timeout() -> None:
 @pytest.mark.youtube
 @pytest.mark.asyncio
 async def test_fetch_youtube_real_video() -> None:
-    pytest.importorskip("youtube_transcript_api")
+    pytest.importorskip("youtube_transcript_api", reason="requires the [ingest-youtube] extra")
     # "Me at the zoo" — the first YouTube video, stable and captioned.
     url = "https://www.youtube.com/watch?v=jNQXAC9IVRw"
     result = await fetch_youtube(url, max_bytes=10_000_000, read_timeout=30.0)

--- a/tests/test_ingest_youtube.py
+++ b/tests/test_ingest_youtube.py
@@ -14,9 +14,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from kagura_memory.exceptions import KaguraFetchError, KaguraIngestError
-from kagura_memory.ingest import _youtube
-from kagura_memory.ingest._youtube import (
+# The module under test references youtube_transcript_api's exception classes
+# via the lazy loader (and the test helpers below import them directly), so the
+# whole module must skip cleanly on a bare install without the optional
+# [ingest-youtube] extra — otherwise collection breaks at import time.
+pytest.importorskip("youtube_transcript_api")
+
+from kagura_memory.exceptions import KaguraFetchError, KaguraIngestError  # noqa: E402
+from kagura_memory.ingest import _youtube  # noqa: E402
+from kagura_memory.ingest._youtube import (  # noqa: E402
     extract_video_id,
     fetch_youtube,
     is_youtube_url,
@@ -207,15 +213,87 @@ async def test_fetch_youtube_transcripts_disabled() -> None:
     api = MagicMock()
     api.list.side_effect = exc
 
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with _patch_api(api), _patch_oembed():
         with pytest.raises(KaguraFetchError) as ei:
-            await fetch_youtube(
-                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                max_bytes=10_000_000,
-                read_timeout=10.0,
-            )
+            await fetch_youtube(url, max_bytes=10_000_000, read_timeout=10.0)
     msg = str(ei.value).lower()
     assert "caption" in msg or "transcript" in msg
+    # The error carries the ORIGINAL url, not the bare video id, so the
+    # derived IngestResult.source_uri surfaces the caller's URL.
+    assert ei.value.url == url
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_no_transcript_found_carries_original_url() -> None:
+    """NoTranscriptFound surfaces the original URL, not the bare video id."""
+    transcript_list = MagicMock()
+    transcript_list.find_manually_created_transcript.side_effect = _no_transcript_found()
+    transcript_list.find_generated_transcript.side_effect = _no_transcript_found()
+    transcript_list.__iter__.return_value = iter([])
+
+    api = MagicMock()
+    api.list.return_value = transcript_list
+
+    url = "https://youtu.be/dQw4w9WgXcQ"
+    with _patch_api(api), _patch_oembed():
+        with pytest.raises(KaguraFetchError) as ei:
+            await fetch_youtube(url, max_bytes=10_000_000, read_timeout=10.0)
+    assert ei.value.url == url
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_age_restricted_carries_original_url() -> None:
+    from youtube_transcript_api import AgeRestricted
+
+    exc = AgeRestricted.__new__(AgeRestricted)
+    Exception.__init__(exc, "age restricted")
+
+    api = MagicMock()
+    api.list.side_effect = exc
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with _patch_api(api), _patch_oembed():
+        with pytest.raises(KaguraFetchError) as ei:
+            await fetch_youtube(url, max_bytes=10_000_000, read_timeout=10.0)
+    assert "age-restricted" in str(ei.value).lower()
+    assert ei.value.url == url
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_could_not_retrieve_carries_original_url() -> None:
+    from youtube_transcript_api import CouldNotRetrieveTranscript
+
+    # CouldNotRetrieveTranscript.__str__ formats a watch URL from .video_id, so
+    # set it on the bare instance (its __init__ signature varies by version).
+    exc = CouldNotRetrieveTranscript.__new__(CouldNotRetrieveTranscript)
+    exc.video_id = "dQw4w9WgXcQ"
+    Exception.__init__(exc, "ip blocked")
+
+    api = MagicMock()
+    api.list.side_effect = exc
+
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    with _patch_api(api), _patch_oembed():
+        with pytest.raises(KaguraFetchError) as ei:
+            await fetch_youtube(url, max_bytes=10_000_000, read_timeout=10.0)
+    assert ei.value.url == url
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_oversize_body_raises() -> None:
+    """A transcript whose body exceeds max_bytes is a hard failure."""
+    snippets = [_snippet("word " * 50, 0.0, 2.0)]
+    api = _fake_api(_fake_transcript(snippets))
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    with _patch_api(api), _patch_oembed():
+        with pytest.raises(KaguraFetchError) as ei:
+            # max_bytes far below the assembled markdown body forces the cap.
+            await fetch_youtube(url, max_bytes=10, read_timeout=10.0)
+    msg = str(ei.value).lower()
+    assert "max_bytes" in msg
+    assert ei.value.url == url
 
 
 @pytest.mark.asyncio
@@ -228,13 +306,11 @@ async def test_fetch_youtube_video_unavailable() -> None:
     api = MagicMock()
     api.list.side_effect = exc
 
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     with _patch_api(api), _patch_oembed():
-        with pytest.raises(KaguraFetchError):
-            await fetch_youtube(
-                "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                max_bytes=10_000_000,
-                read_timeout=10.0,
-            )
+        with pytest.raises(KaguraFetchError) as ei:
+            await fetch_youtube(url, max_bytes=10_000_000, read_timeout=10.0)
+    assert ei.value.url == url
 
 
 @pytest.mark.asyncio
@@ -250,9 +326,6 @@ async def test_fetch_youtube_playlist_rejected() -> None:
 
 @pytest.mark.asyncio
 async def test_fetch_youtube_missing_dependency() -> None:
-    def _raise() -> Any:
-        raise ImportError("no module")
-
     with patch.object(
         _youtube,
         "_load_youtube_transcript_api",
@@ -295,6 +368,25 @@ async def test_fetch_youtube_oembed_failure_degrades_gracefully() -> None:
 # --- Real loader (no dep installed → KaguraIngestError) ----------------------
 
 
+def test_load_youtube_transcript_api_success() -> None:
+    """The real loader returns the module when the dep is installed."""
+    import youtube_transcript_api as real_module
+
+    assert _youtube._load_youtube_transcript_api() is real_module
+
+
+def test_is_youtube_url_handles_unparseable() -> None:
+    """A URL whose parsing raises ValueError returns False, not an error."""
+    # An unterminated IPv6 literal makes urlsplit raise ValueError; the helper
+    # must swallow it and report "not a YouTube URL".
+    assert is_youtube_url("https://[invalid") is False
+
+
+def test_extract_video_id_handles_unparseable() -> None:
+    """A URL whose parsing raises ValueError returns None, not an error."""
+    assert extract_video_id("https://[invalid") is None
+
+
 def test_load_youtube_transcript_api_importerror(monkeypatch: pytest.MonkeyPatch) -> None:
     import builtins
 
@@ -309,6 +401,122 @@ def test_load_youtube_transcript_api_importerror(monkeypatch: pytest.MonkeyPatch
     with pytest.raises(KaguraIngestError) as ei:
         _youtube._load_youtube_transcript_api()
     assert "ingest-youtube" in str(ei.value)
+
+
+# --- Internal helpers --------------------------------------------------------
+
+
+def test_format_timestamp_hours() -> None:
+    """Past an hour, the timestamp gains an ``h:mm:ss`` field."""
+    assert _youtube._format_timestamp(3725.0) == "1:02:05"
+    assert _youtube._format_timestamp(59.0) == "00:59"
+
+
+def test_segment_windows_skips_empty_snippets() -> None:
+    """Blank/whitespace-only snippets are dropped before windowing."""
+    snippets = [
+        _snippet("   ", 0.0, 1.0),
+        _snippet("real text", 1.0, 1.0),
+        _snippet("", 2.0, 1.0),
+    ]
+    windows = _youtube._segment_windows(snippets)
+    assert windows == [(1.0, "real text")]
+
+
+@pytest.mark.asyncio
+async def test_resolve_transcript_first_available_fallback() -> None:
+    """When no manual/generated transcript matches, the first available wins."""
+    snippets = [_snippet("fallback caption", 0.0, 2.0)]
+    fallback = _fake_transcript(snippets, language_code="de")
+
+    transcript_list = MagicMock()
+    transcript_list.find_manually_created_transcript.side_effect = _no_transcript_found()
+    transcript_list.find_generated_transcript.side_effect = _no_transcript_found()
+    transcript_list.__iter__.return_value = iter([fallback])
+
+    api = MagicMock()
+    api.list.return_value = transcript_list
+
+    with _patch_api(api), _patch_oembed():
+        result = await fetch_youtube(
+            "https://youtu.be/dQw4w9WgXcQ", max_bytes=10_000_000, read_timeout=10.0
+        )
+    assert b"fallback caption" in result.body
+
+
+@pytest.mark.asyncio
+async def test_fetch_youtube_truncates_when_over_text_cap() -> None:
+    """A transcript over _MAX_TOTAL_TEXT_CHARS bytes is truncated with a marker."""
+    from kagura_memory.ingest._youtube import _MAX_TOTAL_TEXT_CHARS
+
+    # One huge snippet whose text alone blows past the char/byte cap.
+    big = "x" * (_MAX_TOTAL_TEXT_CHARS + 5000)
+    api = _fake_api(_fake_transcript([_snippet(big, 0.0, 2.0)]))
+
+    with _patch_api(api), _patch_oembed():
+        # max_bytes above the text cap so the _build_markdown truncation path
+        # (not the max_bytes hard cap) is the one exercised here.
+        result = await fetch_youtube(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            max_bytes=_MAX_TOTAL_TEXT_CHARS + 1_000_000,
+            read_timeout=10.0,
+        )
+    body = result.body.decode("utf-8")
+    assert "[transcript truncated: exceeded length cap]" in body
+    assert len(result.body) <= _MAX_TOTAL_TEXT_CHARS
+
+
+@pytest.mark.asyncio
+async def test_fetch_oembed_degrades_on_http_error() -> None:
+    """A non-200 / network error from oEmbed yields (None, None), never raises."""
+    import httpx
+
+    class _FailClient:
+        async def __aenter__(self) -> _FailClient:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def get(self, *args: Any, **kwargs: Any) -> Any:
+            raise httpx.ConnectError("boom")
+
+    with patch.object(httpx, "AsyncClient", return_value=_FailClient()):
+        title, author = await _youtube._fetch_oembed(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ", read_timeout=10.0
+        )
+    assert title is None
+    assert author is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_oembed_returns_title_and_author() -> None:
+    """A 200 oEmbed response yields the parsed title/author."""
+    import httpx
+
+    class _OkResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, str]:
+            return {"title": "My Video", "author_name": "Some Channel"}
+
+    class _OkClient:
+        async def __aenter__(self) -> _OkClient:
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+        async def get(self, *args: Any, **kwargs: Any) -> _OkResponse:
+            return _OkResponse()
+
+    with patch.object(httpx, "AsyncClient", return_value=_OkClient()):
+        title, author = await _youtube._fetch_oembed(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ", read_timeout=10.0
+        )
+    assert title == "My Video"
+    assert author == "Some Channel"
 
 
 # --- Integration (default-skipped) ------------------------------------------


### PR DESCRIPTION
Closes #146

## Summary
- Ingest a YouTube video by its transcript/captions: `ingest("https://www.youtube.com/watch?v=...")` is auto-detected by host and routed to a new Fetcher-layer source resolver, then flows through the normal chunk → summarize → remember pipeline.
- Uses `youtube-transcript-api` (captions, no API key) + YouTube **oEmbed** (title/channel, no API key). Opt-in `[ingest-youtube]` extra; a missing dependency surfaces as a `step="fetch"` error on the `IngestResult`, not an uncaught exception.
- Transcript is formatted as Markdown (H1 title + `## [mm:ss]` time-window sections) and routed through the existing `TextExtractor` — **zero orchestrator structural change** (the first H1 becomes the overview title).

## Implementation notes
- `src/kagura_memory/ingest/_youtube.py`: `is_youtube_url` / `extract_video_id` (handles `watch?v=`, `youtu.be/`, `shorts/`, `embed/`, `v/`, with extra params; rejects playlist/channel), transcript resolution (manual → generated → first-available), oEmbed metadata (best-effort — failure degrades the title, never fails the ingest), time-window segmentation, byte-accurate length cap.
- `_fetch` detects YouTube URLs by host first and routes to `fetch_youtube`; the missing-dep `KaguraIngestError` is wrapped as a `KaguraFetchError` so it surfaces as a `step="fetch"` IngestResult error.
- Caption-disabled / age-restricted / unavailable / region-locked → `KaguraFetchError` with an actionable message.
- 31 unit tests (transcript client + httpx mocked) + orchestrator routing tests + 1 default-skipped `@pytest.mark.youtube` integration test. Example: `examples/ingest_youtube.py`.

## Pre-PR review summary (gate2: advisor-only, consolidated)
- cso: yellow — SSRF surface minimal (fixed YouTube hosts). Note: `youtube-transcript-api` is an **unofficial** captions client → a ToS/reliability consideration for an opt-in extra (operator to weigh).
- qa-lead: green — strong unit + routing coverage; integration gated behind a marker.
- cto: green — clean Fetcher-layer resolver, non-invasive Markdown→TextExtractor integration; minor notes only.
- gate1: yellow via /claude-c-suite:ask (CTO lens — dep=youtube-transcript-api+oEmbed not yt-dlp; chapters deferred; option-A integration)

## Known limitations / follow-ups (non-blocking)
- **Chapters deferred** to a follow-up (require yt-dlp/InnerTube); v1 uses ~60s/1500-char time-window sections.
- `youtube-transcript-api` reliability (cloud-IP blocking, API drift) and YouTube ToS posture — acceptable for an opt-in extra; integration test is marker-gated.

🤖 Generated via /gh-issue-driven:ship
