### PR TITLE
feat(cli): expose source_uri/source_type/linked_* flags on remember (#167)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -232,15 +232,45 @@ def doctor(profile, json_output):
 @click.option("--type", "-t", "memory_type", default="note", help="Memory type")
 @click.option("--importance", "-i", type=float, default=0.5, help="Importance 0.0-1.0")
 @click.option("--tags", help="Comma-separated tags (e.g., 'python,fastapi')")
-def remember(context_id, summary, content, memory_type, importance, tags):
+@click.option(
+    "--source-uri",
+    help="Origin URI (e.g., file:///path/to/note.md, vault://my-vault/note)",
+)
+@click.option(
+    "--source-type",
+    type=click.Choice(["file", "url", "vault", "api", "manual"], case_sensitive=False),
+    default=None,
+    help="Origin classification. Opt-in: omitted means no provenance is stamped.",
+)
+@click.option(
+    "--linked-memory-ids",
+    help="Comma-separated memory UUIDs to link via declared_link edges",
+)
+@click.option(
+    "--linked-source-uris",
+    help="Comma-separated source URIs to resolve to memories and link",
+)
+def remember(
+    context_id,
+    summary,
+    content,
+    memory_type,
+    importance,
+    tags,
+    source_uri,
+    source_type,
+    linked_memory_ids,
+    linked_source_uris,
+):
     """
     Store a memory directly (without AI analysis).
 
     Examples:
       kagura remember -s "FastAPI DI pattern" --content "Use Depends()..."
       kagura remember -c dev -s "OAuth2 setup" --content "..." --tags "auth,oauth"
+      kagura remember -s "Spec" --content "$(cat spec.md)" \\
+        --source-uri file:///spec.md --source-type file
     """
-    tag_list = _parse_tags(tags)
 
     async def op(client: KaguraClient, ctx: str) -> dict[str, Any]:
         return await client.remember(
@@ -249,7 +279,11 @@ def remember(context_id, summary, content, memory_type, importance, tags):
             content=content,
             type=memory_type,
             importance=importance,
-            tags=tag_list,
+            tags=_parse_tags(tags),
+            source_uri=source_uri,
+            source_type=source_type,
+            linked_memory_ids=_parse_tags(linked_memory_ids),
+            linked_source_uris=_parse_tags(linked_source_uris),
         )
 
     _run_client_command(op, context_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,6 +519,131 @@ def test_remember_with_empty_tags(mock_client_cls, mock_config):
     assert call_kwargs[1].get("tags") is None or call_kwargs[1].get("tags") == []
 
 
+def _remember_mock_client(mock_client_cls):
+    """Wire a mock KaguraClient whose ``remember`` returns a memory id."""
+    mock_client = AsyncMock()
+    mock_client.remember.return_value = {"memory_id": "m1"}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = mock_client
+    return mock_client
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_remember_passes_source_uri_and_type(mock_client_cls, mock_config):
+    """remember should forward --source-uri / --source-type to the client."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+    mock_client = _remember_mock_client(mock_client_cls)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "remember",
+            "-s",
+            "test",
+            "--content",
+            "data",
+            "--source-uri",
+            "file:///foo.md",
+            "--source-type",
+            "file",
+        ],
+    )
+    assert result.exit_code == 0
+    kwargs = mock_client.remember.call_args[1]
+    assert kwargs["source_uri"] == "file:///foo.md"
+    assert kwargs["source_type"] == "file"
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_remember_parses_linked_memory_ids_with_whitespace(mock_client_cls, mock_config):
+    """--linked-memory-ids should split on comma and strip whitespace."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+    mock_client = _remember_mock_client(mock_client_cls)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "remember",
+            "-s",
+            "test",
+            "--content",
+            "data",
+            "--linked-memory-ids",
+            "uuid-1, uuid-2 , uuid-3",
+        ],
+    )
+    assert result.exit_code == 0
+    kwargs = mock_client.remember.call_args[1]
+    assert kwargs["linked_memory_ids"] == ["uuid-1", "uuid-2", "uuid-3"]
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_remember_parses_linked_source_uris(mock_client_cls, mock_config):
+    """--linked-source-uris should split on comma into a list."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+    mock_client = _remember_mock_client(mock_client_cls)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "remember",
+            "-s",
+            "test",
+            "--content",
+            "data",
+            "--linked-source-uris",
+            "file:///a.md,vault://v/b",
+        ],
+    )
+    assert result.exit_code == 0
+    kwargs = mock_client.remember.call_args[1]
+    assert kwargs["linked_source_uris"] == ["file:///a.md", "vault://v/b"]
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+def test_remember_omits_provenance_when_not_given(mock_client_cls, mock_config):
+    """Without provenance flags, remember must not stamp source_type/uri/links.
+
+    Guards against a silent behavior change: a plain ``kagura remember`` should
+    pass None for these so the server stores no misleading provenance.
+    """
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": "ctx",
+    }
+    mock_client = _remember_mock_client(mock_client_cls)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["remember", "-s", "test", "--content", "data"])
+    assert result.exit_code == 0
+    kwargs = mock_client.remember.call_args[1]
+    assert kwargs["source_uri"] is None
+    assert kwargs["source_type"] is None
+    assert kwargs["linked_memory_ids"] is None
+    assert kwargs["linked_source_uris"] is None
+
+
 @patch("kagura_memory.cli.load_config")
 @patch("kagura_memory.cli.ResourceClient")
 def test_resource_stats(mock_rc_cls, mock_config):


### PR DESCRIPTION
Closes #167.

## What

`kagura remember` now surfaces the provenance and edge fields that
`client.remember()` and the MCP tool already accept but the CLI did not:

| Option | Maps to |
|--------|---------|
| `--source-uri` | `source_uri` |
| `--source-type [file\|url\|vault\|api\|manual]` | `source_type` |
| `--linked-memory-ids` (comma-separated) | `linked_memory_ids` |
| `--linked-source-uris` (comma-separated) | `linked_source_uris` |

This closes the UX gap where `kagura remember --content "$(cat file.md)"`
produced a memory with no provenance and no edges (empty WebUI References tab).

## Design note

`--source-type` is **opt-in** (default `None`), not the issue's proposed
`manual` default. Always stamping `manual` would misrepresent provenance for
content piped from files and is a silent behavior change for every existing
`kagura remember` call. All acceptance-criteria examples pass `--source-type`
explicitly, so they are unaffected. A regression test
(`test_remember_omits_provenance_when_not_given`) pins the opt-in contract.

The comma-separated linked-* lists reuse `_parse_tags` for whitespace-tolerant
parsing (strips, drops empties, returns `None` when empty).

## Tests (TDD)

Written test-first (RED → GREEN):
- `test_remember_passes_source_uri_and_type`
- `test_remember_parses_linked_memory_ids_with_whitespace`
- `test_remember_parses_linked_source_uris`
- `test_remember_omits_provenance_when_not_given`

All `test_cli.py` (67) pass; ruff + pyright clean. Reviewed via `/code-review`
(haiku): no correctness findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)