### PR TITLE
ci(publish): make github-release job idempotent (race-safe)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,11 +76,23 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Create GitHub Release
+        # Idempotent + race-safe: the /release skill also creates the release
+        # (with hand-written notes) right after pushing the tag, so a plain
+        # check-then-create here can lose the race and 422 with
+        # "Release.tag_name already exists". Re-check after a failed create and
+        # treat "already exists" as success — this job only needs to GUARANTEE a
+        # release exists, not to be the one that created it.
         run: |
-          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            echo "Release ${{ github.ref_name }} already exists, skipping."
+          if gh release view "$REF" >/dev/null 2>&1; then
+            echo "Release $REF already exists, skipping."
+          elif gh release create "$REF" --generate-notes; then
+            echo "Created release $REF."
+          elif gh release view "$REF" >/dev/null 2>&1; then
+            echo "Release $REF was created concurrently; treating as success."
           else
-            gh release create "${{ github.ref_name }}" --generate-notes
+            echo "Failed to create release $REF." >&2
+            exit 1
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Makes the `github-release` job in `publish.yml` **idempotent / race-safe**.

## Problem
The `/release` skill creates the GitHub Release (with hand-written notes) immediately after pushing the tag. The workflow's `github-release` job then does a `check-then-create`: `gh release view` → else `gh release create --generate-notes`. When the workflow's `view` runs *before* the skill's manual creation lands, it takes the `else` branch and then `gh release create` fails with:

```
HTTP 422: Validation Failed
Release.tag_name already exists
```

Observed on the **v0.25.0** release (`build` + `publish-pypi` succeeded; only this redundant job went red).

## Fix
Re-check after a failed create and treat "already exists" as success — the job only needs to *guarantee* a release exists, not to be the one that created it:

```bash
if   gh release view "$REF" >/dev/null 2>&1; then echo "exists, skipping"
elif gh release create "$REF" --generate-notes; then echo "created"
elif gh release view "$REF" >/dev/null 2>&1; then echo "created concurrently; success"
else echo "failed" >&2; exit 1
fi
```

Also moves `github.ref_name` into an `env:` var (`REF`) and quotes it in the script — the recommended safe-input pattern for workflow `run:` blocks.

## Notes
- The `/release` skill's hand-written notes remain the winner; the workflow stays as the fallback creator for tags pushed outside the skill.
- No behavior change to `build` / `publish-pypi` / `publish-testpypi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
