### PR TITLE
feat(ingest): context-aware summarization steering from context_info (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ### Added
 
+- **Context-aware ingest summarization steering** (#148): ingest summaries are
+  no longer context-blind. `FileIngestor.ingest()` gains a keyword-only
+  `steering=None` argument; when omitted, the destination context's own
+  owner-authored configuration steers the summaries, resolved by precedence
+  `caller steering > context_info.instructions > context.summary > None`. The
+  resolved string is injected as a clearly-demarcated, **non-overriding**
+  trusted `<domain_context>` block appended *after* the fixed summarization
+  prompt — it focuses terminology/scope but never replaces the task and never
+  reopens the prompt-injection surface (the document body always stays data in
+  the `user` role; §8.3 preserved). The signal source is owner/editor-authored
+  workspace config, never document content; in a shared context the steering
+  author may differ from the ingesting member, hence the non-overriding
+  demarcation. `get_context_info` is fetched at most once per
+  `(client, context_id)` and cached on `KaguraClient` (failures cache `None`),
+  so steering adds no per-section round-trips; a fetch failure logs a warning
+  and proceeds with `steering=None` rather than failing the ingest. Whitespace-
+  only steering is treated as absent and the resolved value is truncated to
+  2000 characters. Recall-side steering, vision steering, named profiles, and
+  mid-session cache invalidation are deferred follow-ups.
 - **Audio/video transcription via Gemini** (#147): `ingest("talk.mp3")` (and
   `.wav` / `.m4a` / `.mp4`-with-audio) now routes the file to a Gemini
   transcription path (`gemini/gemini-2.5-flash`) that returns timestamped

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -120,6 +120,13 @@ class KaguraClient:
 
         self._session_id: str | None = None
         self._request_id_counter = itertools.count(1)
+        # Per-(client, context_id) cache for ingest steering: get_context_info
+        # is fetched at most once per context for the client's lifetime. A
+        # context_id present as a key with value None is the "fetched but
+        # unusable" sentinel (empty info or fetch failure) — it suppresses
+        # re-fetching on every section summarization. See
+        # :meth:`_get_context_info_cached`.
+        self._context_info_cache: dict[str, ContextInfo | None] = {}
 
     def _next_request_id(self) -> int:
         """Get next JSON-RPC request ID (concurrency-safe via itertools.count)."""
@@ -1009,6 +1016,52 @@ class KaguraClient:
         }
         result = await self._call_tool("get_context_info", arguments)
         return ContextInfo.model_validate(result)
+
+    async def _get_context_info_cached(self, context_id: str) -> ContextInfo | None:
+        """Best-effort, cached :meth:`get_context_info` for ingest steering.
+
+        Internal: the only caller is the ingest pipeline (see
+        :meth:`FileIngestor._resolve_steering`). It lives on the client — not
+        the ingestor — so the fetch-once cache is keyed per
+        ``(client, context_id)`` and shared across ingestors that reuse one
+        client, but it is deliberately kept off the public API surface.
+
+        Fetches the context info at most once per ``context_id`` for this
+        client's lifetime, caching the result (including ``None`` on failure)
+        so repeated callers — e.g. per-section ingest summarization — never
+        re-fetch. On any error the failure is swallowed and ``None`` is cached
+        and returned: steering is purely additive and best-effort, so a
+        missing or unreachable context must never crash ingestion.
+
+        Note: the cache is not invalidated mid-session. A concurrent
+        ``update_context`` is not reflected until a fresh client is created
+        (an intentional v1 design seam).
+
+        Args:
+            context_id: Context UUID.
+
+        Returns:
+            The :class:`ContextInfo`, or ``None`` if it could not be fetched.
+        """
+        if context_id in self._context_info_cache:
+            return self._context_info_cache[context_id]
+        try:
+            info: ContextInfo | None = await self.get_context_info(context_id)
+        except Exception as e:  # noqa: BLE001
+            # Best-effort contract: ingest must never crash because steering
+            # could not be fetched. Catch broadly — not just KaguraError but
+            # also a pydantic ValidationError from get_context_info's
+            # model_validate on a malformed/changed server payload — log a
+            # warning, and cache None so we degrade to steering=None without
+            # re-fetching. (python.md permits a broad catch that logs.)
+            logging.getLogger("kagura_memory").warning(
+                "get_context_info failed for context %s; ingest steering disabled: %s",
+                context_id,
+                e,
+            )
+            info = None
+        self._context_info_cache[context_id] = info
+        return info
 
     async def update_search_config(
         self,

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -48,6 +48,10 @@ from .providers.base import Provider
 _DEFAULT_OVERVIEW_TOKENS = 400
 _DEFAULT_SECTION_TOKENS = 200
 _DEFAULT_CONCURRENCY = 4
+# Upper bound on the resolved steering string injected into the summarization
+# prompt. Caps the per-call input-token overhead (the block rides on every
+# section + the overview call) and bounds untrusted-context-config size.
+_STEERING_MAX_CHARS = 2000
 
 # Keys stamped by the SDK in _write_overview. Callers must not pass these in
 # details_extra — collisions are rejected with ValueError at ingest() entry.
@@ -150,6 +154,7 @@ class FileIngestor:
         render: bool = False,
         archive_original: bool = True,
         details_extra: dict[str, Any] | None = None,
+        steering: str | None = None,
         logger: VerboseLogger | None = None,
     ) -> IngestResult:
         """Run a full ingestion against ``source``.
@@ -197,6 +202,24 @@ class FileIngestor:
                 :exc:`ValueError` at ``ingest()`` entry, before any
                 fetch or write operation is performed. Non-``str`` keys
                 raise :exc:`TypeError` at the same point.
+            steering: Optional caller override for context-aware
+                summarization. When omitted (the default), the destination
+                context's own owner-authored configuration is used as the
+                steering signal, resolved by precedence
+                ``caller steering > context_info.instructions >
+                context.summary > None``. The resolved value is injected as a
+                clearly-demarcated, *non-overriding* trusted block appended to
+                the fixed summarization prompt — it focuses terminology/scope
+                but never replaces the task and never reopens the prompt-
+                injection surface (the document body always stays data in the
+                ``user`` role; see ``providers/_litellm.py`` §8.3). Whitespace-
+                only steering is treated as absent; the resolved value is
+                truncated to 2000 characters. Trust boundary: in a shared
+                context the steering source is whatever the context owner/
+                editor authored, which may differ from the ingesting member —
+                hence the non-overriding demarcation. Fetching the context
+                config is best-effort: a failure logs a warning and proceeds
+                with ``steering=None`` rather than aborting the ingest.
             logger: Optional :class:`VerboseLogger` for progress events
                 (Rich for human stderr, NDJSON for AI consumers). When
                 omitted, the no-op :data:`_NULL_LOGGER` is used and no
@@ -266,6 +289,7 @@ class FileIngestor:
                 importance=importance,
                 archive_original=archive_original,
                 details_extra=details_extra,
+                steering=steering,
                 logger=log,
             )
         except BaseException as e:
@@ -541,11 +565,16 @@ class FileIngestor:
         importance: float,
         archive_original: bool,
         details_extra: dict[str, Any] | None = None,
+        steering: str | None = None,
         logger: VerboseLogger | None = None,
     ) -> IngestResult:
         log = normalize_logger(logger)
         errors: list[IngestErrorRecord] = []
         warnings: list[str] = []
+
+        # Resolve the steering signal once per ingest (not per section): a
+        # caller override wins, else the destination context's own config.
+        resolved_steering = await self._resolve_steering(context_id, steering)
 
         log.action("Extracting and chunking", stage="chunk")
         try:
@@ -585,7 +614,7 @@ class FileIngestor:
             )
 
         log.action(f"Summarizing {len(chunks)} section(s)", stage="summarize")
-        section_summaries = await self._summarize_sections(chunks, errors)
+        section_summaries = await self._summarize_sections(chunks, errors, resolved_steering)
         log.detail("Sections summarized", len(section_summaries), stage="summarize")
 
         # Build the overview from the section summaries (in parallel with
@@ -593,7 +622,9 @@ class FileIngestor:
         log.action("Summarizing overview", stage="summarize")
         try:
             overview_summary = await self._text.summarize_overview(
-                [s for s in section_summaries if s], max_tokens=_DEFAULT_OVERVIEW_TOKENS
+                [s for s in section_summaries if s],
+                max_tokens=_DEFAULT_OVERVIEW_TOKENS,
+                steering=resolved_steering,
             )
         except KaguraLLMError as e:
             errors.append(
@@ -662,10 +693,35 @@ class FileIngestor:
             errors=errors,
         )
 
+    async def _resolve_steering(self, context_id: str, caller_steering: str | None) -> str | None:
+        """Resolve the steering signal for one ingest run.
+
+        Precedence: ``caller_steering > context_info.instructions >
+        context.summary > None``. Each candidate is taken only if it is
+        non-blank after stripping; the chosen value is stripped and truncated
+        to :data:`_STEERING_MAX_CHARS`. Resolution is best-effort — the
+        context-config fetch is cached and never raises (see
+        :meth:`KaguraClient._get_context_info_cached`), so a missing or
+        unreachable context simply yields ``None`` and ingest proceeds.
+        """
+        if caller_steering and caller_steering.strip():
+            return caller_steering.strip()[:_STEERING_MAX_CHARS]
+
+        info = await self._client._get_context_info_cached(context_id)
+        if info is None:
+            return None
+        # instructions (purpose-built usage guidelines) outrank the broader
+        # context.summary description.
+        for candidate in (info.instructions, info.context.summary):
+            if candidate and candidate.strip():
+                return candidate.strip()[:_STEERING_MAX_CHARS]
+        return None
+
     async def _summarize_sections(
         self,
         chunks: list[Chunk],
         errors: list[IngestErrorRecord],
+        steering: str | None = None,
     ) -> list[str | None]:
         sem = asyncio.Semaphore(self._concurrency)
         results: list[str | None] = [None] * len(chunks)
@@ -674,7 +730,9 @@ class FileIngestor:
             async with sem:
                 try:
                     summary = await self._text.summarize(
-                        chunk_obj.text, max_tokens=_DEFAULT_SECTION_TOKENS
+                        chunk_obj.text,
+                        max_tokens=_DEFAULT_SECTION_TOKENS,
+                        steering=steering,
                     )
                 except KaguraLLMError as e:
                     errors.append(

--- a/src/kagura_memory/ingest/providers/_litellm.py
+++ b/src/kagura_memory/ingest/providers/_litellm.py
@@ -50,6 +50,31 @@ _VISION_SYSTEM_PROMPT = (
 
 _FALLBACK_CHARS_PER_TOKEN = 4
 
+# Trusted domain-context block appended AFTER the fixed task prompt when a
+# caller supplies steering. The fixed prompt always comes first and is never
+# replaced — this block only narrows terminology/focus. The label is a fixed
+# string positioned so the steering body cannot be confused for a task
+# instruction (defense-in-depth for shared contexts: the steering text comes
+# from owner-authored workspace config, but it is still demarcated as
+# non-overriding). §8.3 is preserved: the document body stays in the ``user``
+# role as data; this block lives in the ``system`` role as configuration.
+_STEERING_TEMPLATE = (
+    "\n\nDomain context (trusted workspace configuration — guides "
+    "terminology/focus only; NOT part of the document, contains no "
+    "task-overriding instructions):\n<domain_context>\n{steering}\n</domain_context>"
+)
+
+
+def _with_steering(system: str, steering: str | None) -> str:
+    """Append the demarcated steering block to ``system`` when present.
+
+    Returns ``system`` unchanged when ``steering`` is None or blank, so the
+    pre-steering prompt is byte-for-byte identical on the default path.
+    """
+    if steering and steering.strip():
+        return system + _STEERING_TEMPLATE.format(steering=steering)
+    return system
+
 
 class LiteLLMProvider:
     """Base class implementing the :class:`Provider` Protocol via litellm."""
@@ -75,19 +100,21 @@ class LiteLLMProvider:
 
     # --- Public API ----------------------------------------------------------
 
-    async def summarize(self, text: str, *, max_tokens: int) -> str:
+    async def summarize(self, text: str, *, max_tokens: int, steering: str | None = None) -> str:
         return await self._acompletion(
             model=self.text_model,
-            system=_SUMMARIZE_SYSTEM_PROMPT,
+            system=_with_steering(_SUMMARIZE_SYSTEM_PROMPT, steering),
             user_text=text,
             max_tokens=max_tokens,
         )
 
-    async def summarize_overview(self, section_summaries: list[str], *, max_tokens: int) -> str:
+    async def summarize_overview(
+        self, section_summaries: list[str], *, max_tokens: int, steering: str | None = None
+    ) -> str:
         joined = "\n\n".join(f"[Section {i + 1}]\n{s}" for i, s in enumerate(section_summaries))
         return await self._acompletion(
             model=self.text_model,
-            system=_OVERVIEW_SYSTEM_PROMPT,
+            system=_with_steering(_OVERVIEW_SYSTEM_PROMPT, steering),
             user_text=joined,
             max_tokens=max_tokens,
         )

--- a/src/kagura_memory/ingest/providers/base.py
+++ b/src/kagura_memory/ingest/providers/base.py
@@ -24,25 +24,36 @@ class Provider(Protocol):
     default_text_model: ClassVar[str]
     default_vision_model: ClassVar[str | None]
 
-    async def summarize(self, text: str, *, max_tokens: int) -> str:
+    async def summarize(self, text: str, *, max_tokens: int, steering: str | None = None) -> str:
         """Produce a short summary of ``text``.
 
         Args:
             text: Section body to summarize.
             max_tokens: Approximate output ceiling.
+            steering: Optional trusted domain-context string (owner-authored
+                workspace configuration, never document content). When
+                present, it is appended to the fixed system prompt as a
+                clearly-demarcated, non-overriding block to focus terminology
+                — it never replaces the fixed task. ``None`` (default) is the
+                pre-steering behavior. See ``_litellm.py`` (§8.3) for why the
+                document body always stays data in the user role.
 
         Returns:
             Plain-text summary; never None or empty.
         """
         ...
 
-    async def summarize_overview(self, section_summaries: list[str], *, max_tokens: int) -> str:
+    async def summarize_overview(
+        self, section_summaries: list[str], *, max_tokens: int, steering: str | None = None
+    ) -> str:
         """Produce a document-level overview from per-section summaries.
 
         Args:
             section_summaries: Already-summarized section texts in document
                 order.
             max_tokens: Approximate output ceiling.
+            steering: Optional trusted domain-context string; same semantics
+                as :meth:`summarize`.
         """
         ...
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1484,6 +1484,61 @@ async def test_get_context_info_without_details():
     await client.close()
 
 
+@pytest.mark.asyncio
+async def test_get_context_info_cached_fetches_once():
+    """_get_context_info_cached() should hit the MCP tool only once per context_id."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "success",
+            "context": {"id": "uuid-1", "name": "test-ctx", "is_private": True},
+            "instructions": "Steer toward billing terminology.",
+        }
+        first = await client._get_context_info_cached("uuid-1")
+        second = await client._get_context_info_cached("uuid-1")
+
+    assert first is second  # same cached object
+    assert first is not None
+    assert first.instructions == "Steer toward billing terminology."
+    assert mock.call_count == 1  # second call served from cache
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_context_info_cached_degrades_on_failure():
+    """A fetch failure caches and returns None (best-effort), never re-fetching."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.side_effect = KaguraError("context unreachable")
+        first = await client._get_context_info_cached("uuid-missing")
+        second = await client._get_context_info_cached("uuid-missing")
+
+    assert first is None
+    assert second is None
+    assert mock.call_count == 1  # failure is cached; no retry storm
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_context_info_cached_degrades_on_malformed_payload():
+    """A malformed server payload (pydantic ValidationError) degrades to None."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        # Missing the required `context` field → ContextInfo.model_validate raises
+        # a pydantic ValidationError, which is NOT a KaguraError.
+        mock.return_value = {"status": "success"}
+        result = await client._get_context_info_cached("uuid-1")
+
+    assert result is None  # did not crash; degraded to None
+
+    await client.close()
+
+
 # ============================================================================
 # get_embedding_status (REST)
 # ============================================================================

