### PR TITLE
feat(cli): kagura doctor LLM-provider key/model diagnostics (#163)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ uv run pyright src/              # Type check
 - **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs
-- CLI: `kagura auth login/refresh/status`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura context search-config`, `kagura sleep history/report/rollback`
+- CLI: `kagura auth login/refresh/status`, `kagura setup claude`, `kagura doctor` (setup/auth/MCP/connectivity + LLM-provider key/model diagnostics), `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura context search-config`, `kagura sleep history/report/rollback`
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,41 @@ kagura files delete <file-id>
 
 # Config
 kagura config show
+
+# Diagnose local setup, auth, MCP wiring, and connectivity
+kagura doctor
+kagura doctor --json          # machine-readable report
+```
+
+### Diagnostics (`kagura doctor`)
+
+`kagura doctor` runs a batch of read-only checks and prints a `PASS`/`WARN`/`FAIL`/`INFO`
+line per finding. It exits non-zero only when a `FAIL` is present, so it is safe to run in
+CI. Sections covered:
+
+- **auth** — which credential source resolves (env `KAGURA_API_KEY`, `.kagura.json`, or an
+  OAuth profile), API-key shape, and OAuth token expiry. Shadowing warnings when more than
+  one source is configured.
+- **mcp** — `.mcp.json` mode (stdio / url / legacy static-token) and whether `kagura-mcp`
+  is on `PATH`.
+- **server** — reachability and minimum-version check (skipped on an insecure MCP URL).
+- **extras** — which optional ingestion dependencies are installed.
+- **security** — flags a `litellm` version in the known-bad supply-chain range.
+- **providers** — reports which optional LLM-provider keys are set (`GEMINI_API_KEY`,
+  `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_API_KEY`) and **warns** when a configured
+  default model targets a provider whose key is missing (e.g. the agent default
+  `gpt-5.4-nano` with no `OPENAI_API_KEY`, or audio transcription `gemini/gemini-2.5-flash`
+  with no `GEMINI_API_KEY`). These keys are opt-in per feature — a memory/recall-only user
+  needs none, so absence is never a `FAIL`. Key **values** are never read into the report
+  (only env-var names), and no network calls are made to validate them.
+
+```bash
+$ kagura doctor
+PASS Effective Auth: OAuth profile
+PASS MCP Mode: stdio
+INFO LLM provider keys set: none
+WARN agent model gpt-5.4-nano targets openai but OPENAI_API_KEY is not set
+WARN audio ingest model gemini/gemini-2.5-flash targets gemini but GEMINI_API_KEY is not set
 ```
 
 ### Document ingestion (`kagura ingest`)

--- a/README.md
+++ b/README.md
@@ -366,12 +366,13 @@ CI. Sections covered:
 - **extras** — which optional ingestion dependencies are installed.
 - **security** — flags a `litellm` version in the known-bad supply-chain range.
 - **providers** — reports which optional LLM-provider keys are set (`GEMINI_API_KEY`,
-  `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_API_KEY`) and **warns** when a configured
-  default model targets a provider whose key is missing (e.g. the agent default
-  `gpt-5.4-nano` with no `OPENAI_API_KEY`, or audio transcription `gemini/gemini-2.5-flash`
-  with no `GEMINI_API_KEY`). These keys are opt-in per feature — a memory/recall-only user
-  needs none, so absence is never a `FAIL`. Key **values** are never read into the report
-  (only env-var names), and no network calls are made to validate them.
+  `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_API_KEY`) and **warns** when a default model
+  targets a provider whose key is missing: the agent model (`gpt-5.4-nano` unless overridden
+  via `.kagura.json` / `KAGURA_MODEL`) with no `OPENAI_API_KEY`, or the fixed
+  audio-transcription model `gemini/gemini-2.5-flash` with no `GEMINI_API_KEY`. These keys are
+  opt-in per feature — a memory/recall-only user needs none, so absence is never a `FAIL`.
+  Key **values** are never read into the report (only env-var names), and no network calls are
+  made to validate them.
 
 ```bash
 $ kagura doctor

--- a/README.md
+++ b/README.md
@@ -367,12 +367,15 @@ CI. Sections covered:
 - **security** — flags a `litellm` version in the known-bad supply-chain range.
 - **providers** — reports which optional LLM-provider keys are set (`GEMINI_API_KEY`,
   `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_API_KEY`) and **warns** when a default model
-  targets a provider whose key is missing: the agent model (`gpt-5.4-nano` unless overridden
-  via `.kagura.json` / `KAGURA_MODEL`) with no `OPENAI_API_KEY`, or the fixed
-  audio-transcription model `gemini/gemini-2.5-flash` with no `GEMINI_API_KEY`. These keys are
-  opt-in per feature — a memory/recall-only user needs none, so absence is never a `FAIL`.
-  Key **values** are never read into the report (only env-var names), and no network calls are
-  made to validate them.
+  for any LLM-backed feature targets a provider whose credential is missing. Covered features
+  and their default models: agent (`gpt-5.4-nano`, OpenAI — unless overridden via
+  `.kagura.json` / `KAGURA_MODEL`), ingest text (`claude-sonnet-4-6`, Anthropic), ingest
+  vision (`gemini/gemini-2.5-flash`, Gemini), and audio transcription
+  (`gemini/gemini-2.5-flash`, Gemini). The agent also accepts an `llm_api_key` set in
+  `.kagura.json`, which counts as a valid credential. These keys are opt-in per feature — a
+  memory/recall-only user needs none, so absence is never a `FAIL`; Ollama models never warn
+  (no key required). Key **values** are never read into the report (only env-var names), and
+  no network calls are made to validate them.
 
 ```bash
 $ kagura doctor

