### PR TITLE
feat(cli): add --remember to files upload for linked summary memory (#168)

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1790,15 +1790,15 @@ async def _remember_file_object(
     the summary defaults to the filename, which keeps this path usable for
     binaries and in environments without LLM credentials.
 
-    Built like :func:`_run_client_command`: passing ``api_key=None`` lets
-    ``KaguraClient`` run its own credential chain (env > OAuth profile >
-    .kagura.json), so OAuth-only users are handled correctly.
+    ``KaguraClient()`` is constructed with no arguments on purpose: it then
+    runs the exact same ``_resolve_auth`` chain (env > OAuth profile >
+    .kagura.json) that ``_run_files_command`` used for the upload, so the
+    memory write shares the identity that owns the resolved workspace ``ctx``.
+    Passing config-derived ``api_key``/``mcp_url`` would force the "explicit"
+    branch and could diverge from the upload's source for users with
+    credentials in more than one place (cross-workspace 403).
     """
-    config = load_config()
-    client = KaguraClient(
-        api_key=config.get("api_key") or None,
-        mcp_url=config.get("mcp_url") or None,
-    )
+    client = KaguraClient()
     content = (
         f"Uploaded file `{file_obj.filename}` "
         f"({file_obj.size_bytes} bytes, {file_obj.content_type}). "

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -23,7 +23,7 @@ from .doctor import run_doctor
 from .exceptions import _exc_message
 from .files_client import FilesClient
 from .logger import VerboseLogger
-from .models import Message, ProcessResult, ResourceEventRequest, Session
+from .models import FileObject, Message, ProcessResult, ResourceEventRequest, Session
 from .resource_client import ResourceClient
 from .setup_claude import run_setup_claude
 
@@ -1773,10 +1773,86 @@ def files():
     pass
 
 
+async def _remember_file_object(
+    ctx: str,
+    path: Path,
+    file_obj: FileObject,
+    summary: str | None,
+    memory_type: str,
+    importance: float,
+    tags: str | None,
+) -> dict[str, Any]:
+    """Create a summary memory linked to an uploaded file_object.
+
+    The memory carries ``source_uri``/``source_type`` provenance plus a
+    ``details.file_id`` back-reference — the same mechanism ``kagura ingest``
+    uses so callers can resolve memory → original bytes. No LLM is invoked;
+    the summary defaults to the filename, which keeps this path usable for
+    binaries and in environments without LLM credentials.
+
+    Built like :func:`_run_client_command`: passing ``api_key=None`` lets
+    ``KaguraClient`` run its own credential chain (env > OAuth profile >
+    .kagura.json), so OAuth-only users are handled correctly.
+    """
+    config = load_config()
+    client = KaguraClient(
+        api_key=config.get("api_key") or None,
+        mcp_url=config.get("mcp_url") or None,
+    )
+    content = (
+        f"Uploaded file `{file_obj.filename}` "
+        f"({file_obj.size_bytes} bytes, {file_obj.content_type}). "
+        f"Stored as file_object {file_obj.id}."
+    )
+    async with client:
+        return await client.remember(
+            context_id=ctx,
+            summary=summary or f"File: {file_obj.filename}",
+            content=content,
+            type=memory_type,
+            importance=importance,
+            tags=_parse_tags(tags),
+            source_uri=path.resolve().as_uri(),
+            source_type="file",
+            details={
+                "file_id": file_obj.id,
+                "sha256": file_obj.sha256,
+                "size_bytes": file_obj.size_bytes,
+                "content_type": file_obj.content_type,
+            },
+        )
+
+
 @files.command(name="upload")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
 @click.option("--context-id", "-c", help="Target context (workspace) UUID")
 @click.option("--content-type", "-t", help="MIME type override (default: sniffed)")
+@click.option(
+    "--remember",
+    is_flag=True,
+    default=False,
+    help="Also create a summary memory linked to the uploaded file_object (no LLM).",
+)
+@click.option(
+    "--summary",
+    default=None,
+    help="Summary for the --remember memory (default: derived from filename).",
+)
+@click.option(
+    "--type",
+    "memory_type",
+    default="note",
+    show_default=True,
+    help="Memory type for the --remember memory.",
+)
+@click.option(
+    "--importance",
+    type=click.FloatRange(0.0, 1.0),
+    default=0.5,
+    show_default=True,
+    help="Importance 0.0-1.0 for the --remember memory.",
+)
+@click.option("--tags", default=None, help="Comma-separated tags for the --remember memory.")
 @click.option(
     "--verbose",
     "-v",
@@ -1796,25 +1872,59 @@ def files_upload(
     path: Path,
     context_id: str | None,
     content_type: str | None,
+    remember: bool,
+    summary: str | None,
+    memory_type: str,
+    importance: float,
+    tags: str | None,
     verbose: int,
     progress: str | None,
 ):
     """
     Upload a file to Kagura Memory Cloud.
 
-    Example:
+    With --remember, also creates one summary memory linked to the
+    file_object (provenance + details.file_id back-reference), without
+    invoking an LLM — works for binaries and keyless environments. For
+    LLM-extracted section memories use `kagura ingest` instead.
+
+    Examples:
       kagura files upload ./report.pdf --context-id ctx-uuid
+      kagura files upload ./diagram.png --remember --tags "design,arch"
     """
+    # Fail loud rather than silently drop memory-only flags passed without
+    # --remember (the None-default flags are the ones that signal clear intent).
+    if not remember and (summary is not None or tags is not None):
+        raise click.UsageError("--summary and --tags require --remember.")
+
     logger = _resolve_progress_logger(verbose, progress)
 
     async def op(client: FilesClient, ctx: str) -> str:
-        result = await client.upload(
+        file_obj = await client.upload(
             context_id=ctx,
             source=path,
             content_type=content_type,
             logger=logger,
         )
-        return result.model_dump_json(indent=2)
+        if not remember:
+            return file_obj.model_dump_json(indent=2)
+        try:
+            memory = await _remember_file_object(
+                ctx, path, file_obj, summary, memory_type, importance, tags
+            )
+        except Exception as e:
+            # The upload already succeeded — surface the file_id so the user
+            # knows the file_object exists and does not re-upload a duplicate.
+            raise click.ClickException(
+                f"File uploaded (file_id={file_obj.id}), but creating the linked "
+                f"memory failed: {_exc_message(e)}. The file_object is stored; "
+                f"retry the memory write separately or reference it by file_id."
+            ) from e
+        return json.dumps(
+            {"file": file_obj.model_dump(mode="json"), "memory": memory},
+            indent=2,
+            ensure_ascii=False,
+        )
 
     _run_files_command(op, context_id)
 

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -20,7 +20,7 @@ from .auth.cli import auth as _auth_group
 from .client import KaguraClient
 from .config import load_config
 from .doctor import run_doctor
-from .exceptions import _exc_message
+from .exceptions import KaguraError, _exc_message
 from .files_client import FilesClient
 from .logger import VerboseLogger
 from .models import FileObject, Message, ProcessResult, ResourceEventRequest, Session
@@ -1805,7 +1805,7 @@ async def _remember_file_object(
         f"Stored as file_object {file_obj.id}."
     )
     async with client:
-        return await client.remember(
+        result = await client.remember(
             context_id=ctx,
             summary=summary or f"File: {file_obj.filename}",
             content=content,
@@ -1821,6 +1821,17 @@ async def _remember_file_object(
                 "content_type": file_obj.content_type,
             },
         )
+    # remember() surfaces MCP domain errors as a dict (status=="error" /
+    # missing memory_id) rather than raising. Treat those as failures — same
+    # as the ingest path — so the caller's handler can surface the file_id
+    # and exit non-zero instead of printing an error payload as success.
+    if (
+        not isinstance(result, dict)
+        or result.get("status") == "error"
+        or not result.get("memory_id")
+    ):
+        raise KaguraError(f"memory write reported an error: {result}")
+    return result
 
 
 @files.command(name="upload")

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -151,6 +151,12 @@ def test_files_upload_remember_creates_linked_memory(
     assert kwargs["source_uri"] == p.resolve().as_uri()
     # The memory links back to the file_object via details.file_id.
     assert kwargs["details"]["file_id"] == SAMPLE_FILE_ID
+    # The memory client must self-resolve credentials (constructed with no
+    # api_key/mcp_url args) so it shares the exact source that uploaded the
+    # file and owns ``ctx``. Passing config values would force the "explicit"
+    # branch of _resolve_auth and diverge from the upload's env/OAuth source
+    # for multi-source users → cross-workspace 403.
+    mock_kagura_cls.assert_called_once_with()
 
 
 @patch("kagura_memory.cli.load_config")

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -263,6 +263,47 @@ def test_files_upload_remember_failure_still_reports_file_id(
     assert SAMPLE_FILE_ID in result.output
 
 
+@pytest.mark.parametrize(
+    "bad_result",
+    [
+        {"status": "error", "message": "quota exceeded"},  # MCP domain error
+        {"ok": True},  # missing memory_id
+    ],
+)
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_remember_domain_error_is_failure(
+    mock_files_cls, mock_kagura_cls, mock_config, bad_result, tmp_path
+):
+    """remember() returning an error-shaped dict (no raise) must NOT exit 0.
+
+    KaguraClient.remember() surfaces MCP domain errors as a dict with
+    status=="error" / no memory_id rather than raising; treating that as
+    success would print an error payload as if the memory was created.
+    Mirrors the ingest path (ingestor.py).
+    """
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_files = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_files_cls, mock_files)
+    mock_kagura = _mock_kagura_client(mock_kagura_cls)
+    mock_kagura.remember.return_value = bad_result
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p), "--remember"])
+
+    assert result.exit_code != 0
+    # The upload succeeded — file_id still surfaced for recovery.
+    assert SAMPLE_FILE_ID in result.output
+
+
 @patch("kagura_memory.cli.load_config")
 def test_files_upload_summary_without_remember_errors(mock_config, tmp_path):
     """--summary/--tags only make sense with --remember; using them alone must error,

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -107,6 +107,175 @@ def test_files_upload(mock_client_cls, mock_config, tmp_path):
     assert call.kwargs["source"] == p
 
 
+def _mock_kagura_client(mock_client_cls: MagicMock) -> MagicMock:
+    """Wire a KaguraClient mock whose ``remember`` returns a memory id."""
+    client = AsyncMock()
+    client.remember.return_value = {"memory_id": "mem-1"}
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    mock_client_cls.return_value = client
+    return client
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_remember_creates_linked_memory(
+    mock_files_cls, mock_kagura_cls, mock_config, tmp_path
+):
+    """`files upload --remember` uploads, then creates a memory linked to the file_object."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_files = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_files_cls, mock_files)
+    mock_kagura = _mock_kagura_client(mock_kagura_cls)
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hello kagura files")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p), "--remember"])
+
+    assert result.exit_code == 0, result.output
+    # Output reports both the file_object and the created memory.
+    assert SAMPLE_FILE_ID in result.output
+    assert "mem-1" in result.output
+
+    mock_kagura.remember.assert_awaited_once()
+    kwargs = mock_kagura.remember.call_args.kwargs
+    assert kwargs["context_id"] == SAMPLE_CTX_ID
+    assert kwargs["source_type"] == "file"
+    assert kwargs["source_uri"] == p.resolve().as_uri()
+    # The memory links back to the file_object via details.file_id.
+    assert kwargs["details"]["file_id"] == SAMPLE_FILE_ID
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_without_remember_skips_memory(
+    mock_files_cls, mock_kagura_cls, mock_config, tmp_path
+):
+    """Without --remember, no memory is created (default path unchanged)."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_files = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_files_cls, mock_files)
+    mock_kagura = _mock_kagura_client(mock_kagura_cls)
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p)])
+
+    assert result.exit_code == 0, result.output
+    mock_kagura.remember.assert_not_awaited()
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_remember_custom_summary_type_tags(
+    mock_files_cls, mock_kagura_cls, mock_config, tmp_path
+):
+    """--remember forwards --summary / --type / --importance / --tags to remember()."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_files = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_files_cls, mock_files)
+    mock_kagura = _mock_kagura_client(mock_kagura_cls)
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "files",
+            "upload",
+            str(p),
+            "--remember",
+            "--summary",
+            "My doc",
+            "--type",
+            "doc",
+            "--importance",
+            "0.9",
+            "--tags",
+            "a, b",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    kwargs = mock_kagura.remember.call_args.kwargs
+    assert kwargs["summary"] == "My doc"
+    assert kwargs["type"] == "doc"
+    assert kwargs["importance"] == 0.9
+    assert kwargs["tags"] == ["a", "b"]
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.KaguraClient")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_remember_failure_still_reports_file_id(
+    mock_files_cls, mock_kagura_cls, mock_config, tmp_path
+):
+    """If upload succeeds but the memory write fails, the file_id must not be lost.
+
+    Otherwise the user sees a bare error, does not learn the file_object was
+    already created, and re-runs — orphaning a duplicate upload.
+    """
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_files = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_files_cls, mock_files)
+    mock_kagura = _mock_kagura_client(mock_kagura_cls)
+    mock_kagura.remember.side_effect = RuntimeError("boom")
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p), "--remember"])
+
+    assert result.exit_code != 0
+    # The successful upload's file_id is surfaced despite the memory failure.
+    assert SAMPLE_FILE_ID in result.output
+
+
+@patch("kagura_memory.cli.load_config")
+def test_files_upload_summary_without_remember_errors(mock_config, tmp_path):
+    """--summary/--tags only make sense with --remember; using them alone must error,
+    not silently drop the value."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p), "--summary", "x"])
+
+    assert result.exit_code != 0
+    assert "--remember" in result.output
+
+
 @patch("kagura_memory.cli.load_config")
 def test_files_upload_missing_credentials(mock_config, monkeypatch, tmp_path):
     """upload with context-id but no api_key + no OAuth profile → credentials error."""


