### PR TITLE
feat(mcp): setup-claude --profile + auth-status .mcp.json mode (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,26 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
   (e.g. multiple `kagura-mcp` children) cannot lose an update. Windows is a
   documented no-op pending a follow-up (the `msvcrt` semantics differ enough
   to warrant separate work).
+- **`kagura setup claude --profile NAME`** (#157): wires Claude Code to the
+  refresh-aware `kagura-mcp` proxy in one step. With `--profile`, `setup
+  claude` writes the stdio `.mcp.json` form
+  (`{"type": "stdio", "command": "kagura-mcp", "args": ["--profile", NAME]}`)
+  bound to an OAuth profile from `kagura auth login` — no API key, no secret in
+  the file, and the token refreshes automatically. It resolves the MCP URL and
+  auth from the profile, verifies `kagura-mcp` is on `$PATH` (a warning, never a
+  hard failure), and writes a `.kagura.json` without an `api_key`. Without
+  `--profile`, the legacy long-lived API-key url form is unchanged
+  (CI / service accounts). `--profile` and `--api-key` are mutually exclusive.
+- **`kagura auth status` reports the Claude Code integration mode** (#157):
+  when a `.mcp.json` exists in the current directory, `auth status` now reports
+  whether the `kagura-memory` entry is `refresh-aware` (the `kagura-mcp` stdio
+  proxy) or a `legacy static API-key token` (with a migration hint), so you can
+  see at a glance which path a project is on.
 
-Deferred to a follow-up issue (per the design review): `kagura setup claude
---profile` writing the stdio form automatically, `kagura auth status`
-`.mcp.json` mode detection, the Windows locking shim, and the README
-"Connect to Claude Code" rewrite.
+Deferred to a follow-up issue (the #157 PR-B set, per the design review): the
+Windows `msvcrt` locking shim behind `_filelock`, network-level refresh dedup
+(re-check-after-lock so only one proxy hits `/oauth2/token`), and a
+subprocess-based cross-process lock-contention test.
 
 ## v0.24.0
 

--- a/README.md
+++ b/README.md
@@ -294,14 +294,18 @@ Two integration paths:
 | You want… | Use |
 |---|---|
 | **CLI / `KaguraClient`** (terminal use, scripts, `KaguraAgent`) | `kagura auth login` — refresh happens automatically |
-| **Claude Code MCP** (Claude Code reads `.mcp.json`) | `kagura setup claude` with a long-lived API key from the web UI |
+| **Claude Code MCP** (Claude Code reads `.mcp.json`) | `kagura setup claude --profile <name>` — OAuth via the refresh-aware `kagura-mcp` proxy (recommended) |
+| **CI / service accounts** | `kagura setup claude` with a long-lived API key from the web UI |
 
-Claude Code's MCP client reads its config once at startup and does
-not refresh tokens — a refresh-aware MCP proxy daemon
-(`kagura-mcp`) is tracked as a follow-up so that `kagura auth login`
-can eventually power both paths from a single credentials file. For
-now, use the long-lived API key path for Claude Code and the OAuth
-path for everything else.
+Claude Code's MCP client reads its config once at startup and never
+refreshes tokens, so a short-lived OAuth `access_token` baked into
+`.mcp.json` would 401 silently after it expires. `kagura setup claude
+--profile <name>` instead points `.mcp.json` at the **`kagura-mcp`**
+stdio proxy, which owns `~/.kagura/credentials.json`, forwards every
+MCP request to the server, and injects an always-fresh bearer token —
+so the same `kagura auth login` credentials power both the CLI and
+Claude Code. Use the long-lived API-key path only for CI / service
+accounts, where a static token is preferable.
 
 Credential resolution order when `KaguraClient()` is called with no
 arguments: `KAGURA_API_KEY` env (CI / service accounts always win) →
@@ -377,11 +381,26 @@ Provider configuration (env vars, picked up automatically via `litellm`):
 
 ## Claude Code Integration
 
-Use Kagura Memory as an MCP server in Claude Code:
+Wire Kagura Memory into Claude Code as an MCP server. **Recommended: OAuth via
+the refresh-aware `kagura-mcp` proxy** — log in once, then `setup claude` writes
+the stdio `.mcp.json` form and tokens refresh automatically:
 
 ```bash
-cp .mcp.json.example .mcp.json
-# Edit .mcp.json — set workspace_id and API key
+kagura auth login --profile default        # one-time OAuth device flow
+kagura setup claude --profile default      # writes .mcp.json → kagura-mcp stdio proxy
+```
+
+This writes a `.mcp.json` that launches `kagura-mcp` as the MCP server (no secret
+in the file), plus `.claude/` hooks and `/kagura-recall` · `/kagura-remember`
+skills. Check the active mode any time with `kagura auth status` (it reports
+`refresh-aware` vs `legacy static API-key token` for the `.mcp.json` in the
+current directory).
+
+**CI / service accounts** — use a long-lived API key instead (static token, no
+refresh needed):
+
+```bash
+kagura setup claude --api-key kagura_xxx --mcp-url https://memory.kagura-ai.com/mcp
 ```
 
 Or use the CLI directly:

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -79,10 +79,11 @@ def auth():
     running 'kagura recall', 'kagura remember', and other CLI tools
     that talk to the server directly.
 
-    For Claude Code MCP integration, continue to use 'kagura setup
-    claude' with a long-lived API key from the web UI — automatic
-    refresh inside Claude Code's MCP client is tracked in a follow-up
-    (kagura-mcp proxy daemon).
+    For Claude Code MCP integration, run 'kagura setup claude --profile
+    <name>' to wire up the refresh-aware 'kagura-mcp' stdio proxy, which
+    reuses these OAuth credentials and refreshes the token automatically.
+    The long-lived API-key path ('kagura setup claude' with no --profile)
+    remains for CI / service accounts.
     """
 
 
@@ -315,8 +316,9 @@ def _print_login_success(creds: OAuthCredentials, profile: str) -> None:
     click.echo(f"  Expires: {expires_utc} (refreshable)")
     click.echo()
     click.echo(
-        "  Note: To use Kagura from Claude Code, continue to use "
-        "'kagura setup claude' with an API key from the web UI."
+        f"  Next: wire this profile into Claude Code with\n"
+        f"    kagura setup claude --profile {profile}\n"
+        "  (uses the refresh-aware kagura-mcp proxy — no more silent 401s)."
     )
 
 
@@ -359,6 +361,31 @@ def auth_status(profile: str | None) -> None:
             f"Expires: {expires.isoformat()} (EXPIRED — auto-refresh will run on next request)"
         )
     click.echo(f"Issued: {creds.issued_at.astimezone(UTC).isoformat()}")
+
+    _print_mcp_json_mode(Path.cwd())
+
+
+def _print_mcp_json_mode(project_dir: Path) -> None:
+    """Report the Claude Code ``.mcp.json`` integration mode for ``project_dir``.
+
+    Informational only — silent when there is no ``.mcp.json`` (or no
+    ``kagura-memory`` entry) so ``kagura auth status`` stays quiet outside a
+    project configured for Claude Code. Lazy import avoids pulling the setup
+    machinery (and its ``KaguraClient`` dependency) into the common auth path.
+    """
+    from ..setup_claude import MCP_PROXY_COMMAND, detect_mcp_json_mode
+
+    mode = detect_mcp_json_mode(project_dir)
+    if mode == "stdio":
+        click.echo(f"Claude Code (.mcp.json): refresh-aware ({MCP_PROXY_COMMAND} stdio proxy)")
+    elif mode == "static-token":
+        click.echo(
+            "Claude Code (.mcp.json): legacy static API-key token (no auto-refresh)\n"
+            "  Migrate to refresh-aware: kagura setup claude --profile <name>"
+        )
+    elif mode == "url":
+        click.echo("Claude Code (.mcp.json): url form (no Authorization header)")
+    # "none" / "absent" → print nothing
 
 
 # ---------------------------------------------------------------------------

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1029,17 +1029,33 @@ def setup():
 @click.option("--api-key", help="Kagura API key (skip prompt)")
 @click.option("--mcp-url", help="MCP URL (skip prompt)")
 @click.option("--context-id", help="Context ID or name (skip prompt)")
+@click.option(
+    "--profile",
+    default=None,
+    help=(
+        "OAuth profile name (from `kagura auth login`). Writes the refresh-aware "
+        "`kagura-mcp` stdio .mcp.json form instead of a static API-key url. "
+        "Mutually exclusive with --api-key."
+    ),
+)
 @click.option("--project-dir", default=".", help="Project directory (default: current)")
 @click.option("--non-interactive", "-y", is_flag=True, help="No prompts, use defaults/flags")
 @click.option("--no-auto-context", is_flag=True, help="Disable auto-select by directory name")
-def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive, no_auto_context):
+def setup_claude(
+    api_key, mcp_url, context_id, profile, project_dir, non_interactive, no_auto_context
+):
     """
     Set up Kagura Memory integration for Claude Code.
 
     Configures .kagura.json, .mcp.json, hooks, and skills in the target project.
 
+    Two auth modes:
+      - default (API key): static token baked into .mcp.json (CI / service accounts)
+      - --profile NAME (OAuth): refresh-aware `kagura-mcp` stdio proxy, no silent 401s
+
     Examples:
       kagura setup claude
+      kagura setup claude --profile default        # OAuth via kagura-mcp (recommended)
       kagura setup claude --api-key kagura_xxx --mcp-url http://localhost:8080/mcp/w/{workspace_id}
       kagura setup claude -y --api-key kagura_xxx --context-id my-project
       kagura setup claude --no-auto-context  # always show full context list
@@ -1052,6 +1068,7 @@ def setup_claude(api_key, mcp_url, context_id, project_dir, non_interactive, no_
             project_dir=project_dir,
             non_interactive=non_interactive,
             no_auto_context=no_auto_context,
+            profile=profile,
         )
     except (click.Abort, click.ClickException):
         # click.Abort fires on Ctrl+D / explicit abort during prompts — let Click

--- a/src/kagura_memory/setup_claude.py
+++ b/src/kagura_memory/setup_claude.py
@@ -13,6 +13,13 @@ from .exceptions import KaguraAuthError, KaguraConnectionError, _exc_message
 
 DEFAULT_MCP_URL = "http://localhost:8080/mcp"
 
+# Single source of truth for the `.mcp.json` server entry. Both the writers
+# (`_write_mcp_json` / `_write_mcp_json_stdio`) and the `kagura auth status`
+# mode detector (`detect_mcp_json_mode`) key off these so the form that is
+# written and the form that is detected can never drift apart.
+MCP_SERVER_NAME = "kagura-memory"
+MCP_PROXY_COMMAND = "kagura-mcp"
+
 # Trailing space distinguishes "kagura recall/remember" from "kagura-memory" in MCP config
 KAGURA_HOOK_MARKER = "kagura "
 
@@ -126,19 +133,39 @@ def _prompt_mcp_url(existing: str | None, non_interactive: bool) -> str:
     return _validate_not_empty(value, "MCP URL")
 
 
-async def _test_connection(api_key: str, mcp_url: str) -> dict[str, Any]:
+def _make_client(api_key: str | None, mcp_url: str | None, profile: str | None) -> KaguraClient:
+    """Build a KaguraClient for either the API-key or OAuth-profile path.
+
+    When ``profile`` is set, authentication and the MCP URL come from the
+    OAuth profile in ``~/.kagura/credentials.json``; ``api_key`` / ``mcp_url``
+    are ignored. Otherwise the static API-key path is used.
+    """
+    if profile is not None:
+        return KaguraClient(profile=profile)
+    return KaguraClient(api_key=api_key, mcp_url=mcp_url)
+
+
+async def _test_connection(
+    api_key: str | None = None,
+    mcp_url: str | None = None,
+    *,
+    profile: str | None = None,
+) -> dict[str, Any]:
     """Test connection and return contexts list."""
-    client = KaguraClient(api_key=api_key, mcp_url=mcp_url)
-    async with client:
+    async with _make_client(api_key, mcp_url, profile) as client:
         return await client.list_contexts()
 
 
 async def _create_context(
-    api_key: str, mcp_url: str, name: str, summary: str | None
+    api_key: str | None,
+    mcp_url: str | None,
+    name: str,
+    summary: str | None,
+    *,
+    profile: str | None = None,
 ) -> dict[str, Any]:
     """Create a new context."""
-    client = KaguraClient(api_key=api_key, mcp_url=mcp_url)
-    async with client:
+    async with _make_client(api_key, mcp_url, profile) as client:
         return await client.create_context(name=name, summary=summary)
 
 
@@ -177,14 +204,20 @@ def _auto_match_context(
 
 def _select_or_create_context(
     contexts_response: dict[str, Any],
-    api_key: str,
-    mcp_url: str,
+    api_key: str | None,
+    mcp_url: str | None,
     preselected: str | None,
     project_dir: Path,
     non_interactive: bool,
     no_auto_context: bool = False,
+    *,
+    profile: str | None = None,
 ) -> str:
-    """Select existing context or create a new one. Returns context_id."""
+    """Select existing context or create a new one. Returns context_id.
+
+    When ``profile`` is set, any context creation authenticates via the OAuth
+    profile instead of ``api_key`` / ``mcp_url``.
+    """
     contexts = contexts_response.get("contexts", [])
 
     if preselected:
@@ -200,7 +233,7 @@ def _select_or_create_context(
     default_name = project_dir.name.lower().replace(" ", "-")
 
     if non_interactive:
-        result = asyncio.run(_create_context(api_key, mcp_url, default_name, None))
+        result = asyncio.run(_create_context(api_key, mcp_url, default_name, None, profile=profile))
         ctx_id = result.get("context_id") or result.get("id", "")
         click.echo(f"  Created context: {default_name} ({ctx_id[:8]}...)")
         return ctx_id
@@ -233,7 +266,9 @@ def _select_or_create_context(
 
     name = click.prompt("Context name", default=default_name)
     summary = click.prompt("Context summary (optional)", default="", show_default=False)
-    result = asyncio.run(_create_context(api_key, mcp_url, name, summary if summary else None))
+    result = asyncio.run(
+        _create_context(api_key, mcp_url, name, summary if summary else None, profile=profile)
+    )
     ctx_id = result.get("context_id") or result.get("id", "")
     click.echo(f"  Created context: {name} ({ctx_id[:8]}...)")
     return ctx_id
@@ -251,17 +286,82 @@ def _write_kagura_config(project_dir: Path, api_key: str, mcp_url: str, context_
 
 
 def _write_mcp_json(project_dir: Path, api_key: str, mcp_url: str) -> Path:
-    """Write .mcp.json for Claude Code MCP server config, merging with existing."""
+    """Write .mcp.json for Claude Code MCP server config, merging with existing.
+
+    This is the legacy static-token form: the API key is baked into an
+    ``Authorization`` header that Claude Code reads once at startup and never
+    refreshes. Fine for long-lived API keys (CI / service accounts); for
+    short-lived OAuth tokens use :func:`_write_mcp_json_stdio` instead.
+    """
     path = project_dir / ".mcp.json"
     existing = _read_json_safe(path)
     servers = existing.setdefault("mcpServers", {})
-    servers["kagura-memory"] = {
+    servers[MCP_SERVER_NAME] = {
         "type": "url",
         "url": mcp_url,
         "headers": {"Authorization": f"Bearer {api_key}"},
     }
     _write_json(path, existing)
     return path
+
+
+def _write_mcp_json_stdio(project_dir: Path, profile: str) -> Path:
+    """Write .mcp.json pointing Claude Code at the ``kagura-mcp`` stdio proxy.
+
+    The refresh-aware proxy (issue #101) owns ``~/.kagura/credentials.json``
+    and injects an always-fresh OAuth bearer per request, so — unlike the url
+    form written by :func:`_write_mcp_json` — this entry contains **no secret**
+    and never goes stale after the access token's ``expires_at``.
+    """
+    path = project_dir / ".mcp.json"
+    existing = _read_json_safe(path)
+    servers = existing.setdefault("mcpServers", {})
+    servers[MCP_SERVER_NAME] = {
+        "type": "stdio",
+        "command": MCP_PROXY_COMMAND,
+        "args": ["--profile", profile],
+    }
+    _write_json(path, existing)
+    return path
+
+
+def detect_mcp_json_mode(project_dir: Path) -> str:
+    """Classify the ``kagura-memory`` entry in a project's ``.mcp.json``.
+
+    Returns one of:
+
+    * ``"stdio"``        — refresh-aware ``kagura-mcp`` proxy (OAuth).
+    * ``"static-token"`` — legacy url form with a baked ``Authorization`` header.
+    * ``"url"``          — url form **without** an ``Authorization`` header.
+    * ``"absent"``       — file exists (or is unreadable) but has no usable
+      ``kagura-memory`` entry.
+    * ``"none"``         — no ``.mcp.json`` in the directory.
+
+    Used by ``kagura auth status`` to report the current Claude Code
+    integration mode. Keyed off :data:`MCP_SERVER_NAME` /
+    :data:`MCP_PROXY_COMMAND` so it stays in lockstep with the writers.
+    """
+    path = project_dir / ".mcp.json"
+    if not path.exists():
+        return "none"
+    entry = (_read_json_safe(path).get("mcpServers") or {}).get(MCP_SERVER_NAME)
+    if not isinstance(entry, dict):
+        return "absent"
+    if entry.get("type") == "stdio" and entry.get("command") == MCP_PROXY_COMMAND:
+        return "stdio"
+    if entry.get("type") == "url":
+        headers = entry.get("headers")
+        if isinstance(headers, dict) and any(k.lower() == "authorization" for k in headers):
+            return "static-token"
+        return "url"
+    return "absent"
+
+
+def _kagura_mcp_on_path() -> bool:
+    """True when the ``kagura-mcp`` console script is resolvable on ``$PATH``."""
+    import shutil
+
+    return shutil.which(MCP_PROXY_COMMAND) is not None
 
 
 def _is_kagura_hook(hook: dict[str, Any]) -> bool:
@@ -352,8 +452,30 @@ def run_setup_claude(
     project_dir: str,
     non_interactive: bool,
     no_auto_context: bool = False,
+    profile: str | None = None,
 ) -> None:
-    """Run the full setup flow for Claude Code integration."""
+    """Run the full setup flow for Claude Code integration.
+
+    Two mutually exclusive auth paths:
+
+    * ``profile`` set → OAuth path: write the refresh-aware ``kagura-mcp``
+      stdio ``.mcp.json`` form bound to the named OAuth profile (no API key).
+    * ``profile`` unset → legacy API-key path: write the static-token url form.
+    """
+    if profile is not None:
+        if api_key is not None:
+            raise click.UsageError(
+                "--profile (OAuth) and --api-key (static token) are mutually exclusive; pick one."
+            )
+        _run_setup_claude_oauth(
+            profile=profile,
+            context_id=context_id,
+            project_dir=project_dir,
+            non_interactive=non_interactive,
+            no_auto_context=no_auto_context,
+        )
+        return
+
     project = Path(project_dir).resolve()
 
     # Load existing config from project dir (not cwd)
@@ -442,5 +564,136 @@ def run_setup_claude(
         "\nSetup complete! Claude Code will now:\n"
         "  - Recall relevant memories at session start\n"
         "  - Sync .claude/memory/ writes to Kagura\n"
+        "  - /kagura-recall and /kagura-remember available as skills"
+    )
+
+
+def _write_kagura_config_oauth(project_dir: Path, mcp_url: str, context_id: str) -> Path:
+    """Write .kagura.json for the OAuth path (no api_key), merging with existing.
+
+    Unlike :func:`_write_kagura_config`, this never writes an ``api_key`` — the
+    hooks and skills run ``kagura recall`` / ``kagura remember``, which resolve
+    the OAuth profile from ``~/.kagura/credentials.json`` automatically. Any
+    pre-existing ``api_key`` in the file is left untouched (the OAuth profile
+    still wins in the credential-resolution order).
+    """
+    path = project_dir / ".kagura.json"
+    existing = _read_json_safe(path)
+    existing["mcp_url"] = mcp_url
+    existing["context_id"] = context_id
+    _write_json(path, existing)
+    return path
+
+
+def _run_setup_claude_oauth(
+    *,
+    profile: str,
+    context_id: str | None,
+    project_dir: str,
+    non_interactive: bool,
+    no_auto_context: bool,
+) -> None:
+    """Setup flow for the refresh-aware ``kagura-mcp`` (OAuth) integration.
+
+    Resolves auth and the MCP URL from the named OAuth profile in
+    ``~/.kagura/credentials.json`` (created by ``kagura auth login``), then
+    writes the stdio ``.mcp.json`` form so Claude Code launches ``kagura-mcp``
+    as the MCP server with an always-fresh bearer token.
+    """
+    from .auth.credentials import load_credentials_file
+
+    project = Path(project_dir).resolve()
+
+    cf = load_credentials_file()
+    creds = cf.get_profile(profile)
+    if creds is None:
+        raise click.ClickException(
+            f"No OAuth profile '{profile}' in ~/.kagura/credentials.json.\n"
+            f"  Run: kagura auth login --profile {profile}"
+        )
+
+    # $PATH check is a warning, never a hard failure: kagura-mcp is a
+    # console_script that resolves inside its own venv even when that venv is
+    # not on the invoking shell's PATH (a common Claude Code launch setup).
+    if not _kagura_mcp_on_path():
+        click.echo(
+            f"\n  Warning: '{MCP_PROXY_COMMAND}' was not found on $PATH.\n"
+            "  Claude Code launches it as the MCP server command — make sure the\n"
+            "  environment that starts Claude Code has the kagura-memory package\n"
+            "  installed (pip install kagura-memory)."
+        )
+
+    # Verify the profile works and list contexts (auth + URL come from profile)
+    click.echo("\nVerifying connection...")
+    try:
+        contexts_response = asyncio.run(_test_connection(profile=profile))
+    except KaguraAuthError as e:
+        raise click.ClickException(
+            f"Authentication failed: {_exc_message(e)}\n"
+            f"  Your token may have expired — re-run: kagura auth login --profile {profile}"
+        ) from e
+    except KaguraConnectionError as e:
+        raise click.ClickException(f"Cannot connect to {creds.server}: {_exc_message(e)}") from e
+    except Exception as e:
+        raise click.ClickException(f"Connection failed: {_exc_message(e)}") from e
+
+    count = contexts_response.get("count", 0)
+    click.echo(f"  Connected as {creds.user_email or '<unknown>'} ({count} contexts available)")
+
+    resolved_context_id = _select_or_create_context(
+        contexts_response,
+        None,
+        creds.mcp_url,
+        context_id,
+        project,
+        non_interactive,
+        no_auto_context,
+        profile=profile,
+    )
+
+    if not re.match(_CONTEXT_ID_PATTERN, resolved_context_id):
+        raise click.ClickException(
+            f"Invalid context_id: {resolved_context_id!r} — "
+            "must be alphanumeric, hyphens, or underscores only"
+        )
+
+    click.echo("\nSetting up Kagura Memory for Claude Code (OAuth via kagura-mcp)...")
+
+    kagura_path = _write_kagura_config_oauth(project, creds.mcp_url, resolved_context_id)
+    click.echo(f"  Wrote {kagura_path.relative_to(project)}")
+
+    mcp_path = _write_mcp_json_stdio(project, profile)
+    click.echo(
+        f"  Wrote {mcp_path.relative_to(project)} (stdio: {MCP_PROXY_COMMAND} --profile {profile})"
+    )
+
+    hooks_path = _install_hooks(project, resolved_context_id)
+    click.echo(f"  Wrote {hooks_path.relative_to(project)}")
+
+    skill_paths = _install_skills(project, resolved_context_id)
+    for p in skill_paths:
+        click.echo(f"  Wrote {p.relative_to(project)}")
+
+    # The installed hooks shell out to `kagura recall` / `kagura remember`,
+    # which resolve the *default* OAuth profile (they take no --profile flag).
+    # When the chosen profile is not the file's default_profile, those hooks
+    # would sync under the wrong account — warn rather than silently desync.
+    # (The kagura-mcp MCP server itself always uses the named profile.)
+    if profile != cf.default_profile:
+        click.echo(
+            f"\n  Warning: the session/PostToolUse hooks run `kagura recall` / "
+            f"`kagura remember`,\n"
+            f"  which use the DEFAULT profile '{cf.default_profile}', not '{profile}'.\n"
+            f"  To make them use '{profile}', set KAGURA_PROFILE={profile} in the\n"
+            f"  environment that runs Claude Code (the MCP server already uses it)."
+        )
+
+    # Note: the stdio .mcp.json carries NO secret (the proxy injects a fresh
+    # token per request), so the API-key gitignore warning does not apply here.
+    click.echo(
+        "\nSetup complete! Claude Code will use the refresh-aware kagura-mcp proxy:\n"
+        f"  - MCP server: {MCP_PROXY_COMMAND} --profile {profile} "
+        "(auto-refreshes the OAuth token — no more silent 401s)\n"
+        "  - Recall relevant memories at session start\n"
         "  - /kagura-recall and /kagura-remember available as skills"
     )

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -544,6 +545,48 @@ def test_status_no_credentials_errors_with_login_hint(patched_default_path: Path
     result = CliRunner().invoke(main, ["auth", "status"])
     assert result.exit_code != 0
     assert "kagura auth login" in result.output
+
+
+def _write_cwd_mcp_json(entry: dict) -> None:
+    Path(".mcp.json").write_text(json.dumps({"mcpServers": {"kagura-memory": entry}}))
+
+
+def test_status_reports_stdio_mcp_mode(patched_default_path: Path):
+    """status reports refresh-aware mode when cwd .mcp.json uses the kagura-mcp stdio form."""
+    _seed_credentials(patched_default_path.parent.parent, _make_creds())
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_cwd_mcp_json(
+            {"type": "stdio", "command": "kagura-mcp", "args": ["--profile", "default"]}
+        )
+        result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "refresh-aware" in result.output
+    assert "kagura-mcp" in result.output
+
+
+def test_status_reports_legacy_static_token_mode(patched_default_path: Path):
+    """status flags a legacy static-token .mcp.json and offers a migration hint."""
+    _seed_credentials(patched_default_path.parent.parent, _make_creds())
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_cwd_mcp_json(
+            {"type": "url", "url": "https://x/mcp", "headers": {"Authorization": "Bearer kagura_x"}}
+        )
+        result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "legacy static API-key token" in result.output
+    assert "kagura setup claude --profile" in result.output
+
+
+def test_status_silent_when_no_mcp_json(patched_default_path: Path):
+    """status says nothing about Claude Code when there is no .mcp.json in cwd."""
+    _seed_credentials(patched_default_path.parent.parent, _make_creds())
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "Claude Code (.mcp.json)" not in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -589,6 +589,17 @@ def test_status_silent_when_no_mcp_json(patched_default_path: Path):
     assert "Claude Code (.mcp.json)" not in result.output
 
 
+def test_status_reports_url_mode_without_auth(patched_default_path: Path):
+    """status reports a url-form .mcp.json that carries no Authorization header."""
+    _seed_credentials(patched_default_path.parent.parent, _make_creds())
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        _write_cwd_mcp_json({"type": "url", "url": "https://x/mcp"})
+        result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "url form (no Authorization header)" in result.output
+
+
 # ---------------------------------------------------------------------------
 # logout
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_claude_oauth.py
+++ b/tests/test_setup_claude_oauth.py
@@ -1,0 +1,501 @@
+"""Tests for the OAuth / kagura-mcp path of `kagura setup claude` (#157, PR-A).
+
+Covers the stdio `.mcp.json` writer, the `.mcp.json` mode detector (shared with
+`kagura auth status`), the OAuth-specific `.kagura.json` writer, and the
+`setup claude --profile` CLI flow.
+"""
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from kagura_memory.cli import main
+from kagura_memory.setup_claude import (
+    MCP_PROXY_COMMAND,
+    MCP_SERVER_NAME,
+    _create_context,
+    _kagura_mcp_on_path,
+    _make_client,
+    _test_connection,
+    _write_kagura_config_oauth,
+    _write_mcp_json_stdio,
+    detect_mcp_json_mode,
+)
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _oauth_creds() -> MagicMock:
+    creds = MagicMock()
+    creds.mcp_url = "https://memory.kagura-ai.com/mcp"
+    creds.server = "https://memory.kagura-ai.com"
+    creds.user_email = "user@example.com"
+    return creds
+
+
+def _creds_file(creds: MagicMock | None, default_profile: str = "default") -> MagicMock:
+    cf = MagicMock()
+    cf.get_profile.return_value = creds
+    cf.default_profile = default_profile
+    return cf
+
+
+# =============================================================================
+# _write_mcp_json_stdio
+# =============================================================================
+
+
+class TestWriteMcpJsonStdio:
+    def test_creates_stdio_form(self, project_dir: Path) -> None:
+        path = _write_mcp_json_stdio(project_dir, "default")
+        server = json.loads(path.read_text())["mcpServers"][MCP_SERVER_NAME]
+        assert server["type"] == "stdio"
+        assert server["command"] == MCP_PROXY_COMMAND
+        assert server["args"] == ["--profile", "default"]
+        # No secret is written in the stdio form.
+        assert "headers" not in server
+
+    def test_named_profile_in_args(self, project_dir: Path) -> None:
+        path = _write_mcp_json_stdio(project_dir, "work")
+        server = json.loads(path.read_text())["mcpServers"][MCP_SERVER_NAME]
+        assert server["args"] == ["--profile", "work"]
+
+    def test_preserves_other_servers(self, project_dir: Path) -> None:
+        existing = {"mcpServers": {"github": {"type": "stdio", "command": "npx github-mcp"}}}
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        _write_mcp_json_stdio(project_dir, "default")
+        servers = json.loads((project_dir / ".mcp.json").read_text())["mcpServers"]
+        assert "github" in servers
+        assert servers[MCP_SERVER_NAME]["type"] == "stdio"
+
+    def test_overwrites_legacy_url_form(self, project_dir: Path) -> None:
+        """Re-running with --profile migrates a legacy static-token entry to stdio."""
+        existing = {
+            "mcpServers": {
+                MCP_SERVER_NAME: {
+                    "type": "url",
+                    "url": "https://x/mcp",
+                    "headers": {"Authorization": "Bearer kagura_old"},
+                }
+            }
+        }
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        _write_mcp_json_stdio(project_dir, "default")
+        server = json.loads((project_dir / ".mcp.json").read_text())["mcpServers"][MCP_SERVER_NAME]
+        assert server["type"] == "stdio"
+        assert "headers" not in server  # stale token gone
+
+
+# =============================================================================
+# detect_mcp_json_mode
+# =============================================================================
+
+
+class TestDetectMcpJsonMode:
+    def test_none_when_no_file(self, project_dir: Path) -> None:
+        assert detect_mcp_json_mode(project_dir) == "none"
+
+    def test_stdio(self, project_dir: Path) -> None:
+        _write_mcp_json_stdio(project_dir, "default")
+        assert detect_mcp_json_mode(project_dir) == "stdio"
+
+    def test_static_token(self, project_dir: Path) -> None:
+        existing = {
+            "mcpServers": {
+                MCP_SERVER_NAME: {
+                    "type": "url",
+                    "url": "https://x/mcp",
+                    "headers": {"Authorization": "Bearer kagura_x"},
+                }
+            }
+        }
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "static-token"
+
+    def test_static_token_case_insensitive_header(self, project_dir: Path) -> None:
+        existing = {
+            "mcpServers": {
+                MCP_SERVER_NAME: {
+                    "type": "url",
+                    "url": "https://x/mcp",
+                    "headers": {"authorization": "Bearer kagura_x"},
+                }
+            }
+        }
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "static-token"
+
+    def test_url_without_auth(self, project_dir: Path) -> None:
+        existing = {"mcpServers": {MCP_SERVER_NAME: {"type": "url", "url": "https://x/mcp"}}}
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "url"
+
+    def test_absent_when_no_kagura_entry(self, project_dir: Path) -> None:
+        existing = {"mcpServers": {"github": {"type": "stdio", "command": "npx"}}}
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "absent"
+
+    def test_absent_on_malformed_json(self, project_dir: Path) -> None:
+        (project_dir / ".mcp.json").write_text("{not valid json")
+        assert detect_mcp_json_mode(project_dir) == "absent"
+
+    def test_url_with_non_dict_headers_not_misclassified(self, project_dir: Path) -> None:
+        """A malformed `headers` list must not be read as a static-token header."""
+        existing = {
+            "mcpServers": {
+                MCP_SERVER_NAME: {
+                    "type": "url",
+                    "url": "https://x/mcp",
+                    "headers": ["Authorization"],
+                }
+            }
+        }
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "url"
+
+    def test_absent_on_unrecognized_type(self, project_dir: Path) -> None:
+        """An entry whose `type` is neither stdio nor url is classified absent."""
+        existing = {"mcpServers": {MCP_SERVER_NAME: {"type": "sse", "url": "https://x/sse"}}}
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "absent"
+
+
+# =============================================================================
+# _make_client / _kagura_mcp_on_path (dispatch + PATH probe)
+# =============================================================================
+
+
+class TestMakeClient:
+    @patch("kagura_memory.setup_claude.KaguraClient")
+    def test_dispatches_to_profile(self, mock_kc: MagicMock) -> None:
+        _make_client(None, None, "work")
+        mock_kc.assert_called_once_with(profile="work")
+
+    @patch("kagura_memory.setup_claude.KaguraClient")
+    def test_dispatches_to_api_key(self, mock_kc: MagicMock) -> None:
+        _make_client("kagura_x", "https://x/mcp", None)
+        mock_kc.assert_called_once_with(api_key="kagura_x", mcp_url="https://x/mcp")
+
+
+class TestKaguraMcpOnPath:
+    def test_true_when_resolvable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/local/bin/kagura-mcp")
+        assert _kagura_mcp_on_path() is True
+
+    def test_false_when_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        assert _kagura_mcp_on_path() is False
+
+
+def _async_client_mock(mock_kc: MagicMock, inner: AsyncMock) -> None:
+    """Wire a patched KaguraClient so `async with KaguraClient(...) as c` yields `inner`."""
+    mock_kc.return_value.__aenter__ = AsyncMock(return_value=inner)
+    mock_kc.return_value.__aexit__ = AsyncMock(return_value=False)
+
+
+class TestConnectionHelpers:
+    @pytest.mark.asyncio
+    @patch("kagura_memory.setup_claude.KaguraClient")
+    async def test_test_connection_lists_contexts(self, mock_kc: MagicMock) -> None:
+        inner = AsyncMock()
+        inner.list_contexts.return_value = {"count": 2, "contexts": []}
+        _async_client_mock(mock_kc, inner)
+        out = await _test_connection(profile="work")
+        assert out["count"] == 2
+        mock_kc.assert_called_once_with(profile="work")
+
+    @pytest.mark.asyncio
+    @patch("kagura_memory.setup_claude.KaguraClient")
+    async def test_create_context_creates(self, mock_kc: MagicMock) -> None:
+        inner = AsyncMock()
+        inner.create_context.return_value = {"context_id": "ctx-new"}
+        _async_client_mock(mock_kc, inner)
+        out = await _create_context(None, None, "proj", None, profile="work")
+        assert out["context_id"] == "ctx-new"
+        inner.create_context.assert_awaited_once_with(name="proj", summary=None)
+
+
+# =============================================================================
+# _write_kagura_config_oauth
+# =============================================================================
+
+
+class TestWriteKaguraConfigOAuth:
+    def test_no_api_key_written(self, project_dir: Path) -> None:
+        path = _write_kagura_config_oauth(project_dir, "https://x/mcp", "ctx-1")
+        data = json.loads(path.read_text())
+        assert "api_key" not in data
+        assert data["mcp_url"] == "https://x/mcp"
+        assert data["context_id"] == "ctx-1"
+
+    def test_preserves_existing_keys(self, project_dir: Path) -> None:
+        existing = {"api_key": "kagura_old", "model": "gpt-5.4-nano"}
+        (project_dir / ".kagura.json").write_text(json.dumps(existing))
+        _write_kagura_config_oauth(project_dir, "https://x/mcp", "ctx-2")
+        data = json.loads((project_dir / ".kagura.json").read_text())
+        # OAuth path never rewrites api_key, but also does not delete a pre-existing one
+        # (the OAuth profile still wins in the credential-resolution order).
+        assert data["api_key"] == "kagura_old"
+        assert data["model"] == "gpt-5.4-nano"
+        assert data["context_id"] == "ctx-2"
+
+
+# =============================================================================
+# CLI: setup claude --profile
+# =============================================================================
+
+
+def _profile_args(tmp_path: Path, **overrides: str) -> list[str]:
+    args = [
+        "setup",
+        "claude",
+        "--profile",
+        overrides.get("profile", "default"),
+        "--project-dir",
+        str(tmp_path),
+        "-y",
+    ]
+    if "context_id" in overrides:
+        args.extend(["--context-id", overrides["context_id"]])
+    return args
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_writes_stdio_form(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """`setup claude --profile` writes the stdio .mcp.json + api-key-less .kagura.json."""
+    mock_load.return_value = _creds_file(_oauth_creds())
+    mock_conn.return_value = {"count": 1, "contexts": [{"id": "ctx-x", "name": "proj"}]}
+
+    result = runner.invoke(main, _profile_args(tmp_path, context_id="ctx-x"))
+
+    assert result.exit_code == 0, result.output
+    assert "kagura-mcp" in result.output
+
+    server = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"][MCP_SERVER_NAME]
+    assert server["type"] == "stdio"
+    assert server["command"] == MCP_PROXY_COMMAND
+    assert server["args"] == ["--profile", "default"]
+
+    kagura_cfg = json.loads((tmp_path / ".kagura.json").read_text())
+    assert "api_key" not in kagura_cfg
+    assert kagura_cfg["context_id"] == "ctx-x"
+    assert kagura_cfg["mcp_url"] == "https://memory.kagura-ai.com/mcp"
+
+    # Hooks + skills still installed
+    assert (tmp_path / ".claude" / "settings.json").exists()
+    assert (tmp_path / ".claude" / "commands" / "kagura-recall.md").exists()
+
+
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_missing_profile_errors(
+    mock_load: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """A nonexistent profile points the user at `kagura auth login`."""
+    mock_load.return_value = _creds_file(None)
+
+    result = runner.invoke(main, _profile_args(tmp_path, profile="ghost"))
+
+    assert result.exit_code != 0
+    assert "No OAuth profile 'ghost'" in result.output
+    assert "kagura auth login --profile ghost" in result.output
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+def test_setup_claude_profile_and_api_key_mutually_exclusive(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """--profile and --api-key cannot be combined."""
+    result = runner.invoke(
+        main,
+        [
+            "setup",
+            "claude",
+            "--profile",
+            "default",
+            "--api-key",
+            "kagura_x",
+            "--project-dir",
+            str(tmp_path),
+            "-y",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=False)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_warns_when_not_on_path(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Missing `kagura-mcp` on $PATH warns but does not fail the setup."""
+    mock_load.return_value = _creds_file(_oauth_creds())
+    mock_conn.return_value = {"count": 1, "contexts": [{"id": "ctx-x", "name": "proj"}]}
+
+    result = runner.invoke(main, _profile_args(tmp_path, context_id="ctx-x"))
+
+    assert result.exit_code == 0, result.output
+    assert "not found on $PATH" in result.output
+    # Still wrote the config despite the warning
+    assert (tmp_path / ".mcp.json").exists()
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_non_default_profile_warns_hooks_use_default(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """A non-default profile warns that the CLI hooks still resolve the default profile."""
+    mock_load.return_value = _creds_file(_oauth_creds(), default_profile="default")
+    mock_conn.return_value = {"count": 1, "contexts": [{"id": "ctx-x", "name": "proj"}]}
+
+    result = runner.invoke(main, _profile_args(tmp_path, profile="work", context_id="ctx-x"))
+
+    assert result.exit_code == 0, result.output
+    assert "DEFAULT profile 'default', not 'work'" in result.output
+    assert "KAGURA_PROFILE=work" in result.output
+    # The proxy entry still binds the named profile despite the hook caveat
+    server = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"][MCP_SERVER_NAME]
+    assert server["args"] == ["--profile", "work"]
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_default_profile_no_hook_warning(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """The default profile must NOT emit the hook-profile mismatch warning."""
+    mock_load.return_value = _creds_file(_oauth_creds(), default_profile="default")
+    mock_conn.return_value = {"count": 1, "contexts": [{"id": "ctx-x", "name": "proj"}]}
+
+    result = runner.invoke(main, _profile_args(tmp_path, profile="default", context_id="ctx-x"))
+
+    assert result.exit_code == 0, result.output
+    assert "DEFAULT profile" not in result.output
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_auth_failure(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """An auth error during the profile connection test surfaces a re-login hint."""
+    from kagura_memory.exceptions import KaguraAuthError
+
+    mock_load.return_value = _creds_file(_oauth_creds())
+    mock_conn.side_effect = KaguraAuthError("token expired")
+
+    result = runner.invoke(main, _profile_args(tmp_path, context_id="ctx-x"))
+
+    assert result.exit_code != 0
+    assert "Authentication failed" in result.output
+    assert "kagura auth login --profile default" in result.output
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_connection_error(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """A connection error names the profile's server and writes nothing."""
+    from kagura_memory.exceptions import KaguraConnectionError
+
+    mock_load.return_value = _creds_file(_oauth_creds())
+    mock_conn.side_effect = KaguraConnectionError("ECONNREFUSED")
+
+    result = runner.invoke(main, _profile_args(tmp_path, context_id="ctx-x"))
+
+    assert result.exit_code != 0
+    assert "Cannot connect to https://memory.kagura-ai.com" in result.output
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_generic_error(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """An unexpected error surfaces as a generic connection failure."""
+    mock_load.return_value = _creds_file(_oauth_creds())
+    mock_conn.side_effect = RuntimeError("boom")
+
+    result = runner.invoke(main, _profile_args(tmp_path, context_id="ctx-x"))
+
+    assert result.exit_code != 0
+    assert "Connection failed" in result.output
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+@patch("kagura_memory.setup_claude._kagura_mcp_on_path", return_value=True)
+@patch("kagura_memory.setup_claude._test_connection")
+@patch("kagura_memory.auth.credentials.load_credentials_file")
+def test_setup_claude_profile_rejects_malicious_context_id(
+    mock_load: MagicMock,
+    mock_conn: AsyncMock,
+    mock_on_path: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """The OAuth path rejects a shell-special context_id (parity with the api-key path)."""
+    mock_load.return_value = _creds_file(_oauth_creds())
+    mock_conn.return_value = {"count": 0, "contexts": []}
+
+    result = runner.invoke(main, _profile_args(tmp_path, context_id="; rm -rf /"))
+
+    assert result.exit_code != 0
+    assert "Invalid context_id" in result.output
+    assert not (tmp_path / ".mcp.json").exists()

--- a/tests/test_setup_claude_oauth.py
+++ b/tests/test_setup_claude_oauth.py
@@ -171,6 +171,12 @@ class TestDetectMcpJsonMode:
         (project_dir / ".mcp.json").write_text(json.dumps(existing))
         assert detect_mcp_json_mode(project_dir) == "absent"
 
+    def test_stdio_with_wrong_command_not_stdio(self, project_dir: Path) -> None:
+        """A stdio entry whose command isn't kagura-mcp is not classified as stdio."""
+        existing = {"mcpServers": {MCP_SERVER_NAME: {"type": "stdio", "command": "some-other-mcp"}}}
+        (project_dir / ".mcp.json").write_text(json.dumps(existing))
+        assert detect_mcp_json_mode(project_dir) == "absent"
+
 
 # =============================================================================
 # _make_client / _kagura_mcp_on_path (dispatch + PATH probe)
@@ -214,6 +220,7 @@ class TestConnectionHelpers:
         _async_client_mock(mock_kc, inner)
         out = await _test_connection(profile="work")
         assert out["count"] == 2
+        inner.list_contexts.assert_awaited_once()
         mock_kc.assert_called_once_with(profile="work")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #157

PR-A of the kagura-mcp follow-ups. Per the gate1 design review (CTO), the oversized #157 was split into a low-risk UX/wiring half (this PR) and a concurrency-correctness half tracked separately in **#158** (Windows `msvcrt` lock shim, network-level refresh dedup, subprocess lock-contention test).

## Summary
- **`kagura setup claude --profile NAME`** writes the refresh-aware `kagura-mcp` stdio `.mcp.json` form (`{type: stdio, command: kagura-mcp, args: [--profile, NAME]}`) bound to an OAuth profile — **no API key, no secret in the file**, token refreshes automatically. Without `--profile`, the legacy static API-key url form is unchanged (CI / service accounts). `--profile`/`--api-key` are mutually exclusive.
- **`kagura auth status`** now reports the Claude Code integration mode for a `.mcp.json` in the current directory: `refresh-aware` (stdio proxy) vs `legacy static API-key token` (with a migration hint).
- **Docs**: README "Connect to Claude Code" rewrite (OAuth recommended, API key as CI fallback) + refreshed the now-stale "tracked as a follow-up" notes in the auth group docstring and login-success hint.

## Implementation notes
- `MCP_SERVER_NAME` / `MCP_PROXY_COMMAND` are the single source of truth shared by the writer (`_write_mcp_json_stdio`) and the detector (`detect_mcp_json_mode`), so the written form and the detected form cannot drift.
- `run_setup_claude(profile=...)` early-dispatches to a separate `_run_setup_claude_oauth`; the legacy API-key body is left byte-identical (regression-safe). Signature additions are keyword-only (`*, profile=None`), so existing callers are unaffected.
- OAuth-path `.kagura.json` carries no `api_key`; `kagura-mcp` `$PATH` check is a warning, never a hard failure.
- Known limitation (warned at setup, deferred to #158): the installed hooks shell out to `kagura recall`/`remember`, which resolve the *default* OAuth profile (no `--profile` flag yet) — a non-default profile emits a warning rather than silently desyncing.

## Pre-PR review summary
- gate1: yellow via /ask (CTO) — recommended the A/B split, adopted
- gate2 mode: advisor-only (binary_gate=none)
- audit: skipped
- cso: green · qa-lead: yellow (coverage gaps — fixed same run, now ~100% patch coverage on new code) · cto: green
- /code-review (high): ran pre-PR, found + fixed 2 real issues (malformed-headers misclassification, non-default-profile hook desync warning)
- Quality: ruff + format + pyright src 0 errors; full CI selector 1063 passed, 4 skipped

🤖 Generated via /gh-issue-driven:ship