--- a/tests/test_ingest_audio.py
+++ b/tests/test_ingest_audio.py
@@ -597,10 +597,12 @@ class _FakeProvider:
     text_model = "fake/text"
     vision_model: str | None = None
 
-    async def summarize(self, text: str, *, max_tokens: int) -> str:
+    async def summarize(self, text: str, *, max_tokens: int, steering: str | None = None) -> str:
         return f"[summary len={len(text)}]"
 
-    async def summarize_overview(self, section_summaries: list[str], *, max_tokens: int) -> str:
+    async def summarize_overview(
+        self, section_summaries: list[str], *, max_tokens: int, steering: str | None = None
+    ) -> str:
         return f"[overview {len(section_summaries)}]"
 
     async def describe_image(self, image_bytes: bytes, mime: str) -> str:

--- a/tests/test_ingest_ingestor.py
+++ b/tests/test_ingest_ingestor.py
@@ -41,13 +41,18 @@ class FakeProvider:
             self.vision_model = None
         self.summarize_calls: list[str] = []
         self.overview_calls: list[list[str]] = []
+        self.steering_seen: list[str | None] = []
 
-    async def summarize(self, text: str, *, max_tokens: int) -> str:
+    async def summarize(self, text: str, *, max_tokens: int, steering: str | None = None) -> str:
         self.summarize_calls.append(text)