--- a/src/kagura_memory/doctor.py
+++ b/src/kagura_memory/doctor.py
@@ -47,11 +47,17 @@ _PROVIDER_ENV_KEYS: dict[str, str] = {
 }
 
 # Default models for the optional LLM-backed features, mirrored from their
-# sources of truth: agent.py / config.py (`gpt-5.4-nano`) and
-# ingest/_audio.py (`gemini/gemini-2.5-flash`). doctor stays import-light and
-# deliberately does NOT import the ingest package (which pulls optional
-# extras), so these are mirrored here rather than imported.
+# sources of truth. doctor stays import-light and deliberately does NOT import
+# the ingest package (importing it runs ingest/__init__.py, which pulls the
+# optional ingest extras onto every `kagura` invocation), so these are mirrored
+# here rather than imported. Keep in sync with:
+#   - agent:         agent.py / config.py                 (`gpt-5.4-nano`)
+#   - ingest text:   ingest/providers/claude.py           (default text-provider=claude)
+#   - ingest vision: ingest/providers/gemini.py           (default vision-provider=gemini)
+#   - ingest audio:  ingest/_audio.py
 _DEFAULT_AGENT_MODEL = "gpt-5.4-nano"
+_DEFAULT_INGEST_TEXT_MODEL = "claude-sonnet-4-6"
+_DEFAULT_INGEST_VISION_MODEL = "gemini/gemini-2.5-flash"
 _DEFAULT_AUDIO_MODEL = "gemini/gemini-2.5-flash"
 
 
@@ -174,9 +180,11 @@ def _provider_for_model(model: str) -> str | None:
     """
 
     name = model.strip().lower()
+    if not name:
+        return None
     if name.startswith(("ollama/", "ollama_chat/")):
         return "ollama"
-    if name.startswith("gemini/"):
+    if name.startswith(("gemini/", "gemini-")):
         return "gemini"
     if name.startswith(("anthropic/", "claude")):
         return "anthropic"
@@ -204,19 +212,27 @@ def _check_provider_keys() -> DoctorCheck:
 
 
 def _check_model_provider_match(config: dict[str, Any]) -> list[DoctorCheck]:
-    """Warn when a configured default model targets a provider with no key.
+    """Warn when a default model targets a provider with no usable credential.
 
-    Informational only — no network calls are made to validate a key. Ollama
-    needs no key, so it never warns.
+    Covers every optional LLM-backed feature: the agent model and the three
+    ingest defaults (text=claude, vision=gemini, audio=gemini). Informational
+    only — no network calls are made to validate a key. Ollama needs no key, so
+    it never warns. The agent additionally accepts an ``llm_api_key`` from
+    ``.kagura.json`` (forwarded to litellm in cli.py / agent.py), so that counts
+    as a credential alongside the provider env var.
     """
 
