### PR TITLE
fix(ingest): make no-steering path non-breaking for legacy providers (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,12 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
   so steering adds no per-section round-trips; a fetch failure logs a warning
   and proceeds with `steering=None` rather than failing the ingest. Whitespace-
   only steering is treated as absent and the resolved value is truncated to
-  2000 characters. Recall-side steering, vision steering, named profiles, and
-  mid-session cache invalidation are deferred follow-ups.
+  2000 characters. The default (no-steering) path is **fully** non-breaking,
+  including for custom `Provider` implementations written against the
+  pre-steering signature: the `steering=` kwarg is omitted from the summarize
+  call entirely when no steering is resolved, so such providers never receive
+  an unexpected keyword. Recall-side steering, vision steering, named profiles,
+  and mid-session cache invalidation are deferred follow-ups.
 - **Audio/video transcription via Gemini** (#147): `ingest("talk.mp3")` (and
   `.wav` / `.m4a` / `.mp4`-with-audio) now routes the file to a Gemini
   transcription path (`gemini/gemini-2.5-flash`) that returns timestamped

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -1026,12 +1026,20 @@ class KaguraClient:
         ``(client, context_id)`` and shared across ingestors that reuse one
         client, but it is deliberately kept off the public API surface.
 
-        Fetches the context info at most once per ``context_id`` for this
-        client's lifetime, caching the result (including ``None`` on failure)
-        so repeated callers — e.g. per-section ingest summarization — never
-        re-fetch. On any error the failure is swallowed and ``None`` is cached
-        and returned: steering is purely additive and best-effort, so a
-        missing or unreachable context must never crash ingestion.
+        After the first successful (or failed) fetch the result is cached for
+        this client's lifetime — including ``None`` on failure — so repeated
+        callers (e.g. per-section ingest summarization, which is the hot path
+        this exists for) never re-fetch. On any error the failure is swallowed
+        and ``None`` is cached and returned: steering is purely additive and
+        best-effort, so a missing or unreachable context must never crash
+        ingestion.
+
+        Within a single ingest the fetch happens exactly once: the ingestor
+        resolves steering before fanning out the per-section calls. The only
+        case that can fetch more than once is two *concurrent* ingests on the
+        same client racing on the same not-yet-cached ``context_id`` (both miss
+        the cache before either stores) — that simply repeats an idempotent
+        read and converges, so no lock is used.
 
         Note: the cache is not invalidated mid-session. A concurrent
         ``update_context`` is not reflected until a fresh client is created

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -53,6 +53,21 @@ _DEFAULT_CONCURRENCY = 4
 # section + the overview call) and bounds untrusted-context-config size.
 _STEERING_MAX_CHARS = 2000
 
+
+def _steering_kwargs(steering: str | None) -> dict[str, str]:
+    """Build the ``steering=`` kwarg for a provider summarize call.
+
+    Returns ``{"steering": steering}`` only when steering is present, and an
+    empty dict otherwise. The empty-dict case means the kwarg is omitted from
+    the call entirely — so the default (no-steering) path keeps working with
+    custom :class:`~.providers.base.Provider` implementations written against
+    the pre-steering signature, which would otherwise raise ``TypeError`` on an
+    unexpected ``steering`` keyword. This is what makes ``steering=None`` truly
+    non-breaking, not just non-breaking for the bundled providers.
+    """
+    return {"steering": steering} if steering is not None else {}
+
+
 # Keys stamped by the SDK in _write_overview. Callers must not pass these in
 # details_extra — collisions are rejected with ValueError at ingest() entry.
 _OVERVIEW_RESERVED: frozenset[str] = frozenset(
@@ -624,7 +639,7 @@ class FileIngestor:
             overview_summary = await self._text.summarize_overview(
                 [s for s in section_summaries if s],
                 max_tokens=_DEFAULT_OVERVIEW_TOKENS,
-                steering=resolved_steering,
+                **_steering_kwargs(resolved_steering),
             )
         except KaguraLLMError as e:
             errors.append(
@@ -732,7 +747,7 @@ class FileIngestor:
                     summary = await self._text.summarize(
                         chunk_obj.text,
                         max_tokens=_DEFAULT_SECTION_TOKENS,
-                        steering=steering,
+                        **_steering_kwargs(steering),
                     )
                 except KaguraLLMError as e:
                     errors.append(

--- a/tests/test_ingest_ingestor.py
+++ b/tests/test_ingest_ingestor.py
@@ -205,6 +205,59 @@ async def test_caller_steering_overrides_context_config() -> None:
     await client.close()
 
 
+class LegacyProvider:
+    """A pre-steering Provider: summarize/summarize_overview have NO steering kwarg.
+
+    Mirrors a custom provider written against the signature that shipped before
+    #148. The default (no-steering) ingest path must not pass `steering=` to it.
+    """
+
+    name = "legacy"
+    default_text_model = "legacy/text"
+    default_vision_model: str | None = None
+    text_model = "legacy/text"
+    vision_model: str | None = None
+
+    async def summarize(self, text: str, *, max_tokens: int) -> str:
+        return f"[legacy summary len={len(text)}]"
+
+    async def summarize_overview(self, section_summaries: list[str], *, max_tokens: int) -> str:
+        return f"[legacy overview {len(section_summaries)}]"
+
+    async def describe_image(self, image_bytes: bytes, mime: str) -> str:
+        return "[image]"
+
+    def count_tokens(self, text: str, *, for_vision: bool = False) -> int:
+        return max(1, len(text) // 4)
+
+
+@pytest.mark.asyncio
+async def test_no_steering_path_is_nonbreaking_for_legacy_provider() -> None:
+    """Default (no-steering) ingest must not pass steering= to a legacy provider.
+
+    Regression for the back-compat gap: unconditionally forwarding steering=None
+    raises TypeError on a provider whose summarize() predates the steering kwarg.
+    """
+    client = _make_client()
+    provider = LegacyProvider()
+    # Prime the cache to None so _resolve_steering returns None without any fetch,
+    # exercising the steering-omitted call path deterministically.
+    client._context_info_cache["ctx-uuid"] = None
+    ingestor = FileIngestor(client=client, text_provider=provider, vision_provider=None)
+
+    async def fake_remember(**kwargs: Any) -> dict[str, Any]:
+        return {"memory_id": "mem-x"}
+
+    with patch.object(client, "remember", side_effect=fake_remember):
+        result = await ingestor.ingest(str(FIXTURE), context_id="ctx-uuid")
+
+    # Overview created and no summarize errors → the legacy signature was honored.
+    assert result.overview_id == "mem-x"
+    assert [e for e in result.errors if e.step == "summarize"] == []
+
+    await client.close()
+
+
 @pytest.mark.asyncio
 async def test_section_summarize_failure_collected_not_raised() -> None:
     """A per-section LLM failure is recorded in errors, not raised."""


### PR DESCRIPTION
Follow-up to #148 / PR #154 — addresses the post-merge Copilot review.

## Copilot findings and dispositions

| # | Finding | Disposition |
|---|---|---|
| 1 | `summarize_overview` receives `steering=` even when `None` → TypeError on legacy/custom providers | ✅ Fixed |
| 2 | `_summarize_sections` → `summarize` same issue | ✅ Fixed |
| 3 | `_get_context_info_cached` "fetch once" can double-fetch under concurrency | ℹ️ Docstring corrected; no lock (idempotent read) |

## Changes

- **`_steering_kwargs(steering)` helper** returns `{"steering": ...}` only when steering is resolved (non-`None`). Both summarize call sites use it, so the **default no-steering path omits the `steering=` kwarg entirely** — a custom `Provider` written against the pre-#148 signature never receives an unexpected keyword. This makes `steering=None` *fully* non-breaking (AC #148), not just non-breaking for the bundled providers.
- **Regression test**: `test_no_steering_path_is_nonbreaking_for_legacy_provider` runs a `LegacyProvider` whose `summarize()` has no `steering` kwarg through a full no-steering ingest and asserts no `summarize` errors.
- **Docstring correction** on `_get_context_info_cached`: the fetch-once guarantee holds within a single ingest (resolution precedes fan-out); only two *concurrent* ingests racing on the same uncached `context_id` can double-fetch — an idempotent read, so no lock is added (the suggested lock would be over-engineering for a benign fetch).
- CHANGELOG updated to state the no-steering path is fully non-breaking for custom providers.

## Quality
- ruff + format pass; `pyright src/` 0 errors.
- CI selector: 1006 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
