### PR TITLE
feat(mcp): kagura-mcp refresh-aware stdio proxy daemon (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
 
 ## Unreleased
 
+### Added
+
+- **`kagura-mcp` refresh-aware stdio MCP proxy** (#101, core): a new console
+  script (`kagura_memory.mcp_proxy:main`) that Claude Code spawns as a stdio
+  MCP child. It owns `~/.kagura/credentials.json` and transparently forwards
+  every JSON-RPC message to memory-cloud's HTTP `/mcp` endpoint with an
+  always-fresh OAuth bearer — fixing the silent 401 that occurs when a
+  short-lived `access_token` is baked into a static `.mcp.json` `headers`
+  block. The proxy is a thin pass-through pump (not a tool-registering server),
+  captures and replays the upstream `mcp-session-id`, and on an upstream `401`
+  forces one token refresh + retry, surfacing an actionable "run `kagura auth
+  login`" MCP error if the refresh itself fails. Point a `.mcp.json` entry at
+  it with `{"type": "stdio", "command": "kagura-mcp", "args": ["--profile",
+  "default"]}`.
+- **`KaguraOAuth.force_refresh()`**: unconditional token refresh (ignores the
+  skew window), coalesced through the same in-process lock as skew-driven
+  refreshes. Backs the proxy's 401-retry.
+- **Cross-process credentials locking**: `update_profile()` now wraps its
+  read-modify-write in a POSIX `fcntl` advisory lock (on a sibling
+  `credentials.json.lock`), so concurrent writers in different processes
+  (e.g. multiple `kagura-mcp` children) cannot lose an update. Windows is a
+  documented no-op pending a follow-up (the `msvcrt` semantics differ enough
+  to warrant separate work).
+
+Deferred to a follow-up issue (per the design review): `kagura setup claude
+--profile` writing the stdio form automatically, `kagura auth status`
+`.mcp.json` mode detection, the Windows locking shim, and the README
+"Connect to Claude Code" rewrite.
+
 ## v0.24.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ ingest-all = [
 
 [project.scripts]
 kagura = "kagura_memory.cli:main"
+kagura-mcp = "kagura_memory.mcp_proxy:main"
 
 [project.urls]
 Homepage = "https://github.com/kagura-ai/kagura-memory-python-sdk"

--- a/src/kagura_memory/_filelock.py
+++ b/src/kagura_memory/_filelock.py
@@ -1,0 +1,75 @@
+"""Cross-process advisory file locking for ``~/.kagura/credentials.json``.
+
+The in-process :class:`asyncio.Lock` in ``auth.credentials`` serializes
+credential refreshes *within* a single process. When several processes own
+the same credentials file at once — e.g. multiple ``kagura-mcp`` proxy
+children (one per Claude Code session) plus a stray ``KaguraClient`` — they
+need a *cross-process* gate so a concurrent read-modify-write cannot lose an
+update. This module provides that gate as a small advisory-lock context
+manager wrapping a lock file next to the target.
+
+POSIX only for v1 (``fcntl.flock``). On platforms without ``fcntl`` (Windows)
+the context manager degrades to a **no-op** with a one-time debug log — a
+deliberate, documented limitation tracked as a follow-up (the Windows
+``msvcrt.locking`` shim has materially different semantics — byte-range,
+mandatory, no shared/exclusive distinction — and is out of scope here). The
+no-op is safe because the atomic ``os.replace`` write in ``auth.credentials``
+already guarantees the file is never torn; the lock only adds *serialization*
+of the read-modify-write, which single-owner deployments (the common Claude
+Code case) do not require.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+logger = logging.getLogger("kagura_memory")
+
+
+def _lock_path(target: Path) -> Path:
+    """Sibling ``.lock`` file for ``target`` (never the credentials file itself).
+
+    Locking a dedicated sibling rather than the credentials file avoids
+    interfering with the atomic ``os.replace`` (which swaps the inode out from
+    under any fd holding a lock on the original file).
+    """
+    return target.with_name(target.name + ".lock")
+
+
+@contextlib.contextmanager
+def file_lock(target: Path, *, exclusive: bool = True) -> Iterator[None]:
+    """Hold a cross-process advisory lock for ``target`` for the block's body.
+
+    Args:
+        target: The file being protected (the lock is taken on a sibling
+            ``<name>.lock``, created with mode 0600).
+        exclusive: ``True`` for a write lock (``LOCK_EX``), ``False`` for a
+            shared read lock (``LOCK_SH``).
+
+    On non-POSIX platforms this is a no-op (see module docstring). The lock is
+    always released — including on exception — by the ``finally`` block.
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - exercised only on Windows
+        logger.debug("fcntl unavailable; credentials file lock is a no-op on this platform")
+        yield
+        return
+
+    lock_file = _lock_path(target)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    # O_CREAT so the lock file is created on first use; mode 0600 keeps it as
+    # private as the credentials file it guards.
+    fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)

--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -353,15 +353,23 @@ def update_profile(
 ) -> None:
     """Load, mutate one profile, and atomically save back.
 
-    The whole-file read-modify-write is intentionally simple — no file
-    locking. The in-process :class:`asyncio.Lock` held in
-    :class:`_SharedCredentialsState` serializes refreshes within a
-    single process; multi-process coordination is out of scope here.
+    The read-modify-write is serialized two ways: the in-process
+    :class:`asyncio.Lock` held in :class:`_SharedCredentialsState` coalesces
+    refreshes within a single process, and a cross-process advisory
+    :func:`kagura_memory._filelock.file_lock` (POSIX ``fcntl``; a no-op on
+    Windows pending a follow-up) wraps the load→set→save so concurrent writers
+    in *different* processes — e.g. multiple ``kagura-mcp`` proxy children —
+    cannot lose an update. The lock is on a sibling ``credentials.json.lock``,
+    not the file itself, so it never races the atomic ``os.replace`` in
+    :func:`save_credentials_file`.
     """
+    from .._filelock import file_lock
+
     path = _resolve_path(path)
-    cf = load_credentials_file(path)
-    cf.set_profile(profile_name, creds)
-    save_credentials_file(cf, path)
+    with file_lock(path, exclusive=True):
+        cf = load_credentials_file(path)
+        cf.set_profile(profile_name, creds)
+        save_credentials_file(cf, path)
 
 
 def delete_profile(
@@ -516,28 +524,44 @@ class KaguraOAuth(httpx.Auth):
         async with self._state.lock:
             if not self._state.credentials.is_expired(skew_seconds=REFRESH_SKEW_SEC):
                 return
+            await self._refresh_locked()
 
-            # Lazy import: ``device_flow`` may depend on this module's
-            # public types, so resolve only at refresh time to avoid a
-            # cycle at import time.
-            from .device_flow import make_oauth_client, refresh_access_token
+    async def force_refresh(self) -> None:
+        """Unconditionally refresh the access_token, ignoring the skew window.
 
-            async with make_oauth_client() as client:
-                token = await refresh_access_token(
-                    client,
-                    server=self._state.credentials.server,
-                    client_id=self._state.credentials.client_id,
-                    refresh_token=self._state.credentials.refresh_token,
-                )
-            # Pass ``None`` when the server omits ``refresh_token`` so the
-            # stored token is preserved. ``TokenResponse.refresh_token``
-            # defaults to ``""`` when absent, and passing the empty string
-            # to ``with_refreshed`` would overwrite a valid stored token
-            # with an empty one — breaking every subsequent refresh.
-            self._state.credentials = self._state.credentials.with_refreshed(
-                access_token=token.access_token,
-                refresh_token=token.refresh_token or None,
-                expires_at=token.expires_at,
-                scope=token.scope,
+        Used by the ``kagura-mcp`` proxy on an upstream ``401``: the token was
+        rejected server-side (rotated / revoked out-of-band) even though it is
+        not yet within the skew window, so :meth:`_maybe_refresh` would no-op.
+        The same lock serializes this with skew-driven refreshes, so a 401 on
+        one in-flight request and a skew refresh on another coalesce to a
+        single ``/oauth2/token`` call.
+        """
+        async with self._state.lock:
+            await self._refresh_locked()
+
+    async def _refresh_locked(self) -> None:
+        """Perform the ``/oauth2/token`` refresh and persist. Caller holds the lock."""
+        # Lazy import: ``device_flow`` may depend on this module's
+        # public types, so resolve only at refresh time to avoid a
+        # cycle at import time.
+        from .device_flow import make_oauth_client, refresh_access_token
+
+        async with make_oauth_client() as client:
+            token = await refresh_access_token(
+                client,
+                server=self._state.credentials.server,
+                client_id=self._state.credentials.client_id,
+                refresh_token=self._state.credentials.refresh_token,
             )
-            update_profile(self._state.profile_name, self._state.credentials, self._state.path)
+        # Pass ``None`` when the server omits ``refresh_token`` so the
+        # stored token is preserved. ``TokenResponse.refresh_token``
+        # defaults to ``""`` when absent, and passing the empty string
+        # to ``with_refreshed`` would overwrite a valid stored token
+        # with an empty one — breaking every subsequent refresh.
+        self._state.credentials = self._state.credentials.with_refreshed(
+            access_token=token.access_token,
+            refresh_token=token.refresh_token or None,
+            expires_at=token.expires_at,
+            scope=token.scope,
+        )
+        update_profile(self._state.profile_name, self._state.credentials, self._state.path)

--- a/src/kagura_memory/mcp_proxy.py
+++ b/src/kagura_memory/mcp_proxy.py
@@ -1,0 +1,210 @@
+"""``kagura-mcp`` — refresh-aware stdio MCP proxy for Claude Code.
+
+Claude Code's MCP client reads ``.mcp.json`` once at startup and replays the
+configured ``Authorization`` header forever — it never refreshes. Baking a
+short-lived OAuth ``access_token`` into ``.mcp.json`` therefore 401s silently
+after ``expires_at``. This module is the fix: a stdio-mode MCP server that
+Claude Code spawns as a child process, which owns ``~/.kagura/credentials.json``
+and forwards every MCP request to memory-cloud's HTTP ``/mcp`` endpoint with an
+always-fresh bearer token.
+
+Design (see issue #101, gate1 review):
+
+- **Transparent JSON-RPC bridge, not a tool-registering server.** Claude Code
+  speaks newline-delimited JSON-RPC on stdin/stdout; we forward each message
+  verbatim to the upstream HTTP endpoint and write the upstream response back.
+  This is a thin pump rather than the ``mcp`` SDK's tool-registration server
+  API, which keeps ``tools/list`` / ``tools/call`` / future methods working
+  without enumerating them here.
+- **Auth via the existing :class:`KaguraOAuth`** httpx.Auth — it injects a
+  fresh token per request and refreshes within the skew window through the
+  shared in-process lock. On an upstream ``401`` (token rotated/revoked
+  out-of-band, outside the skew window) we force one refresh + retry; if the
+  refresh itself fails we return an actionable MCP error pointing at
+  ``kagura auth login``.
+- **mcp_url comes from the profile** (or ``--server``) explicitly — never via
+  ``KaguraClient`` env resolution, which ignores ``KAGURA_MCP_URL`` and would
+  silently fall back to the hardcoded cloud URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+
+from ._http import SDK_VERSION, validate_https_url
+from .auth.credentials import KaguraOAuth, get_shared_state
+
+_PROXY_TIMEOUT_SEC = 60.0
+_JSONRPC_INTERNAL_ERROR = -32000
+
+
+class _Upstream:
+    """Forwards JSON-RPC messages to an HTTP MCP endpoint with fresh bearers.
+
+    Owns the upstream ``mcp-session-id`` lifecycle: the value returned by the
+    ``initialize`` response header is captured and replayed on every
+    subsequent request, mirroring :class:`KaguraClient`'s transport.
+    """
+
+    def __init__(self, http: httpx.AsyncClient, mcp_url: str, oauth: KaguraOAuth) -> None:
+        self._http = http
+        self._mcp_url = mcp_url
+        self._oauth = oauth
+        self._session_id: str | None = None
+
+    async def forward(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        """Forward one JSON-RPC message; return the response dict, or ``None``.
+
+        ``None`` means "no response body to write back" — a JSON-RPC
+        notification (no ``id``) the upstream acknowledged with ``202`` /
+        an empty body. The caller must not emit anything in that case.
+        """
+        resp = await self._post_with_retry(message)
+        session_id = resp.headers.get("mcp-session-id")
+        if session_id:
+            self._session_id = session_id
+        resp.raise_for_status()
+        if resp.status_code == 202 or not resp.content:
+            return None
+        return resp.json()
+
+    async def _post_with_retry(self, message: dict[str, Any]) -> httpx.Response:
+        """POST once; on ``401`` force a token refresh and retry exactly once."""
+        headers = {"mcp-session-id": self._session_id} if self._session_id else {}
+        resp = await self._http.post(self._mcp_url, json=message, headers=headers)
+        if resp.status_code == 401:
+            # The per-request KaguraOAuth refresh only fires inside the skew
+            # window; a 401 here means the token was rejected anyway, so force
+            # a refresh and retry the single request.
+            await self._oauth.force_refresh()
+            resp = await self._http.post(self._mcp_url, json=message, headers=headers)
+        return resp
+
+
+def _error_response(message: dict[str, Any], exc: Exception) -> dict[str, Any] | None:
+    """Build a JSON-RPC error response for ``message``, or ``None`` if it had no id.
+
+    A notification (no ``id``) gets no response even on failure — replying
+    would violate JSON-RPC. The error text is made actionable for the common
+    refresh-failure case so Claude Code surfaces the re-login hint to the user.
+    """
+    msg_id = message.get("id")
+    if msg_id is None:
+        return None
+    detail = str(exc)
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 401:
+        detail = (
+            "Kagura authentication failed and the token could not be refreshed. "
+            "Run `kagura auth login` to re-authenticate."
+        )
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": _JSONRPC_INTERNAL_ERROR, "message": f"kagura-mcp: {detail}"},
+    }
+
+
+async def serve(
+    upstream: _Upstream,
+    read_line: Callable[[], Awaitable[str]],
+    write_line: Callable[[str], None],
+) -> None:
+    """Run the stdio bridge loop until EOF.
+
+    ``read_line`` returns the next newline-terminated line (``""`` at EOF);
+    ``write_line`` emits one serialized JSON-RPC response. Both are injected so
+    tests can drive the loop with in-memory streams instead of real stdio.
+    """
+    while True:
+        line = await read_line()
+        if line == "":  # EOF
+            return
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            message = json.loads(stripped)
+        except json.JSONDecodeError:
+            # Unparseable input has no id to correlate an error to — drop it.
+            continue
+        try:
+            response = await upstream.forward(message)
+        except Exception as exc:  # noqa: BLE001 - bridge must never crash the loop
+            response = _error_response(message, exc)
+        if response is not None:
+            write_line(json.dumps(response))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kagura-mcp",
+        description="Refresh-aware stdio MCP proxy for Claude Code (Kagura Memory).",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        help="OAuth profile in ~/.kagura/credentials.json (default: the file's default_profile).",
+    )
+    parser.add_argument(
+        "--server",
+        default=None,
+        help="Override the upstream MCP URL (default: the profile's mcp_url).",
+    )
+    return parser
+
+
+async def _amain(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    state = get_shared_state(profile=args.profile)
+    if state is None:
+        which = f" --profile {args.profile}" if args.profile else ""
+        print(
+            f"kagura-mcp: no OAuth profile found in ~/.kagura/credentials.json.\n"
+            f"  Run: kagura auth login{which}",
+            file=sys.stderr,
+        )
+        return 1
+
+    mcp_url = args.server or state.credentials.mcp_url
+    # Enforce HTTPS (localhost allowed for dev), matching KaguraClient.
+    validate_https_url(mcp_url, label="MCP URL")
+
+    oauth = KaguraOAuth(state)
+    async with httpx.AsyncClient(
+        timeout=_PROXY_TIMEOUT_SEC,
+        auth=oauth,
+        headers={"User-Agent": f"kagura-mcp/{SDK_VERSION}"},
+    ) as http:
+        upstream = _Upstream(http, mcp_url, oauth)
+
+        async def read_line() -> str:
+            # Run the blocking stdin read off the event loop so concurrent
+            # refresh round-trips are not starved.
+            return await asyncio.to_thread(sys.stdin.readline)
+
+        def write_line(text: str) -> None:
+            sys.stdout.write(text + "\n")
+            sys.stdout.flush()
+
+        await serve(upstream, read_line, write_line)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console-script entry point for ``kagura-mcp``."""
+    try:
+        return asyncio.run(_amain(argv))
+    except KeyboardInterrupt:  # pragma: no cover - interactive interrupt
+        return 130
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_auth_credentials.py
+++ b/tests/test_auth_credentials.py
@@ -506,3 +506,60 @@ class _AsyncContextStub:
 
     async def __aexit__(self, *_):
         return None
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_refreshes_even_when_not_expired(tmp_path: Path):
+    """force_refresh() rotates the token regardless of the skew window (kagura-mcp 401 path)."""
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    # Token is far from expiry → _maybe_refresh would no-op, force_refresh must not.
+    creds = _sample_creds(access_token="old", expires_at=datetime.now(UTC) + timedelta(hours=1))
+    cf = CredentialsFile()
+    cf.set_profile("default", creds)
+    save_credentials_file(cf, path)
+
+    state = get_shared_state(path)
+    auth = KaguraOAuth(state)
+
+    refreshed = TokenResponse(
+        access_token="forced-new",
+        refresh_token="new-rtok",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope="memory:read",
+    )
+    with (
+        patch(
+            "kagura_memory.auth.device_flow.refresh_access_token",
+            new=AsyncMock(return_value=refreshed),
+        ),
+        patch(
+            "kagura_memory.auth.device_flow.make_oauth_client",
+            return_value=_AsyncContextStub(),
+        ),
+    ):
+        await auth.force_refresh()
+
+    assert state.credentials.access_token == "forced-new"
+    assert load_credentials_file(path).get_profile().access_token == "forced-new"
+
+
+def test_update_profile_is_file_lock_guarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """update_profile wraps its read-modify-write in the cross-process file lock."""
+    import kagura_memory._filelock as fl
+
+    calls: list[bool] = []
+    real_file_lock = fl.file_lock
+
+    def spy_file_lock(target: Path, *, exclusive: bool = True):
+        calls.append(exclusive)
+        return real_file_lock(target, exclusive=exclusive)
+
+    monkeypatch.setattr(fl, "file_lock", spy_file_lock)
+
+    path = tmp_path / "creds.json"
+    update_profile("default", _sample_creds(access_token="locked-write"), path)
+
+    assert calls == [True]  # acquired exactly once, exclusively
+    assert load_credentials_file(path).get_profile().access_token == "locked-write"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,0 +1,77 @@
+"""Tests for kagura_memory._filelock (cross-process advisory credentials lock)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from kagura_memory._filelock import _lock_path, file_lock
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX fcntl lock; Windows is a no-op"
+)
+
+
+def test_lock_path_is_sibling_not_target():
+    """The lock is taken on <name>.lock, never the credentials file itself."""
+    target = Path("/home/u/.kagura/credentials.json")
+    assert _lock_path(target) == Path("/home/u/.kagura/credentials.json.lock")
+
+
+@_POSIX_ONLY
+def test_file_lock_creates_lock_file_and_yields(tmp_path: Path):
+    target = tmp_path / "credentials.json"
+    with file_lock(target, exclusive=True):
+        # The sibling lock file exists while the lock is held.
+        assert (tmp_path / "credentials.json.lock").exists()
+
+
+@_POSIX_ONLY
+def test_file_lock_sequential_acquire_release(tmp_path: Path):
+    """Re-acquiring after release must not deadlock (lock is released on exit)."""
+    target = tmp_path / "credentials.json"
+    for _ in range(3):
+        with file_lock(target, exclusive=True):
+            pass
+    with file_lock(target, exclusive=False):  # shared also acquirable afterwards
+        pass
+
+
+@_POSIX_ONLY
+def test_file_lock_released_on_exception(tmp_path: Path):
+    """An exception inside the block still releases the lock (finally)."""
+    target = tmp_path / "credentials.json"
+    with pytest.raises(ValueError, match="boom"):
+        with file_lock(target, exclusive=True):
+            raise ValueError("boom")
+    # If the lock leaked, this second acquire would hang; it returns promptly.
+    with file_lock(target, exclusive=True):
+        pass
+
+
+@_POSIX_ONLY
+def test_file_lock_creates_parent_dir(tmp_path: Path):
+    target = tmp_path / "nested" / "credentials.json"
+    with file_lock(target, exclusive=True):
+        assert target.parent.is_dir()
+
+
+def test_file_lock_noop_when_fcntl_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """On a platform without fcntl the CM degrades to a no-op (no lock file)."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "fcntl":
+            raise ImportError("simulated no fcntl (Windows)")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    target = tmp_path / "credentials.json"
+    with file_lock(target, exclusive=True):
+        pass
+    # No-op path must not have created a lock file.
+    assert not (tmp_path / "credentials.json.lock").exists()

--- a/tests/test_mcp_proxy.py
+++ b/tests/test_mcp_proxy.py
@@ -203,3 +203,94 @@ async def test_amain_exits_1_when_no_profile(monkeypatch: pytest.MonkeyPatch, ca
     err = capsys.readouterr().err
     assert "kagura auth login" in err
     assert "--profile default" in err
+
+
+def _build_state(tmp_path):
+    """A real _SharedCredentialsState backed by a tmp credentials file."""
+    from datetime import UTC, datetime, timedelta
+
+    from kagura_memory.auth.credentials import (
+        CredentialsFile,
+        OAuthCredentials,
+        get_shared_state,
+        reset_state_cache,
+        save_credentials_file,
+    )
+
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    creds = OAuthCredentials(
+        server="https://test.example.com",
+        mcp_url="https://test.example.com/mcp",
+        client_id="kagura-cli",
+        access_token="atok",
+        refresh_token="rtok",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope="memory:read",
+        workspace_id="ws-1",
+        workspace_name="ws",
+        user_email="u@example.com",
+        issued_at=datetime.now(UTC),
+    )
+    cf = CredentialsFile()
+    cf.set_profile("default", creds)
+    save_credentials_file(cf, path)
+    return get_shared_state(path)
+
+
+@pytest.mark.asyncio
+async def test_amain_happy_path_runs_serve_until_eof(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """_amain wires a real httpx client + serve loop; immediate stdin EOF → clean exit 0."""
+    import io
+
+    state = _build_state(tmp_path)
+    monkeypatch.setattr(mcp_proxy, "get_shared_state", lambda profile=None: state)
+    # Empty stdin → readline() returns "" → serve() exits immediately, no upstream call.
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    rc = await mcp_proxy._amain([])
+    assert rc == 0
+
+
+def test_main_returns_amain_exit_code(monkeypatch: pytest.MonkeyPatch):
+    """main() drives asyncio.run(_amain(...)) and returns its exit code."""
+    monkeypatch.setattr(mcp_proxy, "get_shared_state", lambda profile=None: None)
+    assert mcp_proxy.main(["--profile", "x"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_amain_forwards_one_request_and_writes_response(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    """End-to-end: _amain reads one stdin line, forwards via the real client, writes the reply."""
+    import io
+
+    state = _build_state(tmp_path)
+    monkeypatch.setattr(mcp_proxy, "get_shared_state", lambda profile=None: state)
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}\n'),
+    )
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": 1, "result": {"tools": []}},
+            headers={"mcp-session-id": "s1"},
+        )
+
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(**kwargs: Any) -> httpx.AsyncClient:
+        # Inject a MockTransport so no real network call is made; the real
+        # KaguraOAuth auth flow still runs (token is fresh, so it no-ops).
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(**kwargs)
+
+    monkeypatch.setattr(mcp_proxy.httpx, "AsyncClient", fake_async_client)
+
+    rc = await mcp_proxy._amain([])
+    assert rc == 0
+    assert json.loads(out.getvalue().strip())["result"] == {"tools": []}

--- a/tests/test_mcp_proxy.py
+++ b/tests/test_mcp_proxy.py
@@ -1,0 +1,205 @@
+"""Tests for kagura_memory.mcp_proxy (the kagura-mcp stdio MCP proxy)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from kagura_memory import mcp_proxy
+from kagura_memory.mcp_proxy import _error_response, _Upstream, serve
+
+
+class _FakeOAuth:
+    """Stand-in for KaguraOAuth: records force_refresh calls."""
+
+    def __init__(self) -> None:
+        self.force_calls = 0
+
+    async def force_refresh(self) -> None:
+        self.force_calls += 1
+
+
+def _upstream(handler: Any, oauth: _FakeOAuth | None = None) -> tuple[_Upstream, _FakeOAuth]:
+    oauth = oauth or _FakeOAuth()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    return _Upstream(client, "https://test.example.com/mcp", oauth), oauth  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _Upstream.forward
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forward_returns_response_and_captures_session_id():
+    seen_headers: list[dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(dict(request.headers))
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": 1, "result": {"tools": []}},
+            headers={"mcp-session-id": "sess-1"},
+        )
+
+    up, _ = _upstream(handler)
+    result = await up.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}})
+    assert result == {"jsonrpc": "2.0", "id": 1, "result": {"tools": []}}
+
+    # Session id captured, then replayed on the next request.
+    second = await up.forward({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    assert second is not None
+    assert "mcp-session-id" not in seen_headers[0]  # first request had none yet
+    assert seen_headers[1]["mcp-session-id"] == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_forward_401_forces_refresh_and_retries_once():
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(401, json={"error": "expired"})
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": "ok"})
+
+    up, oauth = _upstream(handler)
+    result = await up.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}})
+    assert result == {"jsonrpc": "2.0", "id": 1, "result": "ok"}
+    assert oauth.force_calls == 1  # refreshed exactly once
+    assert calls["n"] == 2  # one retry
+
+
+@pytest.mark.asyncio
+async def test_forward_persistent_401_raises_after_single_retry():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "invalid_grant"})
+
+    up, oauth = _upstream(handler)
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        await up.forward({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}})
+    assert exc_info.value.response.status_code == 401
+    assert oauth.force_calls == 1  # forced refresh once, did not loop
+
+
+@pytest.mark.asyncio
+async def test_forward_notification_returns_none():
+    """A 202/empty-body upstream ack (notification) yields no response to write."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202)
+
+    up, _ = _upstream(handler)
+    result = await up.forward({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _error_response
+# ---------------------------------------------------------------------------
+
+
+def test_error_response_with_id_builds_jsonrpc_error():
+    resp = _error_response({"jsonrpc": "2.0", "id": 7, "method": "x"}, RuntimeError("nope"))
+    assert resp is not None
+    assert resp["id"] == 7
+    assert resp["error"]["code"] == -32000
+    assert "nope" in resp["error"]["message"]
+
+
+def test_error_response_without_id_returns_none():
+    """Notifications (no id) get no error reply — replying would break JSON-RPC."""
+    assert _error_response({"jsonrpc": "2.0", "method": "notify"}, RuntimeError("x")) is None
+
+
+def test_error_response_401_is_actionable():
+    req = httpx.Request("POST", "https://test/mcp")
+    exc = httpx.HTTPStatusError("401", request=req, response=httpx.Response(401, request=req))
+    resp = _error_response({"jsonrpc": "2.0", "id": 1}, exc)
+    assert resp is not None
+    assert "kagura auth login" in resp["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# serve loop
+# ---------------------------------------------------------------------------
+
+
+class _FakeUpstream:
+    def __init__(self, responder: Any) -> None:
+        self._responder = responder
+
+    async def forward(self, message: dict[str, Any]) -> dict[str, Any] | None:
+        return self._responder(message)
+
+
+def _line_reader(lines: list[str]):
+    queue = list(lines)
+
+    async def read_line() -> str:
+        return queue.pop(0) if queue else ""
+
+    return read_line
+
+
+@pytest.mark.asyncio
+async def test_serve_forwards_and_writes_response():
+    written: list[str] = []
+    up = _FakeUpstream(lambda m: {"jsonrpc": "2.0", "id": m["id"], "result": "ok"})
+    reader = _line_reader(['{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}\n'])
+    await serve(up, reader, written.append)  # type: ignore[arg-type]
+    assert len(written) == 1
+    assert json.loads(written[0]) == {"jsonrpc": "2.0", "id": 1, "result": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_serve_skips_blank_and_unparseable_lines():
+    written: list[str] = []
+    up = _FakeUpstream(lambda m: {"jsonrpc": "2.0", "id": m["id"], "result": "ok"})
+    reader = _line_reader(["\n", "not json\n", '{"jsonrpc":"2.0","id":5,"method":"x"}\n'])
+    await serve(up, reader, written.append)  # type: ignore[arg-type]
+    assert len(written) == 1
+    assert json.loads(written[0])["id"] == 5
+
+
+@pytest.mark.asyncio
+async def test_serve_writes_nothing_for_notification_response():
+    written: list[str] = []
+    up = _FakeUpstream(lambda m: None)  # forward returns None (notification)
+    reader = _line_reader(['{"jsonrpc":"2.0","method":"notifications/initialized"}\n'])
+    await serve(up, reader, written.append)  # type: ignore[arg-type]
+    assert written == []
+
+
+@pytest.mark.asyncio
+async def test_serve_forward_exception_becomes_error_response():
+    written: list[str] = []
+
+    def boom(_message: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("upstream down")
+
+    up = _FakeUpstream(boom)
+    reader = _line_reader(['{"jsonrpc":"2.0","id":9,"method":"tools/call"}\n'])
+    await serve(up, reader, written.append)  # type: ignore[arg-type]
+    assert len(written) == 1
+    err = json.loads(written[0])
+    assert err["id"] == 9
+    assert "upstream down" in err["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# _amain — startup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_amain_exits_1_when_no_profile(monkeypatch: pytest.MonkeyPatch, capsys):
+    monkeypatch.setattr(mcp_proxy, "get_shared_state", lambda profile=None: None)
+    rc = await mcp_proxy._amain(["--profile", "default"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "kagura auth login" in err
+    assert "--profile default" in err


### PR DESCRIPTION
Closes #101 (core; see "Deferred" below for the follow-up split)

## Summary
- Adds **`kagura-mcp`** — a refresh-aware stdio MCP proxy that Claude Code spawns as a child process. It owns `~/.kagura/credentials.json` and transparently forwards JSON-RPC to memory-cloud's HTTP `/mcp` endpoint with an always-fresh OAuth bearer, fixing the silent 401 that occurs when a short-lived `access_token` is baked into a static `.mcp.json` `headers` block.
- The proxy is a **thin pass-through pump** (not a tool-registering server): it forwards each message verbatim, captures/replays the upstream `mcp-session-id`, and on an upstream `401` forces one refresh + retry — returning an actionable "run `kagura auth login`" MCP error if the refresh itself fails.
- `mcp_url` is resolved **explicitly from the profile** (or `--server`), never via `KaguraClient` env resolution (which ignores `KAGURA_MCP_URL` and falls back to the hardcoded cloud URL).

## Implementation notes
- `src/kagura_memory/mcp_proxy.py` — the bridge. `serve()` is injected with a line-reader and write-callback so the loop is unit-tested with in-memory streams; `main()` wires real stdio via `asyncio.to_thread(sys.stdin.readline)`.
- `KaguraOAuth.force_refresh()` — unconditional refresh (ignores the skew window), coalesced through the existing in-process lock; backs the 401-retry.
- `_filelock.py` + `update_profile()` — POSIX `fcntl` advisory lock on a sibling `credentials.json.lock` so concurrent cross-process writers (multiple `kagura-mcp` children) cannot lose an update. The lock is on a sibling file, never the credentials file, so it never races the atomic `os.replace` write.
- `kagura-mcp` console entry point.

### Usage
```json
{
  "mcpServers": {
    "kagura-memory": {"type": "stdio", "command": "kagura-mcp", "args": ["--profile", "default"]}
  }
}
```

## Scope — deferred to a follow-up (per the gate1 design review)
This PR is the **POSIX-first core** (proxy + refresh plumbing + cross-process write-lock + tests). Intentionally **not** in this PR, to keep it reviewable:
- `kagura setup claude --profile` writing the stdio form automatically.
- `kagura auth status` detecting `.mcp.json` integration mode.
- The **Windows** `msvcrt` locking shim (POSIX is a no-op there for now).
- Cross-process refresh **dedup** over the network (only the credential *write* is lost-update-safe today).
- README "Connect to Claude Code" rewrite.

## Tests
- Proxy: forwarding + `mcp-session-id` replay, 401→force-refresh→retry, persistent-401, notification→no-reply, error mapping (incl. actionable 401 text), serve loop (blank/unparseable/exception), profile-missing startup exit.
- `force_refresh` rotates even when not within skew; `update_profile` is file-lock-guarded; `file_lock` primitive (sibling path, release-on-exception, no-op without fcntl).
- ruff + format clean; `pyright src/` 0 errors; CI selector **1026 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