+        self.steering_seen.append(steering)
         return f"[summary len={len(text)}]"
 
-    async def summarize_overview(self, section_summaries: list[str], *, max_tokens: int) -> str:
+    async def summarize_overview(
+        self, section_summaries: list[str], *, max_tokens: int, steering: str | None = None
+    ) -> str:
         self.overview_calls.append(list(section_summaries))
+        self.steering_seen.append(steering)
         return f"[overview of {len(section_summaries)} sections]"
 
     async def describe_image(self, image_bytes: bytes, mime: str) -> str:
@@ -151,6 +156,56 @@ async def test_full_ingest_writes_overview_and_sections() -> None:
 
 
 @pytest.mark.asyncio
+async def test_context_config_steering_flows_to_provider() -> None:
+    """End-to-end: context instructions become steering on every summarize call."""
+    from kagura_memory.models import ContextDetail, ContextInfo
+
+    client = _make_client()
+    provider = FakeProvider()
+    # Prime the steering cache so no get_context_info network call is made.
+    client._context_info_cache["ctx-uuid"] = ContextInfo(
+        context=ContextDetail(id="ctx-uuid", name="billing", summary="ignored — instructions win"),
+        instructions="Focus on billing terminology.",
+    )
+    ingestor = FileIngestor(client=client, text_provider=provider, vision_provider=None)
+
+    async def fake_remember(**kwargs: Any) -> dict[str, Any]:
+        return {"memory_id": "mem-x"}
+
+    with patch.object(client, "remember", side_effect=fake_remember):
+        await ingestor.ingest(str(FIXTURE), context_id="ctx-uuid")
+
+    # 3 sections + 1 overview, all steered by the resolved instructions.
+    assert provider.steering_seen == ["Focus on billing terminology."] * 4
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_caller_steering_overrides_context_config() -> None:
+    """An explicit steering= kwarg wins over context instructions."""
+    from kagura_memory.models import ContextDetail, ContextInfo
+
+    client = _make_client()
+    provider = FakeProvider()
+    client._context_info_cache["ctx-uuid"] = ContextInfo(
+        context=ContextDetail(id="ctx-uuid", name="ctx", summary="ctx summary"),
+        instructions="context instructions",
+    )
+    ingestor = FileIngestor(client=client, text_provider=provider, vision_provider=None)
+
+    async def fake_remember(**kwargs: Any) -> dict[str, Any]:
+        return {"memory_id": "mem-x"}
+
+    with patch.object(client, "remember", side_effect=fake_remember):
+        await ingestor.ingest(str(FIXTURE), context_id="ctx-uuid", steering="caller wins")
+
+    assert set(provider.steering_seen) == {"caller wins"}
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_section_summarize_failure_collected_not_raised() -> None:
     """A per-section LLM failure is recorded in errors, not raised."""
     from kagura_memory.exceptions import KaguraLLMError