-    configured: list[tuple[str, str]] = [
-        ("agent", config.get("model") or _DEFAULT_AGENT_MODEL),
-        ("audio ingest", _DEFAULT_AUDIO_MODEL),
+    agent_has_config_key = bool(config.get("llm_api_key"))
+    # (feature label, model, whether .kagura.json carries a usable llm_api_key)
+    configured: list[tuple[str, str, bool]] = [
+        ("agent", config.get("model") or _DEFAULT_AGENT_MODEL, agent_has_config_key),
+        ("ingest text", _DEFAULT_INGEST_TEXT_MODEL, False),
+        ("ingest vision", _DEFAULT_INGEST_VISION_MODEL, False),
+        ("ingest audio", _DEFAULT_AUDIO_MODEL, False),
     ]
 
     checks: list[DoctorCheck] = []
-    for feature, model in configured:
+    for feature, model, has_config_key in configured:
         details: dict[str, Any] = {"feature": feature, "model": model}
         provider = _provider_for_model(model)
         if provider is None:
@@ -233,6 +249,10 @@ def _check_model_provider_match(config: dict[str, Any]) -> list[DoctorCheck]:
                 if os.getenv(env_var):
                     status = "pass"
                     message = f"{feature} model {model}: {env_var} is set"
+                elif has_config_key:
+                    status = "pass"
+                    message = f"{feature} model {model}: credential via .kagura.json llm_api_key"
+                    details["credential_source"] = "config"
                 else:
                     status = "warn"
                     message = f"{feature} model {model} targets {provider} but {env_var} is not set"

--- a/src/kagura_memory/doctor.py
+++ b/src/kagura_memory/doctor.py
@@ -36,6 +36,24 @@ _OPTIONAL_INGESTION_DEPENDENCIES: dict[str, str] = {
     "ingest-browser": "playwright",
 }
 
+# Environment variable that litellm reads for each LLM provider the SDK can
+# route to. Used only by the optional ingest / agent features; a memory- or
+# recall-only user needs none of these.
+_PROVIDER_ENV_KEYS: dict[str, str] = {
+    "gemini": "GEMINI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "ollama": "OLLAMA_API_KEY",
+}
+
+# Default models for the optional LLM-backed features, mirrored from their
+# sources of truth: agent.py / config.py (`gpt-5.4-nano`) and
+# ingest/_audio.py (`gemini/gemini-2.5-flash`). doctor stays import-light and
+# deliberately does NOT import the ingest package (which pulls optional
+# extras), so these are mirrored here rather than imported.
+_DEFAULT_AGENT_MODEL = "gpt-5.4-nano"
+_DEFAULT_AUDIO_MODEL = "gemini/gemini-2.5-flash"
+
 
 @dataclass
 class DoctorCheck:
@@ -146,6 +164,83 @@ def _check_litellm() -> DoctorCheck:
         message=f"LiteLLM version: {version}",
         details={"version": version},
     )
