### PR TITLE
feat(mcp): kagura-mcp PR-B — Windows lock shim + cross-process refresh dedup (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,28 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
   whether the `kagura-memory` entry is `refresh-aware` (the `kagura-mcp` stdio
   proxy) or a `legacy static API-key token` (with a migration hint), so you can
   see at a glance which path a project is on.
-
-Deferred to a follow-up issue (the #157 PR-B set, per the design review): the
-Windows `msvcrt` locking shim behind `_filelock`, network-level refresh dedup
-(re-check-after-lock so only one proxy hits `/oauth2/token`), and a
-subprocess-based cross-process lock-contention test.
+- **Windows credentials-lock shim** (#158): `_filelock.file_lock` now has a
+  Windows backend (`msvcrt.locking`) alongside the POSIX `fcntl` one, replacing
+  the previous non-POSIX no-op. Because the Windows API has no shared-lock mode,
+  `exclusive=False` is upgraded to an exclusive lock (concurrent readers
+  serialize on Windows where they run in parallel on POSIX — the documented
+  behavior difference), and a non-blocking `LK_NBLCK` retry loop emulates
+  `flock`'s blocking acquire without `msvcrt`'s 10-second `LK_LOCK` timeout.
+- **Cross-process refresh dedup over the network** (#158): concurrent
+  `kagura-mcp` proxies no longer each hit `/oauth2/token`. `KaguraOAuth`'s
+  refresh now acquires the cross-process advisory lock (off the event loop, in
+  a worker thread, so other coroutines keep running), re-reads the on-disk
+  token, and **skips the network round-trip when another process already
+  rotated it** — adopting the on-disk token instead. The skew-driven path and
+  the 401-retry path use different "already rotated?" predicates: the skew path
+  skips when the on-disk token is outside the skew window, while the 401 path
+  skips only when the on-disk token *differs* from the rejected one (an
+  identical token means nobody rotated yet, so a real refresh must fire — an
+  `expires_at`-based skip there would loop on the rejected token). The lock is
+  released synchronously (never offloaded) so a saturated executor cannot
+  deadlock the release. Covered by a subprocess-based cross-process
+  lock-contention test (no lost updates under `N`-way contention) plus
+  deterministic in-process dedup tests with a negative control.
 
 ## v0.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,9 @@ See [GitHub Releases](https://github.com/kagura-ai/kagura-memory-python-sdk/rele
   `flock`'s blocking acquire without `msvcrt`'s 10-second `LK_LOCK` timeout.
 - **Cross-process refresh dedup over the network** (#158): concurrent
   `kagura-mcp` proxies no longer each hit `/oauth2/token`. `KaguraOAuth`'s
-  refresh now acquires the cross-process advisory lock (off the event loop, in
-  a worker thread, so other coroutines keep running), re-reads the on-disk
+  refresh now acquires the cross-process advisory lock with non-blocking
+  attempts on the event loop (so other coroutines keep running and a
+  cancellation while waiting cannot leak the lock), re-reads the on-disk
   token, and **skips the network round-trip when another process already
   rotated it** — adopting the on-disk token instead. The skew-driven path and
   the 401-retry path use different "already rotated?" predicates: the skew path

--- a/src/kagura_memory/_filelock.py
+++ b/src/kagura_memory/_filelock.py
@@ -8,15 +8,25 @@ need a *cross-process* gate so a concurrent read-modify-write cannot lose an
 update. This module provides that gate as a small advisory-lock context
 manager wrapping a lock file next to the target.
 
-POSIX only for v1 (``fcntl.flock``). On platforms without ``fcntl`` (Windows)
-the context manager degrades to a **no-op** with a one-time debug log — a
-deliberate, documented limitation tracked as a follow-up (the Windows
-``msvcrt.locking`` shim has materially different semantics — byte-range,
-mandatory, no shared/exclusive distinction — and is out of scope here). The
-no-op is safe because the atomic ``os.replace`` write in ``auth.credentials``
-already guarantees the file is never torn; the lock only adds *serialization*
-of the read-modify-write, which single-owner deployments (the common Claude
-Code case) do not require.
+Two backends, selected at runtime by which module imports:
+
+- **POSIX** (``fcntl.flock``): whole-file advisory lock, with a real
+  shared/exclusive distinction (``LOCK_SH`` / ``LOCK_EX``).
+- **Windows** (``msvcrt.locking``): byte-range, *mandatory* lock. The Windows
+  API has **no shared-lock mode**, so :func:`file_lock` treats
+  ``exclusive=False`` as exclusive too — concurrent readers serialize on
+  Windows where they would run in parallel on POSIX. This is acceptable for
+  the credentials file (low contention, short critical section) and is the
+  documented semantic difference between the backends. ``msvcrt.locking``
+  also has no blocking-until-acquired mode that waits indefinitely, so the
+  Windows path uses a non-blocking lock attempt (``LK_NBLCK``) in a short
+  retry loop to emulate ``flock``'s blocking acquire.
+
+On a platform that has neither module the context manager degrades to a
+**no-op** with a one-time debug log. The no-op is safe because the atomic
+``os.replace`` write in ``auth.credentials`` already guarantees the file is
+never torn; the lock only adds *serialization* of the read-modify-write,
+which single-owner deployments (the common Claude Code case) do not require.
 """
 
 from __future__ import annotations
@@ -24,10 +34,19 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import time
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger("kagura_memory")
+
+# msvcrt locks a byte range from the current file position; one byte at offset
+# 0 is enough to gate the whole sibling lock file (Windows permits locking a
+# region at/beyond EOF, so the empty lock file needs no pre-write).
+_MSVCRT_LOCK_BYTES = 1
+# Poll interval while waiting for a contended msvcrt lock (LK_NBLCK retry loop).
+_MSVCRT_RETRY_SEC = 0.05
 
 
 def _lock_path(target: Path) -> Path:
@@ -40,6 +59,52 @@ def _lock_path(target: Path) -> Path:
     return target.with_name(target.name + ".lock")
 
 
+def _detect_backend() -> tuple[str, Any]:
+    """Return ``(name, module)`` for the available lock backend.
+
+    ``name`` is ``"fcntl"``, ``"msvcrt"``, or ``"noop"`` (module is ``None``
+    for ``"noop"``). POSIX ``fcntl`` is preferred when both somehow resolve.
+    """
+    try:
+        import fcntl
+
+        return "fcntl", fcntl
+    except ImportError:
+        pass
+    try:
+        import msvcrt
+
+        return "msvcrt", msvcrt
+    except ImportError:  # pragma: no cover - only on exotic platforms (no fcntl, no msvcrt)
+        return "noop", None
+
+
+def _lock_fd(backend: str, mod: Any, fd: int, *, exclusive: bool) -> None:
+    """Acquire the advisory lock on ``fd`` using the selected backend."""
+    if backend == "fcntl":
+        mod.flock(fd, mod.LOCK_EX if exclusive else mod.LOCK_SH)
+        return
+    # msvcrt: no shared mode (exclusive param is honored for API parity but
+    # every lock is exclusive). LK_NBLCK never blocks; loop to emulate
+    # flock's blocking acquire without msvcrt's 10-second LK_LOCK timeout.
+    os.lseek(fd, 0, os.SEEK_SET)
+    while True:
+        try:
+            mod.locking(fd, mod.LK_NBLCK, _MSVCRT_LOCK_BYTES)
+            return
+        except OSError:
+            time.sleep(_MSVCRT_RETRY_SEC)
+
+
+def _unlock_fd(backend: str, mod: Any, fd: int) -> None:
+    """Release the advisory lock on ``fd`` using the selected backend."""
+    if backend == "fcntl":
+        mod.flock(fd, mod.LOCK_UN)
+        return
+    os.lseek(fd, 0, os.SEEK_SET)
+    mod.locking(fd, mod.LK_UNLCK, _MSVCRT_LOCK_BYTES)
+
+
 @contextlib.contextmanager
 def file_lock(target: Path, *, exclusive: bool = True) -> Iterator[None]:
     """Hold a cross-process advisory lock for ``target`` for the block's body.
@@ -47,16 +112,16 @@ def file_lock(target: Path, *, exclusive: bool = True) -> Iterator[None]:
     Args:
         target: The file being protected (the lock is taken on a sibling
             ``<name>.lock``, created with mode 0600).
-        exclusive: ``True`` for a write lock (``LOCK_EX``), ``False`` for a
-            shared read lock (``LOCK_SH``).
+        exclusive: ``True`` for a write lock, ``False`` for a shared read lock.
+            On the Windows (``msvcrt``) backend there is no shared mode, so
+            ``False`` is upgraded to an exclusive lock (see module docstring).
 
-    On non-POSIX platforms this is a no-op (see module docstring). The lock is
-    always released — including on exception — by the ``finally`` block.
+    On a platform with neither ``fcntl`` nor ``msvcrt`` this is a no-op. The
+    lock is always released — including on exception — by the ``finally`` block.
     """
-    try:
-        import fcntl
-    except ImportError:  # pragma: no cover - exercised only on Windows
-        logger.debug("fcntl unavailable; credentials file lock is a no-op on this platform")
+    backend, mod = _detect_backend()
+    if backend == "noop":  # pragma: no cover - only on exotic platforms
+        logger.debug("no fcntl/msvcrt; credentials file lock is a no-op on this platform")
         yield
         return
 
@@ -66,10 +131,10 @@ def file_lock(target: Path, *, exclusive: bool = True) -> Iterator[None]:
     # private as the credentials file it guards.
     fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        _lock_fd(backend, mod, fd, exclusive=exclusive)
         try:
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            _unlock_fd(backend, mod, fd)
     finally:
         os.close(fd)

--- a/src/kagura_memory/_filelock.py
+++ b/src/kagura_memory/_filelock.py
@@ -31,11 +31,12 @@ which single-owner deployments (the common Claude Code case) do not require.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
 import os
 import time
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -45,8 +46,14 @@ logger = logging.getLogger("kagura_memory")
 # 0 is enough to gate the whole sibling lock file (Windows permits locking a
 # region at/beyond EOF, so the empty lock file needs no pre-write).
 _MSVCRT_LOCK_BYTES = 1
-# Poll interval while waiting for a contended msvcrt lock (LK_NBLCK retry loop).
-_MSVCRT_RETRY_SEC = 0.05
+# Poll interval while waiting for a contended lock (msvcrt sync loop and the
+# async non-blocking poll both use it).
+_LOCK_RETRY_SEC = 0.05
+# Safety ceiling on a *contended* acquire so a stuck/hung peer holding the lock
+# cannot wedge a waiter forever. Sized well above the OAuth refresh round-trip
+# (the only operation that holds the lock across a network call), so it never
+# trips in normal contention — it only bounds the pathological case.
+_LOCK_ACQUIRE_TIMEOUT_SEC = 90.0
 
 
 def _lock_path(target: Path) -> Path:
@@ -79,21 +86,47 @@ def _detect_backend() -> tuple[str, Any]:
         return "noop", None
 
 
+def _try_lock_fd(backend: str, mod: Any, fd: int, *, exclusive: bool) -> bool:
+    """Attempt a single non-blocking lock acquire. Return ``True`` if acquired.
+
+    Returns ``False`` only when the lock is *held by someone else* (a retryable
+    condition). Any other error — a bad fd, a permission failure, an
+    unsupported filesystem — propagates, so a permanent failure surfaces
+    instead of spinning forever.
+    """
+    if backend == "fcntl":
+        try:
+            mod.flock(fd, (mod.LOCK_EX if exclusive else mod.LOCK_SH) | mod.LOCK_NB)
+            return True
+        except BlockingIOError:
+            # EWOULDBLOCK/EAGAIN — held by another owner. Other OSErrors raise.
+            return False
+    # msvcrt: no shared mode (exclusive is honored for API parity but every
+    # lock is exclusive). LK_NBLCK raises OSError when the region is held; we
+    # cannot reliably distinguish errno across Windows versions here, so the
+    # caller bounds the retry loop with a deadline.
+    os.lseek(fd, 0, os.SEEK_SET)
+    try:
+        mod.locking(fd, mod.LK_NBLCK, _MSVCRT_LOCK_BYTES)
+        return True
+    except OSError:
+        return False
+
+
 def _lock_fd(backend: str, mod: Any, fd: int, *, exclusive: bool) -> None:
-    """Acquire the advisory lock on ``fd`` using the selected backend."""
+    """Acquire the advisory lock on ``fd`` (blocking) using the selected backend."""
     if backend == "fcntl":
         mod.flock(fd, mod.LOCK_EX if exclusive else mod.LOCK_SH)
         return
-    # msvcrt: no shared mode (exclusive param is honored for API parity but
-    # every lock is exclusive). LK_NBLCK never blocks; loop to emulate
-    # flock's blocking acquire without msvcrt's 10-second LK_LOCK timeout.
-    os.lseek(fd, 0, os.SEEK_SET)
-    while True:
-        try:
-            mod.locking(fd, mod.LK_NBLCK, _MSVCRT_LOCK_BYTES)
-            return
-        except OSError:
-            time.sleep(_MSVCRT_RETRY_SEC)
+    # msvcrt has no blocking-until-acquired mode that waits indefinitely, so
+    # emulate flock's blocking acquire with a bounded non-blocking retry loop.
+    deadline = time.monotonic() + _LOCK_ACQUIRE_TIMEOUT_SEC
+    while not _try_lock_fd(backend, mod, fd, exclusive=exclusive):
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"could not acquire credentials lock within {_LOCK_ACQUIRE_TIMEOUT_SEC}s"
+            )
+        time.sleep(_LOCK_RETRY_SEC)
 
 
 def _unlock_fd(backend: str, mod: Any, fd: int) -> None:
@@ -132,6 +165,49 @@ def file_lock(target: Path, *, exclusive: bool = True) -> Iterator[None]:
     fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT, 0o600)
     try:
         _lock_fd(backend, mod, fd, exclusive=exclusive)
+        try:
+            yield
+        finally:
+            _unlock_fd(backend, mod, fd)
+    finally:
+        os.close(fd)
+
+
+@contextlib.asynccontextmanager
+async def async_file_lock(target: Path, *, exclusive: bool = True) -> AsyncIterator[None]:
+    """Event-loop-friendly, cancellation-safe variant of :func:`file_lock`.
+
+    Coroutines must not call the blocking :func:`file_lock` directly (it would
+    stall the whole event loop while waiting on a contended lock). This variant
+    acquires the lock with **non-blocking attempts on the loop**, awaiting
+    :func:`asyncio.sleep` between tries. The only ``await`` performed while the
+    lock is *not yet held* is that sleep, so a cancellation between attempts
+    leaves nothing acquired — there is no worker thread that could win the lock
+    after the awaiting task has gone away (the failure mode of offloading a
+    blocking ``__enter__`` to :func:`asyncio.to_thread`). Once acquired, the
+    release path is synchronous and runs in the ``finally``, so cancellation
+    inside the body still releases.
+
+    A stuck holder is bounded by :data:`_LOCK_ACQUIRE_TIMEOUT_SEC` (raises
+    :class:`TimeoutError`). On a platform with neither backend this is a no-op.
+    """
+    backend, mod = _detect_backend()
+    if backend == "noop":  # pragma: no cover - only on exotic platforms
+        logger.debug("no fcntl/msvcrt; credentials file lock is a no-op on this platform")
+        yield
+        return
+
+    lock_file = _lock_path(target)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        deadline = time.monotonic() + _LOCK_ACQUIRE_TIMEOUT_SEC
+        while not _try_lock_fd(backend, mod, fd, exclusive=exclusive):
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"could not acquire credentials lock within {_LOCK_ACQUIRE_TIMEOUT_SEC}s"
+                )
+            await asyncio.sleep(_LOCK_RETRY_SEC)
         try:
             yield
         finally:

--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -13,11 +13,14 @@ This module owns three responsibilities:
    ``/oauth2/token`` refresh fires per cycle even when many client
    instances run side by side.
 
-Multi-process coordination (e.g. two ``KaguraClient`` instances in
-different worker processes refreshing the same file) is out of scope
-for this module — the in-process lock collapses to a no-op across
-process boundaries. The follow-up proxy daemon (issue #101) becomes
-the single owner of the credentials file in that scenario.
+Multi-process coordination (e.g. several ``kagura-mcp`` proxy children
+refreshing the same file) is handled in two layers: the in-process
+:class:`asyncio.Lock` coalesces refreshes *within* a process, and the
+cross-process advisory lock in :mod:`kagura_memory._filelock` (acquired
+inside :meth:`KaguraOAuth._refresh_locked`) re-reads the on-disk token
+after locking and skips the ``/oauth2/token`` round-trip when another
+process already rotated it — so only one process hits the token endpoint
+per cycle (issue #158).
 """
 
 from __future__ import annotations
@@ -532,36 +535,100 @@ class KaguraOAuth(httpx.Auth):
         Used by the ``kagura-mcp`` proxy on an upstream ``401``: the token was
         rejected server-side (rotated / revoked out-of-band) even though it is
         not yet within the skew window, so :meth:`_maybe_refresh` would no-op.
-        The same lock serializes this with skew-driven refreshes, so a 401 on
-        one in-flight request and a skew refresh on another coalesce to a
-        single ``/oauth2/token`` call.
+        The same in-process lock serializes this with skew-driven refreshes, so
+        a 401 on one in-flight request and a skew refresh on another coalesce to
+        a single ``/oauth2/token`` call. Cross-process dedup is handled in
+        :meth:`_refresh_locked` via the rejected-token identity check.
         """
         async with self._state.lock:
-            await self._refresh_locked()
+            rejected_token = self._state.credentials.access_token
+            await self._refresh_locked(expected_stale_token=rejected_token)
 
-    async def _refresh_locked(self) -> None:
-        """Perform the ``/oauth2/token`` refresh and persist. Caller holds the lock."""
-        # Lazy import: ``device_flow`` may depend on this module's
-        # public types, so resolve only at refresh time to avoid a
-        # cycle at import time.
+    async def _refresh_locked(self, *, expected_stale_token: str | None = None) -> None:
+        """Refresh ``/oauth2/token`` once across all processes. Caller holds the in-process lock.
+
+        The cross-process advisory lock is acquired off the event loop (in a
+        worker thread) so other coroutines — e.g. concurrent ``kagura-mcp``
+        proxy forwards — keep running while we wait. After acquiring it we
+        re-read the credentials from disk and **skip the network call when
+        another process already rotated the token**, so only one proxy among
+        many hits ``/oauth2/token`` per cycle (dedup over the network, not just
+        a lost-update-safe write).
+
+        Args:
+            expected_stale_token: governs the "already rotated?" predicate.
+                ``None`` (skew-driven path) → skip when the on-disk token is no
+                longer within the skew window (another process produced a fresh
+                token). A token string (401 path) → skip only when the on-disk
+                token *differs* from this rejected token; an identical on-disk
+                token means nobody has rotated yet, so this process must refresh
+                (a 401 is independent of ``expires_at``).
+        """
+        from .._filelock import file_lock
+
+        path = self._state.path
+        profile = self._state.profile_name
+        lock_cm = file_lock(path, exclusive=True)
+        # Block for the cross-process lock in a worker thread: holding the
+        # blocking acquire on the event loop would stall every other coroutine
+        # (the proxy multiplexes many MCP forwards on one loop). Release is
+        # synchronous and non-blocking (LOCK_UN / os.close), so it must NOT be
+        # offloaded — doing so could starve on a saturated executor (every
+        # worker blocked acquiring this same lock) and deadlock the release.
+        await asyncio.to_thread(lock_cm.__enter__)
+        try:
+            disk = load_credentials_file(path).get_profile(profile)
+            if disk is not None and self._already_rotated(disk, expected_stale_token):
+                # Another process refreshed while we waited — adopt its token
+                # and skip the network call. "Skip" means "adopt the on-disk
+                # result", never "leave the stale in-memory token in place".
+                self._state.credentials = disk
+                return
+            base = disk if disk is not None else self._state.credentials
+            await self._network_refresh_and_save(base, path, profile)
+        finally:
+            lock_cm.__exit__(None, None, None)
+
+    def _already_rotated(self, disk: OAuthCredentials, expected_stale_token: str | None) -> bool:
+        """Whether ``disk`` shows another process already produced a usable token."""
+        if expected_stale_token is None:
+            # Skew path: a token outside the skew window is fresh enough.
+            return not disk.is_expired(skew_seconds=REFRESH_SKEW_SEC)
+        # 401 path: a different token means someone rotated; an identical token
+        # means the rejected token is still current and we must refresh.
+        return disk.access_token != expected_stale_token
+
+    async def _network_refresh_and_save(
+        self, base: OAuthCredentials, path: Path, profile: str
+    ) -> None:
+        """Hit ``/oauth2/token`` from ``base`` and persist. Caller holds both locks."""
+        # Lazy import: ``device_flow`` may depend on this module's public types,
+        # so resolve only at refresh time to avoid a cycle at import time.
         from .device_flow import make_oauth_client, refresh_access_token
 
         async with make_oauth_client() as client:
             token = await refresh_access_token(
                 client,
-                server=self._state.credentials.server,
-                client_id=self._state.credentials.client_id,
-                refresh_token=self._state.credentials.refresh_token,
+                server=base.server,
+                client_id=base.client_id,
+                refresh_token=base.refresh_token,
             )
-        # Pass ``None`` when the server omits ``refresh_token`` so the
-        # stored token is preserved. ``TokenResponse.refresh_token``
-        # defaults to ``""`` when absent, and passing the empty string
-        # to ``with_refreshed`` would overwrite a valid stored token
-        # with an empty one — breaking every subsequent refresh.
-        self._state.credentials = self._state.credentials.with_refreshed(
+        # Pass ``None`` when the server omits ``refresh_token`` so the stored
+        # token is preserved. ``TokenResponse.refresh_token`` defaults to ``""``
+        # when absent, and passing the empty string to ``with_refreshed`` would
+        # overwrite a valid stored token with an empty one — breaking every
+        # subsequent refresh.
+        self._state.credentials = base.with_refreshed(
             access_token=token.access_token,
             refresh_token=token.refresh_token or None,
             expires_at=token.expires_at,
             scope=token.scope,
         )
-        update_profile(self._state.profile_name, self._state.credentials, self._state.path)
+        # We already hold the cross-process lock; write directly rather than via
+        # update_profile (which would re-acquire the same lock on a second fd
+        # and self-deadlock — fcntl treats independent open descriptions
+        # independently, even within one process). Re-load → set → save still
+        # preserves every other profile in the file.
+        cf = load_credentials_file(path)
+        cf.set_profile(profile, self._state.credentials)
+        save_credentials_file(cf, path)

--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -540,8 +540,13 @@ class KaguraOAuth(httpx.Auth):
         a single ``/oauth2/token`` call. Cross-process dedup is handled in
         :meth:`_refresh_locked` via the rejected-token identity check.
         """
+        # Capture the rejected token BEFORE the in-process lock: if a peer
+        # coroutine already rotated it while we waited on the lock, we must
+        # still compare against the token that actually got the 401, otherwise
+        # the rotated token (== current in-memory) would compare equal to disk
+        # and force a redundant /oauth2/token call instead of coalescing.
+        rejected_token = self._state.credentials.access_token
         async with self._state.lock:
-            rejected_token = self._state.credentials.access_token
             await self._refresh_locked(expected_stale_token=rejected_token)
 
     async def _refresh_locked(self, *, expected_stale_token: str | None = None) -> None:
@@ -564,19 +569,15 @@ class KaguraOAuth(httpx.Auth):
                 token means nobody has rotated yet, so this process must refresh
                 (a 401 is independent of ``expires_at``).
         """
-        from .._filelock import file_lock
+        from .._filelock import async_file_lock
 
         path = self._state.path
         profile = self._state.profile_name
-        lock_cm = file_lock(path, exclusive=True)
-        # Block for the cross-process lock in a worker thread: holding the
-        # blocking acquire on the event loop would stall every other coroutine
-        # (the proxy multiplexes many MCP forwards on one loop). Release is
-        # synchronous and non-blocking (LOCK_UN / os.close), so it must NOT be
-        # offloaded — doing so could starve on a saturated executor (every
-        # worker blocked acquiring this same lock) and deadlock the release.
-        await asyncio.to_thread(lock_cm.__enter__)
-        try:
+        # async_file_lock acquires the cross-process lock with non-blocking
+        # attempts on the event loop (asyncio.sleep between tries), so it never
+        # stalls the loop and is cancellation-safe — a cancellation while
+        # waiting holds nothing, and the body is released in its own finally.
+        async with async_file_lock(path, exclusive=True):
             disk = load_credentials_file(path).get_profile(profile)
             if disk is not None and self._already_rotated(disk, expected_stale_token):
                 # Another process refreshed while we waited — adopt its token
@@ -586,8 +587,6 @@ class KaguraOAuth(httpx.Auth):
                 return
             base = disk if disk is not None else self._state.credentials
             await self._network_refresh_and_save(base, path, profile)
-        finally:
-            lock_cm.__exit__(None, None, None)
 
     def _already_rotated(self, disk: OAuthCredentials, expected_stale_token: str | None) -> bool:
         """Whether ``disk`` shows another process already produced a usable token."""

--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -552,9 +552,11 @@ class KaguraOAuth(httpx.Auth):
     async def _refresh_locked(self, *, expected_stale_token: str | None = None) -> None:
         """Refresh ``/oauth2/token`` once across all processes. Caller holds the in-process lock.
 
-        The cross-process advisory lock is acquired off the event loop (in a
-        worker thread) so other coroutines — e.g. concurrent ``kagura-mcp``
-        proxy forwards — keep running while we wait. After acquiring it we
+        The cross-process advisory lock is acquired with non-blocking attempts
+        on the event loop (``asyncio.sleep`` between tries — see
+        :func:`async_file_lock`), so other coroutines — e.g. concurrent
+        ``kagura-mcp`` proxy forwards — keep running while we wait, and a
+        cancellation while waiting holds nothing. After acquiring it we
         re-read the credentials from disk and **skip the network call when
         another process already rotated the token**, so only one proxy among
         many hits ``/oauth2/token`` per cycle (dedup over the network, not just

--- a/tests/test_auth_credentials.py
+++ b/tests/test_auth_credentials.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import stat
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,6 +21,7 @@ from kagura_memory.auth.credentials import (
     CredentialsFile,
     KaguraOAuth,
     OAuthCredentials,
+    _SharedCredentialsState,
     delete_credentials_file,
     delete_profile,
     get_shared_state,
@@ -29,6 +31,13 @@ from kagura_memory.auth.credentials import (
     update_profile,
 )
 from kagura_memory.auth.device_flow import TokenResponse
+
+# The cross-process refresh-dedup tests rely on fcntl serializing two
+# independent open descriptions of the same lock file; gate them to POSIX (CI
+# runs Linux). The Windows msvcrt backend is unit-tested in test_filelock.py.
+_POSIX_ONLY_CREDS = pytest.mark.skipif(
+    sys.platform == "win32", reason="cross-process dedup test uses POSIX fcntl"
+)
 
 
 def _sample_creds(
@@ -542,6 +551,204 @@ async def test_force_refresh_refreshes_even_when_not_expired(tmp_path: Path):
         await auth.force_refresh()
 
     assert state.credentials.access_token == "forced-new"
+    assert load_credentials_file(path).get_profile().access_token == "forced-new"
+
+
+# ---------------------------------------------------------------------------
+# Cross-process refresh dedup (#158)
+#
+# These tests construct two _SharedCredentialsState objects with *separate*
+# asyncio.Locks over the SAME credentials file to simulate two processes. The
+# cross-process fcntl lock genuinely serializes them — flock treats independent
+# open descriptions independently even within one process — so the dedup logic
+# is exercised deterministically without spawning subprocesses (the real
+# cross-process *lock* itself is covered by the subprocess test in
+# tests/test_filelock.py).
+# ---------------------------------------------------------------------------
+
+
+def _independent_state(path: Path, creds: OAuthCredentials, profile: str = "default"):
+    """A state with its own asyncio.Lock — a stand-in for a separate process."""
+    return _SharedCredentialsState(
+        credentials=creds,
+        profile_name=profile,
+        path=path.resolve(),
+        lock=asyncio.Lock(),
+    )
+
+
+def _fresh_token(access_token: str) -> TokenResponse:
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token="new-rtok",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope="memory:read",
+    )
+
+
+@_POSIX_ONLY_CREDS
+@pytest.mark.asyncio
+async def test_refresh_dedup_skew_only_one_network_call(tmp_path: Path):
+    """Two 'processes' both within the skew window → exactly one /oauth2/token call.
+
+    The second to acquire the cross-process lock re-reads the freshly-rotated
+    token from disk and adopts it instead of hitting the network again.
+    """
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    near = datetime.now(UTC) + timedelta(seconds=10)  # within REFRESH_SKEW_SEC
+    cf = CredentialsFile()
+    cf.set_profile("default", _sample_creds(access_token="old", expires_at=near))
+    save_credentials_file(cf, path)
+
+    auth_a = KaguraOAuth(
+        _independent_state(path, _sample_creds(access_token="old", expires_at=near))
+    )
+    auth_b = KaguraOAuth(
+        _independent_state(path, _sample_creds(access_token="old", expires_at=near))
+    )
+
+    calls = 0
+
+    async def fake_refresh(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.02)  # hold the lock so the other waits on it
+        return _fresh_token("fresh")
+
+    with (
+        patch("kagura_memory.auth.device_flow.refresh_access_token", new=fake_refresh),
+        patch("kagura_memory.auth.device_flow.make_oauth_client", return_value=_AsyncContextStub()),
+    ):
+        await asyncio.gather(auth_a._maybe_refresh(), auth_b._maybe_refresh())
+
+    assert calls == 1, f"expected exactly one network refresh across processes, got {calls}"
+    assert auth_a._state.credentials.access_token == "fresh"
+    # The process that skipped the network still adopts the on-disk token.
+    assert auth_b._state.credentials.access_token == "fresh"
+    assert load_credentials_file(path).get_profile().access_token == "fresh"
+
+
+@_POSIX_ONLY_CREDS
+@pytest.mark.asyncio
+async def test_refresh_dedup_negative_control_without_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """With the cross-process lock disabled, both processes hit the network.
+
+    This proves the dedup in the positive test is the *lock's* doing, not an
+    artifact of the test harness (the recalled TOCTOU 3-layer pattern: a
+    positive race test needs a negative control to prove it can fail).
+    """
+    import contextlib
+
+    import kagura_memory._filelock as fl
+
+    @contextlib.contextmanager
+    def noop_lock(target, *, exclusive=True):
+        yield
+
+    monkeypatch.setattr(fl, "file_lock", noop_lock)
+
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    near = datetime.now(UTC) + timedelta(seconds=10)
+    cf = CredentialsFile()
+    cf.set_profile("default", _sample_creds(access_token="old", expires_at=near))
+    save_credentials_file(cf, path)
+
+    auth_a = KaguraOAuth(
+        _independent_state(path, _sample_creds(access_token="old", expires_at=near))
+    )
+    auth_b = KaguraOAuth(
+        _independent_state(path, _sample_creds(access_token="old", expires_at=near))
+    )
+
+    calls = 0
+
+    async def fake_refresh(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.02)
+        return _fresh_token("fresh")
+
+    with (
+        patch("kagura_memory.auth.device_flow.refresh_access_token", new=fake_refresh),
+        patch("kagura_memory.auth.device_flow.make_oauth_client", return_value=_AsyncContextStub()),
+    ):
+        await asyncio.gather(auth_a._maybe_refresh(), auth_b._maybe_refresh())
+
+    assert calls == 2, f"without the lock both processes should refresh, got {calls}"
+
+
+@_POSIX_ONLY_CREDS
+@pytest.mark.asyncio
+async def test_force_refresh_adopts_when_another_process_rotated(tmp_path: Path):
+    """401 path: if the on-disk token already differs from the rejected one, adopt + skip.
+
+    A different on-disk token means another proxy already rotated in response
+    to the same out-of-band revocation — no second /oauth2/token call needed.
+    """
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    # Disk already holds a rotated token (a peer process refreshed first).
+    cf = CredentialsFile()
+    cf.set_profile("default", _sample_creds(access_token="peer-rotated"))
+    save_credentials_file(cf, path)
+
+    # This process still holds the now-rejected token in memory.
+    auth = KaguraOAuth(_independent_state(path, _sample_creds(access_token="rejected-401")))
+
+    calls = 0
+
+    async def fake_refresh(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _fresh_token("should-not-happen")
+
+    with (
+        patch("kagura_memory.auth.device_flow.refresh_access_token", new=fake_refresh),
+        patch("kagura_memory.auth.device_flow.make_oauth_client", return_value=_AsyncContextStub()),
+    ):
+        await auth.force_refresh()
+
+    assert calls == 0, "a peer already rotated; this process must not hit the network"
+    assert auth._state.credentials.access_token == "peer-rotated"
+
+
+@_POSIX_ONLY_CREDS
+@pytest.mark.asyncio
+async def test_force_refresh_hits_network_when_token_unchanged(tmp_path: Path):
+    """401 path: an identical on-disk token means nobody rotated → this process refreshes.
+
+    Guards against the wrong predicate: an expires_at-based skip here would
+    wrongly no-op on a 401 while the rejected token is still current, looping.
+    """
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    # On-disk token is the SAME one that just got 401'd, and not near expiry.
+    cf = CredentialsFile()
+    cf.set_profile("default", _sample_creds(access_token="rejected-401"))
+    save_credentials_file(cf, path)
+
+    auth = KaguraOAuth(_independent_state(path, _sample_creds(access_token="rejected-401")))
+
+    calls = 0
+
+    async def fake_refresh(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _fresh_token("forced-new")
+
+    with (
+        patch("kagura_memory.auth.device_flow.refresh_access_token", new=fake_refresh),
+        patch("kagura_memory.auth.device_flow.make_oauth_client", return_value=_AsyncContextStub()),
+    ):
+        await auth.force_refresh()
+
+    assert calls == 1, "nobody rotated; the 401 must force a real refresh"
+    assert auth._state.credentials.access_token == "forced-new"
     assert load_credentials_file(path).get_profile().access_token == "forced-new"
 
 

--- a/tests/test_auth_credentials.py
+++ b/tests/test_auth_credentials.py
@@ -645,11 +645,11 @@ async def test_refresh_dedup_negative_control_without_lock(
 
     import kagura_memory._filelock as fl
 
-    @contextlib.contextmanager
-    def noop_lock(target, *, exclusive=True):
+    @contextlib.asynccontextmanager
+    async def noop_lock(target, *, exclusive=True):
         yield
 
-    monkeypatch.setattr(fl, "file_lock", noop_lock)
+    monkeypatch.setattr(fl, "async_file_lock", noop_lock)
 
     reset_state_cache()
     path = tmp_path / "creds.json"

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import builtins
 import sys
+import time
 from pathlib import Path
 
 import pytest
 
+import kagura_memory._filelock as fl
 from kagura_memory._filelock import _lock_path, file_lock
 
 _POSIX_ONLY = pytest.mark.skipif(
@@ -75,3 +78,145 @@ def test_file_lock_noop_when_fcntl_missing(tmp_path: Path, monkeypatch: pytest.M
         pass
     # No-op path must not have created a lock file.
     assert not (tmp_path / "credentials.json.lock").exists()
+
+
+# ---------------------------------------------------------------------------
+# Windows msvcrt backend (#158)
+#
+# msvcrt is unavailable on the Linux CI runner, so the backend logic is
+# exercised by forcing `import fcntl` to fail and injecting a fake `msvcrt`
+# module. This unit-tests the byte-range / no-shared-mode / retry-loop logic
+# without a real Windows host.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMsvcrt:
+    """Minimal stand-in for the ``msvcrt`` module's locking API."""
+
+    LK_LOCK = 1
+    LK_NBLCK = 2
+    LK_UNLCK = 0
+
+    def __init__(self, fail_nblck_times: int = 0) -> None:
+        self.calls: list[tuple[int, int]] = []
+        self._fail = fail_nblck_times
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        self.calls.append((mode, nbytes))
+        if mode == self.LK_NBLCK and self._fail > 0:
+            self._fail -= 1
+            raise OSError("Resource temporarily unavailable (simulated contention)")
+
+
+def _force_msvcrt(monkeypatch: pytest.MonkeyPatch, fake: _FakeMsvcrt) -> None:
+    """Make ``_detect_backend`` resolve to ``fake`` (no fcntl, then msvcrt)."""
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "fcntl":
+            raise ImportError("simulated no fcntl (Windows)")
+        if name == "msvcrt":
+            return fake
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_msvcrt_backend_locks_and_unlocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The msvcrt path creates the lock file and brackets the body lock→unlock."""
+    fake = _FakeMsvcrt()
+    _force_msvcrt(monkeypatch, fake)
+
+    target = tmp_path / "credentials.json"
+    with file_lock(target, exclusive=True):
+        assert (tmp_path / "credentials.json.lock").exists()
+
+    modes = [mode for mode, _ in fake.calls]
+    assert modes == [fake.LK_NBLCK, fake.LK_UNLCK]
+    assert all(nbytes == 1 for _, nbytes in fake.calls)
+
+
+def test_msvcrt_backend_treats_shared_as_exclusive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Windows has no shared mode: exclusive=False still takes an exclusive lock."""
+    fake = _FakeMsvcrt()
+    _force_msvcrt(monkeypatch, fake)
+
+    target = tmp_path / "credentials.json"
+    with file_lock(target, exclusive=False):
+        pass
+
+    # Same NBLCK acquire as the exclusive case — no shared variant exists.
+    assert fake.calls[0][0] == fake.LK_NBLCK
+
+
+def test_msvcrt_backend_retries_on_contention(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A busy lock (LK_NBLCK raising OSError) is retried until it succeeds."""
+    fake = _FakeMsvcrt(fail_nblck_times=2)
+    _force_msvcrt(monkeypatch, fake)
+    monkeypatch.setattr(fl, "_MSVCRT_RETRY_SEC", 0)  # don't actually sleep
+
+    target = tmp_path / "credentials.json"
+    with file_lock(target, exclusive=True):
+        pass
+
+    # 2 failed NBLCK attempts + 1 success + 1 UNLCK release.
+    nblck = [m for m, _ in fake.calls if m == fake.LK_NBLCK]
+    assert len(nblck) == 3
+    assert fake.calls[-1][0] == fake.LK_UNLCK
+
+
+# ---------------------------------------------------------------------------
+# Cross-process lock contention (subprocess-based, #158)
+# ---------------------------------------------------------------------------
+
+
+def _contend_worker(cred_path: str, counter_path: str, barrier, iters: int) -> None:
+    """Increment a shared counter under the file lock; lost updates fail the test."""
+    from pathlib import Path as _Path
+
+    from kagura_memory._filelock import file_lock as _file_lock
+
+    cred = _Path(cred_path)
+    counter = _Path(counter_path)
+    barrier.wait()  # release all workers simultaneously to maximize contention
+    for _ in range(iters):
+        with _file_lock(cred, exclusive=True):
+            value = int(counter.read_text() or "0")
+            time.sleep(0.001)  # widen the read-modify-write window
+            counter.write_text(str(value + 1))
+
+
+@_POSIX_ONLY
+def test_file_lock_serializes_across_processes(tmp_path: Path):
+    """N processes doing read-modify-write under the lock lose zero updates.
+
+    A deterministic count==N*iters proves cross-process mutual exclusion. The
+    matching negative control (no lock → lost updates) is the deterministic
+    in-process ``test_refresh_dedup_negative_control_without_lock`` in
+    tests/test_auth_credentials.py — a subprocess negative control would be
+    inherently racy, which we avoid (flaky tests erode trust).
+    """
+    import multiprocessing as mp
+
+    ctx = mp.get_context("fork")
+    cred = tmp_path / "credentials.json"
+    counter = tmp_path / "counter.txt"
+    counter.write_text("0")
+
+    n_procs, iters = 4, 5
+    barrier = ctx.Barrier(n_procs)
+    procs = [
+        ctx.Process(target=_contend_worker, args=(str(cred), str(counter), barrier, iters))
+        for _ in range(n_procs)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)  # hard timeout: a deadlock must fail, not hang CI
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            pytest.fail("lock-contention worker timed out — possible cross-process deadlock")
+        assert p.exitcode == 0
+
+    assert int(counter.read_text()) == n_procs * iters

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -11,8 +11,11 @@ from pathlib import Path
 
 import pytest
 
-import kagura_memory._filelock as fl
 from kagura_memory._filelock import _lock_path, async_file_lock, file_lock
+
+# Module path for monkeypatching module-level lock constants (string-target form
+# so we don't also `import ... as fl`, keeping a single import style).
+_FL = "kagura_memory._filelock"
 
 _POSIX_ONLY = pytest.mark.skipif(
     sys.platform == "win32", reason="POSIX fcntl lock; Windows is a no-op"
@@ -162,7 +165,7 @@ def test_msvcrt_backend_retries_on_contention(tmp_path: Path, monkeypatch: pytes
     """A busy lock (LK_NBLCK raising OSError) is retried until it succeeds."""
     fake = _FakeMsvcrt(fail_nblck_times=2)
     _force_msvcrt(monkeypatch, fake)
-    monkeypatch.setattr(fl, "_LOCK_RETRY_SEC", 0)  # don't actually sleep
+    monkeypatch.setattr(f"{_FL}._LOCK_RETRY_SEC", 0)  # don't actually sleep
 
     target = tmp_path / "credentials.json"
     with file_lock(target, exclusive=True):
@@ -178,8 +181,8 @@ def test_msvcrt_backend_times_out_on_stuck_lock(tmp_path: Path, monkeypatch: pyt
     """A permanently-busy msvcrt lock raises TimeoutError instead of spinning forever."""
     fake = _FakeMsvcrt(fail_nblck_times=10_000)  # never succeeds
     _force_msvcrt(monkeypatch, fake)
-    monkeypatch.setattr(fl, "_LOCK_RETRY_SEC", 0)
-    monkeypatch.setattr(fl, "_LOCK_ACQUIRE_TIMEOUT_SEC", 0.0)  # trip the deadline at once
+    monkeypatch.setattr(f"{_FL}._LOCK_RETRY_SEC", 0)
+    monkeypatch.setattr(f"{_FL}._LOCK_ACQUIRE_TIMEOUT_SEC", 0.0)  # trip the deadline at once
 
     target = tmp_path / "credentials.json"
     with pytest.raises(TimeoutError):
@@ -318,8 +321,8 @@ async def test_async_file_lock_times_out_on_held_lock(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """A contended async acquire raises TimeoutError once the deadline passes."""
-    monkeypatch.setattr(fl, "_LOCK_RETRY_SEC", 0)
-    monkeypatch.setattr(fl, "_LOCK_ACQUIRE_TIMEOUT_SEC", 0.0)  # trip immediately
+    monkeypatch.setattr(f"{_FL}._LOCK_RETRY_SEC", 0)
+    monkeypatch.setattr(f"{_FL}._LOCK_ACQUIRE_TIMEOUT_SEC", 0.0)  # trip immediately
 
     target = tmp_path / "credentials.json"
     async with async_file_lock(target, exclusive=True):

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import builtins
+import os
 import sys
 import time
 from pathlib import Path
@@ -10,7 +12,7 @@ from pathlib import Path
 import pytest
 
 import kagura_memory._filelock as fl
-from kagura_memory._filelock import _lock_path, file_lock
+from kagura_memory._filelock import _lock_path, async_file_lock, file_lock
 
 _POSIX_ONLY = pytest.mark.skipif(
     sys.platform == "win32", reason="POSIX fcntl lock; Windows is a no-op"
@@ -99,9 +101,14 @@ class _FakeMsvcrt:
 
     def __init__(self, fail_nblck_times: int = 0) -> None:
         self.calls: list[tuple[int, int]] = []
+        self.offsets: list[int] = []
         self._fail = fail_nblck_times
 
     def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        # Record the fd position so the test can assert the caller seeked to 0
+        # (real msvcrt locks a byte range relative to the current position —
+        # dropping the lseek would lock/unlock the wrong region on Windows).
+        self.offsets.append(os.lseek(fd, 0, os.SEEK_CUR))
         self.calls.append((mode, nbytes))
         if mode == self.LK_NBLCK and self._fail > 0:
             self._fail -= 1
@@ -134,6 +141,8 @@ def test_msvcrt_backend_locks_and_unlocks(tmp_path: Path, monkeypatch: pytest.Mo
     modes = [mode for mode, _ in fake.calls]
     assert modes == [fake.LK_NBLCK, fake.LK_UNLCK]
     assert all(nbytes == 1 for _, nbytes in fake.calls)
+    # Both lock and unlock must operate at offset 0 (byte 0 of the lock file).
+    assert fake.offsets == [0, 0]
 
 
 def test_msvcrt_backend_treats_shared_as_exclusive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -153,7 +162,7 @@ def test_msvcrt_backend_retries_on_contention(tmp_path: Path, monkeypatch: pytes
     """A busy lock (LK_NBLCK raising OSError) is retried until it succeeds."""
     fake = _FakeMsvcrt(fail_nblck_times=2)
     _force_msvcrt(monkeypatch, fake)
-    monkeypatch.setattr(fl, "_MSVCRT_RETRY_SEC", 0)  # don't actually sleep
+    monkeypatch.setattr(fl, "_LOCK_RETRY_SEC", 0)  # don't actually sleep
 
     target = tmp_path / "credentials.json"
     with file_lock(target, exclusive=True):
@@ -163,6 +172,19 @@ def test_msvcrt_backend_retries_on_contention(tmp_path: Path, monkeypatch: pytes
     nblck = [m for m, _ in fake.calls if m == fake.LK_NBLCK]
     assert len(nblck) == 3
     assert fake.calls[-1][0] == fake.LK_UNLCK
+
+
+def test_msvcrt_backend_times_out_on_stuck_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A permanently-busy msvcrt lock raises TimeoutError instead of spinning forever."""
+    fake = _FakeMsvcrt(fail_nblck_times=10_000)  # never succeeds
+    _force_msvcrt(monkeypatch, fake)
+    monkeypatch.setattr(fl, "_LOCK_RETRY_SEC", 0)
+    monkeypatch.setattr(fl, "_LOCK_ACQUIRE_TIMEOUT_SEC", 0.0)  # trip the deadline at once
+
+    target = tmp_path / "credentials.json"
+    with pytest.raises(TimeoutError):
+        with file_lock(target, exclusive=True):
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -186,24 +208,32 @@ def _contend_worker(cred_path: str, counter_path: str, barrier, iters: int) -> N
             counter.write_text(str(value + 1))
 
 
-@_POSIX_ONLY
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="uses mp 'fork' start method; fork is unsafe/non-default on macOS, absent on Windows",
+)
 def test_file_lock_serializes_across_processes(tmp_path: Path):
     """N processes doing read-modify-write under the lock lose zero updates.
 
     A deterministic count==N*iters proves cross-process mutual exclusion. The
-    matching negative control (no lock → lost updates) is the deterministic
-    in-process ``test_refresh_dedup_negative_control_without_lock`` in
-    tests/test_auth_credentials.py — a subprocess negative control would be
+    contention (high iteration count + a held read-modify-write window) is sized
+    so that WITHOUT the lock — e.g. if file_lock regressed to the no-op backend —
+    lost updates are near-certain and the count would fall short. The matching
+    deterministic negative control (no lock → both refresh) is the in-process
+    ``test_refresh_dedup_negative_control_without_lock`` in
+    tests/test_auth_credentials.py; a subprocess negative control would be
     inherently racy, which we avoid (flaky tests erode trust).
     """
     import multiprocessing as mp
 
+    # 'fork' lets the worker inherit the Barrier (a spawn context cannot pickle
+    # it as a plain arg). Gated to Linux above where fork is the safe default.
     ctx = mp.get_context("fork")
     cred = tmp_path / "credentials.json"
     counter = tmp_path / "counter.txt"
     counter.write_text("0")
 
-    n_procs, iters = 4, 5
+    n_procs, iters = 4, 25
     barrier = ctx.Barrier(n_procs)
     procs = [
         ctx.Process(target=_contend_worker, args=(str(cred), str(counter), barrier, iters))
@@ -220,3 +250,80 @@ def test_file_lock_serializes_across_processes(tmp_path: Path):
         assert p.exitcode == 0
 
     assert int(counter.read_text()) == n_procs * iters
+
+
+# ---------------------------------------------------------------------------
+# async_file_lock — event-loop-friendly, cancellation-safe (#158)
+# ---------------------------------------------------------------------------
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_async_file_lock_acquires_and_releases(tmp_path: Path):
+    """The async lock creates the lock file and releases so it can be re-taken."""
+    target = tmp_path / "credentials.json"
+    async with async_file_lock(target, exclusive=True):
+        assert (tmp_path / "credentials.json.lock").exists()
+    # A second acquire after release must not hang.
+    async with async_file_lock(target, exclusive=True):
+        pass
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_async_file_lock_waits_and_is_cancellation_safe(tmp_path: Path):
+    """A waiter blocked on a held lock can be cancelled WITHOUT leaking the lock.
+
+    This is the failure mode the async lock exists to prevent: offloading a
+    blocking ``__enter__`` to a worker thread would let the thread win the lock
+    after the awaiting task is cancelled, leaking it forever. Here the waiter
+    only ever awaits ``asyncio.sleep`` while not holding the lock, so cancelling
+    it holds nothing.
+    """
+    target = tmp_path / "credentials.json"
+    release = asyncio.Event()
+    acquired_b = False
+
+    async def holder() -> None:
+        async with async_file_lock(target, exclusive=True):
+            await release.wait()
+
+    async def waiter() -> None:
+        nonlocal acquired_b
+        async with async_file_lock(target, exclusive=True):
+            acquired_b = True
+
+    h = asyncio.create_task(holder())
+    await asyncio.sleep(0.05)  # let the holder acquire first
+    w = asyncio.create_task(waiter())
+    await asyncio.sleep(0.1)  # waiter polls but cannot acquire
+    assert not acquired_b, "waiter must not acquire while the holder holds the lock"
+
+    w.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await w
+
+    # If the cancelled waiter had leaked the lock, this fresh acquire would hang
+    # (and the join-free test would time out). Release the holder, then prove
+    # the lock is cleanly re-acquirable.
+    release.set()
+    await h
+    async with async_file_lock(target, exclusive=True):
+        pass
+
+
+@_POSIX_ONLY
+@pytest.mark.asyncio
+async def test_async_file_lock_times_out_on_held_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A contended async acquire raises TimeoutError once the deadline passes."""
+    monkeypatch.setattr(fl, "_LOCK_RETRY_SEC", 0)
+    monkeypatch.setattr(fl, "_LOCK_ACQUIRE_TIMEOUT_SEC", 0.0)  # trip immediately
+
+    target = tmp_path / "credentials.json"
+    async with async_file_lock(target, exclusive=True):
+        # A second acquire on a different fd of the same already-held lock.
+        with pytest.raises(TimeoutError):
+            async with async_file_lock(target, exclusive=True):
+                pass


### PR DESCRIPTION
Closes #158

## Summary
- Adds a Windows `msvcrt.locking` backend to `_filelock.file_lock`, replacing the prior non-POSIX no-op. Windows has no shared-lock mode, so `exclusive=False` is upgraded to exclusive (documented behavior difference); a bounded `LK_NBLCK` retry loop emulates `flock`'s blocking acquire.
- Implements cross-process `/oauth2/token` refresh dedup: concurrent `kagura-mcp` proxies no longer each hit the token endpoint. `KaguraOAuth` re-reads the on-disk token under a cross-process lock and skips the network call when another process already rotated it.
- Adds a new cancellation-safe `async_file_lock` (non-blocking poll on the event loop) for the coroutine refresh path; the sync `file_lock` is retained for `update_profile`/CLI.
- Subprocess cross-process lock-contention test + deterministic in-process dedup tests with a negative control + msvcrt-backend unit tests.

## Implementation notes
- **Two refresh predicates** (`_already_rotated`): the skew path skips when the on-disk token is outside the skew window; the 401 path skips only when the on-disk token *differs* from the rejected one (an identical token means nobody rotated → a real refresh must fire, else it would loop on a rejected token). The rejected token is captured *before* the in-process lock so concurrent same-process 401s coalesce.
- **Disk-token adoption**: the process that skips the network adopts the on-disk token (never leaves a stale in-memory token).
- **No self-deadlock**: while holding the cross-process lock, the refresh writes via `save_credentials_file` directly, not `update_profile` (which would re-acquire the lock on a second fd — fcntl treats independent open descriptions independently, even within one process).
- **Cancellation safety**: `async_file_lock` acquires via non-blocking attempts with `asyncio.sleep` backoff — the only `await` while not holding the lock is the sleep, so a cancellation mid-wait holds nothing (the failure mode of offloading a blocking `__enter__` to `asyncio.to_thread`). A stuck holder is bounded by a 90s acquire timeout → `TimeoutError`.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (escalated to CTO; design guidance fully implemented)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/158-feat-feat-mcp-kagura-mcp-pr-b-windows-lock-shi.gate1.md
- ~/.claude/cache/gh-issue-driven/158-feat-feat-mcp-kagura-mcp-pr-b-windows-lock-shi.gate2.md

🤖 Generated via /gh-issue-driven:ship