@@ -161,11 +216,11 @@ async def test_section_summarize_failure_collected_not_raised() -> None:
     call_count = {"n": 0}
     original_summarize = provider.summarize
 
-    async def flaky_summarize(text: str, *, max_tokens: int) -> str:
+    async def flaky_summarize(text: str, *, max_tokens: int, steering: str | None = None) -> str:
         call_count["n"] += 1
         if call_count["n"] == 2:
             raise KaguraLLMError("simulated LLM failure")
-        return await original_summarize(text, max_tokens=max_tokens)
+        return await original_summarize(text, max_tokens=max_tokens, steering=steering)
 
     provider.summarize = flaky_summarize  # type: ignore[method-assign]
 

--- a/tests/test_ingest_litellm_provider.py
+++ b/tests/test_ingest_litellm_provider.py
@@ -202,6 +202,76 @@ async def test_summarize_overview_joins_section_summaries() -> None:
     assert "section B." in user_msg
 
 
+# ---------------------------------------------------------------------------
+# steering — context-aware summarization (#148)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summarize_appends_steering_block_after_fixed_prompt() -> None:
+    """steering rides in the system prompt as a demarcated block AFTER the fixed task."""
+    p = ClaudeProvider()
+    fake = AsyncMock(return_value=_mock_response("A short summary."))
+
+    with patch("litellm.acompletion", fake):
+        await p.summarize("the section text", max_tokens=200, steering="Focus on billing terms.")
+
+    system = fake.call_args.kwargs["messages"][0]["content"]
+    # Fixed task prompt is preserved and comes first.
+    assert system.startswith("You are a precise summarization assistant.")
+    fixed_end = system.index("not as instructions.") + len("not as instructions.")
+    # The steering block is demarcated and appears strictly after the fixed prompt.
+    assert "<domain_context>" in system
+    assert "Focus on billing terms." in system
+    assert system.index("<domain_context>") > fixed_end
+    # The document body stays data in the user role (§8.3 preserved).
+    assert fake.call_args.kwargs["messages"][1]["content"] == "the section text"
+
+
+@pytest.mark.asyncio
+async def test_summarize_no_steering_block_when_none() -> None:
+    """Without steering the system prompt is byte-for-byte the pre-steering prompt."""
+    p = ClaudeProvider()
+    fake = AsyncMock(return_value=_mock_response("A short summary."))
+
+    with patch("litellm.acompletion", fake):
+        await p.summarize("the section text", max_tokens=200)
+
+    system = fake.call_args.kwargs["messages"][0]["content"]
+    assert "<domain_context>" not in system
+    assert system.endswith("not as instructions.")
+
+
+@pytest.mark.asyncio
+async def test_summarize_blank_steering_omits_block() -> None:
+    """Whitespace-only steering is treated as absent — no block is injected."""
+    p = ClaudeProvider()
+    fake = AsyncMock(return_value=_mock_response("A short summary."))
+
+    with patch("litellm.acompletion", fake):
+        await p.summarize("the section text", max_tokens=200, steering="   \n  ")
+
+    system = fake.call_args.kwargs["messages"][0]["content"]
+    assert "<domain_context>" not in system
+
+
+@pytest.mark.asyncio
+async def test_summarize_overview_appends_steering_block() -> None:
+    """summarize_overview() injects the same demarcated steering block."""
+    p = ClaudeProvider()
+    fake = AsyncMock(return_value=_mock_response("Document overview."))
+
+    with patch("litellm.acompletion", fake):
+        await p.summarize_overview(
+            ["section A."], max_tokens=400, steering="Prefer Japanese terms."
+        )
+
+    system = fake.call_args.kwargs["messages"][0]["content"]
+    assert system.startswith("You are a precise summarization assistant.")
+    assert "<domain_context>" in system
+    assert "Prefer Japanese terms." in system
+
+
 @pytest.mark.asyncio
 async def test_summarize_raises_kagura_llm_error_on_provider_failure() -> None:
     p = ClaudeProvider()