### PR DESCRIPTION
Closes #168.

## Scope decision

#168 as literally written (`kagura ingest file <path>`) **overlapped with
existing commands** and its premise ("there is no CLI subcommand wrapping file
upload") is now outdated:

- `kagura files upload <path>` already uploads a file_object (= the issue's
  `--no-memory` case).
- `kagura ingest <file>` already does LLM extraction + memories + R2 archive
  with `file_id` stamped (a *superset*, but requires LLM providers).

The genuine remaining gap is: **upload a file_object AND create one simple
linked summary memory, without an LLM** (works for binaries / keyless envs).
Rather than add a redundant `ingest file` subcommand (which would also force a
breaking conversion of the flat `ingest` command to a group), this extends the
existing `files upload` with `--remember`.

## What

`kagura files upload --remember`:
1. uploads the file_object (unchanged path), then
2. creates one summary memory linked back via `details.file_id`, with
   `source_uri=file://<abs>` + `source_type=file` provenance.

| Option | Effect (only with `--remember`) |
|--------|-------------------------------|
| `--remember` | enable the linked-memory write |
| `--summary` | memory summary (default: `File: <name>`) |
| `--type` | memory type (default `note`) |
| `--importance` | 0.0–1.0 (default 0.5) |
| `--tags` | comma-separated |

No LLM is invoked; linking uses the same `details.file_id` mechanism as
`kagura ingest`.

## Robustness (self-review, via `/code-review` haiku)

- **Partial failure**: if upload succeeds but the memory write fails, the error
  now surfaces the `file_id` so the user doesn't re-upload a duplicate of an
  orphaned file.
- **Fail loud**: `--summary`/`--tags` without `--remember` now error instead of
  silently dropping the values.

Reviewed findings I did *not* action (noted for transparency): minor
client-construction / details-dict duplication with `ingest_file`, and the
"KaguraClient built inside a FilesClient op" altitude smell — both match
existing patterns; folding them into a shared helper is a separate cleanup.

## Tests (TDD)

Written test-first (RED → GREEN):
- `test_files_upload_remember_creates_linked_memory`
- `test_files_upload_without_remember_skips_memory`
- `test_files_upload_remember_custom_summary_type_tags`
- `test_files_upload_remember_failure_still_reports_file_id`
- `test_files_upload_summary_without_remember_errors`

Full suite: 1013 passed, 12 skipped (eval tests need live LLM keys); ruff +
pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)