+
+
+def _provider_for_model(model: str) -> str | None:
+    """Map a litellm model string to a known provider name.
+
+    Returns one of the keys in :data:`_PROVIDER_ENV_KEYS`, or ``None`` when the
+    provider cannot be determined from the model string (key check is skipped).
+    """
+
+    name = model.strip().lower()
+    if name.startswith(("ollama/", "ollama_chat/")):
+        return "ollama"
+    if name.startswith("gemini/"):
+        return "gemini"
+    if name.startswith(("anthropic/", "claude")):
+        return "anthropic"
+    if name.startswith(("openai/", "gpt", "o1", "o3", "o4")):
+        return "openai"
+    return None
+
+
+def _check_provider_keys() -> DoctorCheck:
+    """Report which optional LLM-provider keys are present (informational).
+
+    Only the env-var names are reported — values are never read into the
+    message, so there is nothing to leak. Absence is never a failure: these
+    keys are opt-in per feature.
+    """
+
+    present = [env for env in _PROVIDER_ENV_KEYS.values() if os.getenv(env)]
+    absent = [env for env in _PROVIDER_ENV_KEYS.values() if env not in present]
+    return DoctorCheck(
+        section="providers",
+        status="info",
+        message="LLM provider keys set: " + (", ".join(present) if present else "none"),
+        details={"present": present, "absent": absent},
+    )
+
+
+def _check_model_provider_match(config: dict[str, Any]) -> list[DoctorCheck]:
+    """Warn when a configured default model targets a provider with no key.
+
+    Informational only — no network calls are made to validate a key. Ollama
+    needs no key, so it never warns.
+    """
+
+    configured: list[tuple[str, str]] = [
+        ("agent", config.get("model") or _DEFAULT_AGENT_MODEL),
+        ("audio ingest", _DEFAULT_AUDIO_MODEL),
+    ]
+
+    checks: list[DoctorCheck] = []
+    for feature, model in configured:
+        details: dict[str, Any] = {"feature": feature, "model": model}
+        provider = _provider_for_model(model)
+        if provider is None:
+            status: DoctorStatus = "info"
+            message = f"{feature} model {model}: provider not recognized; key check skipped"
+        else:
+            env_var = _PROVIDER_ENV_KEYS[provider]
+            details["provider"] = provider
+            if provider == "ollama":
+                status = "info"
+                message = f"{feature} model {model} targets Ollama (no API key required)"
+            else:
+                details["env"] = env_var
+                if os.getenv(env_var):
+                    status = "pass"
+                    message = f"{feature} model {model}: {env_var} is set"
+                else:
+                    status = "warn"
+                    message = f"{feature} model {model} targets {provider} but {env_var} is not set"
+        checks.append(
+            DoctorCheck(section="providers", status=status, message=message, details=details)
+        )
+
+    return checks
 
 
 def _check_auth(
@@ -511,6 +606,8 @@ def run_doctor(*, project_dir: Path | None = None, profile: str | None = None) -
     checks.extend(_check_mcp(cwd))
     checks.extend(_check_optional_dependencies())
     checks.append(_check_litellm())
+    checks.append(_check_provider_keys())
+    checks.extend(_check_model_provider_match(config))
 
     if resolved is not None:
         https_check = _check_https(resolved.mcp_url)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -644,21 +644,51 @@ def test_model_provider_match_warns_on_missing_audio_key():
 
     checks = _check_model_provider_match({})
 
-    audio = next(c for c in checks if c.details.get("feature") == "audio ingest")
+    audio = next(c for c in checks if c.details.get("feature") == "ingest audio")
     assert audio.status == "warn"
     assert audio.details["provider"] == "gemini"
     assert "GEMINI_API_KEY" in audio.message
 
 
+def test_model_provider_match_covers_agent_and_ingest_features():
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({})
+    by_feature = {c.details["feature"]: c for c in checks}
+
+    assert set(by_feature) == {"agent", "ingest text", "ingest vision", "ingest audio"}
+    # ingest text defaults to the claude provider, vision/audio to gemini.
+    assert by_feature["ingest text"].details["provider"] == "anthropic"
+    assert by_feature["ingest vision"].details["provider"] == "gemini"
+    assert by_feature["ingest audio"].details["provider"] == "gemini"
+
+
 def test_model_provider_match_passes_when_keys_present(monkeypatch):
     from kagura_memory.doctor import _check_model_provider_match
 
+    # All four features across openai (agent), anthropic (text), gemini (vision/audio).
     monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-x")
     monkeypatch.setenv("GEMINI_API_KEY", "gem-x")
 
     checks = _check_model_provider_match({})
 
     assert all(c.status == "pass" for c in checks)
+
+
+def test_model_provider_match_accepts_config_llm_api_key():
+    """A `.kagura.json` llm_api_key satisfies the agent credential (no env var)."""
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({"llm_api_key": "sk-from-config"})
+
+    agent = next(c for c in checks if c.details.get("feature") == "agent")
+    assert agent.status == "pass"
+    assert agent.details["credential_source"] == "config"
+    assert "llm_api_key" in agent.message
+    # config llm_api_key is agent-only; ingest features still warn without env keys.
+    text = next(c for c in checks if c.details.get("feature") == "ingest text")
+    assert text.status == "warn"
 
 
 def test_model_provider_match_respects_configured_model():

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -28,6 +28,14 @@ def _isolate_doctor_env(monkeypatch, tmp_path):
     monkeypatch.delenv("KAGURA_API_KEY", raising=False)
     monkeypatch.delenv("KAGURA_PROFILE", raising=False)
     monkeypatch.delenv("KAGURA_MCP_URL", raising=False)
+    monkeypatch.delenv("KAGURA_MODEL", raising=False)
+    for _provider_env in (
+        "GEMINI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "OLLAMA_API_KEY",
+    ):
+        monkeypatch.delenv(_provider_env, raising=False)
     yield
     reset_state_cache()
 
@@ -564,3 +572,142 @@ def test_doctor_cli_passes_profile(monkeypatch):
 
     assert result.exit_code == 0
     assert seen["profile"] == "dev"
+
+
+# ---------------------------------------------------------------------------
+# LLM-provider diagnostics (#163)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("gpt-5.4-nano", "openai"),
+        ("openai/gpt-4o", "openai"),
+        ("o3-mini", "openai"),
+        ("gemini/gemini-2.5-flash", "gemini"),
+        ("claude-haiku-4-5-20251001", "anthropic"),
+        ("anthropic/claude-3", "anthropic"),
+        ("ollama/qwen3:30b", "ollama"),
+        ("ollama_chat/qwen3:30b", "ollama"),
+        ("some-unknown-model", None),
+    ],
+)
+def test_provider_for_model_mapping(model, expected):
+    from kagura_memory.doctor import _provider_for_model
+
+    assert _provider_for_model(model) == expected
+
+
+def test_check_provider_keys_reports_none_when_unset():
+    from kagura_memory.doctor import _check_provider_keys
+
+    check = _check_provider_keys()
+
+    assert check.section == "providers"
+    assert check.status == "info"
+    assert check.message == "LLM provider keys set: none"
+    assert check.details["present"] == []
+    assert "OPENAI_API_KEY" in check.details["absent"]
+
+
+def test_check_provider_keys_lists_only_set_keys(monkeypatch):
+    from kagura_memory.doctor import _check_provider_keys
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-value")
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-secret-value")
+
+    check = _check_provider_keys()
+
+    assert check.status == "info"
+    assert "OPENAI_API_KEY" in check.details["present"]
+    assert "GEMINI_API_KEY" in check.details["present"]
+    assert "ANTHROPIC_API_KEY" in check.details["absent"]
+    # Values are never read into the report — only env-var names.
+    assert "sk-secret-value" not in check.message
+    assert "gem-secret-value" not in check.message
+
+
+def test_model_provider_match_warns_on_missing_agent_key():
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({})
+
+    agent = next(c for c in checks if c.details.get("feature") == "agent")
+    assert agent.status == "warn"
+    assert agent.details["provider"] == "openai"
+    assert "OPENAI_API_KEY" in agent.message
+
+
+def test_model_provider_match_warns_on_missing_audio_key():
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({})
+
+    audio = next(c for c in checks if c.details.get("feature") == "audio ingest")
+    assert audio.status == "warn"
+    assert audio.details["provider"] == "gemini"
+    assert "GEMINI_API_KEY" in audio.message
+
+
+def test_model_provider_match_passes_when_keys_present(monkeypatch):
+    from kagura_memory.doctor import _check_model_provider_match
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-x")
+
+    checks = _check_model_provider_match({})
+
+    assert all(c.status == "pass" for c in checks)
+
+
+def test_model_provider_match_respects_configured_model():
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({"model": "gemini/gemini-2.5-pro"})
+
+    agent = next(c for c in checks if c.details.get("feature") == "agent")
+    assert agent.status == "warn"
+    assert agent.details["provider"] == "gemini"
+    assert "gemini/gemini-2.5-pro" in agent.message
+
+
+def test_model_provider_match_ollama_never_warns():
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({"model": "ollama/qwen3:30b"})
+
+    agent = next(c for c in checks if c.details.get("feature") == "agent")
+    assert agent.status == "info"
+    assert "no API key required" in agent.message
+
+
+def test_model_provider_match_unknown_provider_skips_key_check():
+    from kagura_memory.doctor import _check_model_provider_match
+
+    checks = _check_model_provider_match({"model": "mystery-model-v9"})
+
+    agent = next(c for c in checks if c.details.get("feature") == "agent")
+    assert agent.status == "info"
+    assert "provider not recognized" in agent.message
+
+
+def test_doctor_never_fails_on_missing_provider_keys(monkeypatch):
+    """Missing provider keys must never raise the exit code (warn-only)."""
+    creds_file = CredentialsFile()
+    resolved = _StaticAuth(
+        api_key="kagura_12345678abcdef",
+        mcp_url="https://example.com/mcp",
+        source="env",
+    )
+    _patch_common_doctor_surface(monkeypatch, resolved=resolved, creds_file=creds_file)
+    monkeypatch.setenv("KAGURA_API_KEY", "kagura_12345678abcdef")
+    _patch_server(monkeypatch)
+
+    from kagura_memory.doctor import run_doctor
+
+    report = run_doctor()
+
+    assert report.exit_code == 0
+    assert any(c.section == "providers" and c.status == "warn" for c in report.checks)
+    assert report.section_statuses["providers"] == "warn"