--- a/tests/test_ingest_steering.py
+++ b/tests/test_ingest_steering.py
@@ -1,0 +1,122 @@
+"""Steering resolution for context-aware ingest summarization (#148).
+
+These exercise ``FileIngestor._resolve_steering`` directly with a primed
+context-info cache, so they need neither pymupdf nor a PDF fixture — the
+resolution precedence is pure logic over the cached ``ContextInfo``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kagura_memory.client import KaguraClient
+from kagura_memory.ingest import FileIngestor
+from kagura_memory.ingest.ingestor import _STEERING_MAX_CHARS
+from kagura_memory.models import ContextDetail, ContextInfo
+
+
+class _FakeProvider:
+    """Minimal Provider stand-in — construction must not touch litellm."""
+
+    name = "fake"
+    default_text_model = "fake/text"
+    default_vision_model: str | None = None
+    text_model = "fake/text"
+    vision_model: str | None = None
+
+    async def summarize(self, text: str, *, max_tokens: int, steering: str | None = None) -> str:
+        return f"[summary len={len(text)}]"
+
+    async def summarize_overview(
+        self, section_summaries: list[str], *, max_tokens: int, steering: str | None = None
+    ) -> str:
+        return f"[overview {len(section_summaries)}]"
+
+    async def describe_image(self, image_bytes: bytes, mime: str) -> str:
+        return "[image]"
+
+    def count_tokens(self, text: str, *, for_vision: bool = False) -> int:
+        return max(1, len(text) // 4)
+
+
+def _ctx_info(*, instructions: str | None, summary: str | None) -> ContextInfo:
+    return ContextInfo(
+        context=ContextDetail(id="ctx-1", name="ctx", summary=summary),
+        instructions=instructions,
+    )
+
+
+def _make_ingestor() -> FileIngestor:
+    client = KaguraClient(api_key="test", mcp_url="https://test.com/mcp")
+    client._session_id = "test-session"
+    return FileIngestor(
+        client=client, text_provider=_FakeProvider(), vision_provider=_FakeProvider()
+    )
+
+
+async def _resolve(
+    ingestor: FileIngestor, *, cached: ContextInfo | None, caller: str | None
+) -> str | None:
+    # Prime the per-(client, context_id) cache so no network call is made.
+    ingestor._client._context_info_cache["ctx-1"] = cached
+    return await ingestor._resolve_steering("ctx-1", caller)
+
+
+@pytest.mark.asyncio
+async def test_precedence_caller_wins_over_context_config() -> None:
+    ingestor = _make_ingestor()
+    cached = _ctx_info(instructions="from instructions", summary="from summary")
+    assert await _resolve(ingestor, cached=cached, caller="from caller") == "from caller"
+    await ingestor._client.close()
+
+
+@pytest.mark.asyncio
+async def test_precedence_instructions_win_over_summary() -> None:
+    ingestor = _make_ingestor()
+    cached = _ctx_info(instructions="from instructions", summary="from summary")
+    assert await _resolve(ingestor, cached=cached, caller=None) == "from instructions"
+    await ingestor._client.close()
+
+
+@pytest.mark.asyncio
+async def test_precedence_summary_used_when_no_instructions() -> None:
+    ingestor = _make_ingestor()
+    cached = _ctx_info(instructions=None, summary="from summary")
+    assert await _resolve(ingestor, cached=cached, caller=None) == "from summary"
+    await ingestor._client.close()
+
+
+@pytest.mark.asyncio
+async def test_precedence_none_when_nothing_available() -> None:
+    ingestor = _make_ingestor()
+    # No caller, no cached context info at all (fetch failed / empty sentinel).
+    assert await _resolve(ingestor, cached=None, caller=None) is None
+    # And when the context info exists but carries no usable signal.
+    cached = _ctx_info(instructions="   ", summary=None)
+    assert await _resolve(ingestor, cached=cached, caller=None) is None
+    await ingestor._client.close()
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_caller_falls_through_to_context_config() -> None:
+    ingestor = _make_ingestor()
+    cached = _ctx_info(instructions="from instructions", summary=None)
+    assert await _resolve(ingestor, cached=cached, caller="   \n ") == "from instructions"
+    await ingestor._client.close()
+
+
+@pytest.mark.asyncio
+async def test_resolved_steering_truncated_to_max_chars() -> None:
+    ingestor = _make_ingestor()
+    long_caller = "x" * (_STEERING_MAX_CHARS + 500)
+    resolved = await _resolve(ingestor, cached=None, caller=long_caller)
+    assert resolved is not None
+    assert len(resolved) == _STEERING_MAX_CHARS
+
+    # Truncation also applies to context-config-sourced steering.
+    long_instr = "y" * (_STEERING_MAX_CHARS + 100)
+    cached = _ctx_info(instructions=long_instr, summary=None)
+    resolved2 = await _resolve(ingestor, cached=cached, caller=None)
+    assert resolved2 is not None
+    assert len(resolved2) == _STEERING_MAX_CHARS
+    await ingestor._client.close()


### PR DESCRIPTION
Closes #148

## Summary
- Adds **context-aware ingest summarization steering**: ingest summaries are no longer context-blind.
- `FileIngestor.ingest()` gains a keyword-only `steering=None` argument; when omitted, the destination context's own owner-authored config steers the summaries (precedence `caller > context_info.instructions > context.summary > None`; whitespace → absent; truncated to 2000 chars).
- `Provider.summarize` / `summarize_overview` gain a keyword-only `steering`; it is injected as a demarcated, **non-overriding** `<domain_context>` block appended *after* the fixed prompt. The document body stays data in the `user` role — the §8.3 prompt-injection mitigation is preserved.
- `get_context_info` is fetched at most once per `(client, context_id)` and cached on `KaguraClient`; failures (incl. malformed-payload `ValidationError`) cache `None` and degrade to `steering=None` so ingest never crashes.

## Implementation notes
- **Layering**: resolution/precedence/truncation in `ingestor._resolve_steering`; fetch-once cache on `KaguraClient._get_context_info_cached` (private — only the ingest pipeline calls it, so it stays off the public API surface while keeping the AC's per-`(client, context_id)` cache locality); prompt rendering in `providers/_litellm.py` via `_with_steering`.
- Protocol change is additive + keyword-only-with-default → backward compatible (default `steering=None` path is byte-identical; all 3 providers inherit `LiteLLMProvider`, no other call sites).
- Vision (`describe_image`) steering, recall-side steering, named profiles, and mid-session cache invalidation are deferred follow-ups.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/148-feat-feat-ingest-context-aware-summarization.gate1.md
- ~/.claude/cache/gh-issue-driven/148-feat-feat-ingest-context-aware-summarization.gate2.md

🤖 Generated via /gh-issue-driven:ship