### PR DESCRIPTION
Closes #163

## Summary
- Add a `providers` section to `kagura doctor` (follow-up to #162) reporting which optional LLM-provider keys are set (`GEMINI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OLLAMA_API_KEY`) — env-var names only, values never read; absence is never a failure (opt-in per feature).
- Warn when a default model for **any LLM-backed feature** targets a provider whose credential is missing, covering all four defaults that match the real ingest CLI defaults (text=claude, vision=gemini):
  - agent — `gpt-5.4-nano` (OpenAI), overridable via `.kagura.json` / `KAGURA_MODEL`
  - ingest text — `claude-sonnet-4-6` (Anthropic)
  - ingest vision — `gemini/gemini-2.5-flash` (Gemini)
  - audio transcription — `gemini/gemini-2.5-flash` (Gemini)
- Recognize the agent's `.kagura.json` `llm_api_key` as a valid credential (cli.py / agent.py forward it to litellm) — avoids a false `WARN` for config-key users.
- Ollama needs no key; unrecognized providers skip the check. Informational only — no network calls.
- Document `kagura doctor` in the README (new "Diagnostics" subsection — the command was undocumented even after #162) and list it in the CLAUDE.md CLI surface.

## Implementation notes
- New helpers in `src/kagura_memory/doctor.py`: `_provider_for_model` (litellm model-string → provider via prefix, safe `None` fallthrough), `_check_provider_keys` (single `info` summary, names only), `_check_model_provider_match` (per-feature pass/warn/info, honoring env var **or** config `llm_api_key` for the agent).
- **Import-light by design**: `doctor.py` is loaded by `cli.py` on every `kagura` invocation, so it deliberately does *not* import the `ingest` package (which would pull the ingest stack + optional extras onto the CLI import path). The four default-model constants are mirrored locally, with a comment pinning each to its source of truth. The prefix matcher likewise avoids a hard `litellm` dependency (`doctor` already tolerates litellm being absent).
- Tests follow #162's isolation pattern; the autouse fixture additionally clears the four provider env vars + `KAGURA_MODEL`. Coverage: parametrized provider mapping, key presence, all four feature branches, config-`llm_api_key` credential path, and a `run_doctor` integration test asserting warnings never raise the exit code.

## Credit
This PR absorbs the broader-coverage and `llm_api_key` credential ideas from the parallel #166 by @Akarsh-2004 (co-authored), implemented here on top of the import-light + documented base so a single PR can supersede both.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green · qa-lead: green · cto: green
- /code-review: 1 doc-accuracy fix applied; headline correctness candidate refuted on verification (doctor faithfully mirrors `cli.py` agent-model resolution)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
