### PR TITLE
feat(client): deterministic delivery — delivery_mode kwarg + load_pinned() (#172)

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -281,6 +281,7 @@ class KaguraClient:
         linked_memory_ids: list[str] | None = None,
         linked_source_uris: list[str] | None = None,
         source_type: Literal["file", "url", "vault", "api", "manual"] | None = None,
+        delivery_mode: Literal["always", "on_recall", "on_trigger"] = "on_recall",
         context_summary: str | None = None,
         details: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
@@ -304,6 +305,14 @@ class KaguraClient:
                 Unresolved URIs are silently skipped server-side.
             source_type: Origin classification. Closed enum per the MCP
                 tool schema; pairs with ``source_uri`` for downstream filters.
+            delivery_mode: When the memory is surfaced. ``"on_recall"``
+                (default) leaves it to probabilistic :meth:`recall`.
+                ``"always"`` pins it to ``scope="persistent"`` on write so it
+                is returned by every :meth:`load_pinned` call (Goal / Guardrail
+                / critical-policy memories). ``"on_trigger"`` is for
+                trigger-delivered memories. The default is sent only when it
+                differs from the server's ``server_default='on_recall'``, so
+                an unset value stays forward-compatible.
             context_summary: Brief explanation (max 2000 chars) of why the
                 memory exists and how to use it. Distinct from ``summary``,
                 which is the search-target text.
@@ -329,6 +338,10 @@ class KaguraClient:
             arguments["source_uri"] = source_uri
         if source_type is not None:
             arguments["source_type"] = source_type
+        # Only send a non-default delivery_mode; the server applies
+        # server_default='on_recall' so omitting it stays forward-compatible.
+        if delivery_mode != "on_recall":
+            arguments["delivery_mode"] = delivery_mode
         if context_summary is not None:
             arguments["context_summary"] = context_summary
         if details is not None:
@@ -408,6 +421,53 @@ class KaguraClient:
         if include_explore_hints:
             arguments["include_explore_hints"] = True
         return await self._call_tool("recall", arguments)
+
+    async def load_pinned(
+        self,
+        context_id: str,
+        cap: int | None = None,
+    ) -> dict[str, Any]:
+        """Deterministically load a context's pinned (``delivery_mode="always"``) memories.
+
+        This is the **deterministic** counterpart to :meth:`recall`: it returns
+        the complete, unranked pinned set on every call — no semantic search, no
+        ranking, no rerank — so an agent's Goal / Guardrail / critical-policy
+        memories load identically every turn. Pin a memory with
+        :meth:`remember` (``delivery_mode="always"``) or :meth:`update_memory`
+        (``delivery_mode="always"``); unpin with
+        :meth:`update_memory` (``delivery_mode="on_recall"``).
+
+        Results carry summary + context_summary only (Layer 1+2). Fetch full
+        content with :meth:`reference` using a result's ``memory_id``.
+
+        The set is **bounded, never silently dropped**: when more pinned
+        memories exist than ``cap``, the response ``truncated`` flag is ``True``
+        and ``total_available`` reports the real count. Callers loading a
+        complete policy set should check ``truncated`` and raise ``cap`` (or
+        page via :meth:`list_memories`) rather than assume completeness.
+
+        Args:
+            context_id: Target context UUID.
+            cap: Optional override for the maximum number returned (1-1000).
+                Omit to use the server default.
+
+        Returns:
+            API response with ``results`` (the pinned set), ``truncated``
+            (bool), and ``total_available`` (int).
+
+        Example:
+            >>> pinned = await client.load_pinned(context_id=ctx)
+            >>> if pinned["truncated"]:
+            ...     pinned = await client.load_pinned(context_id=ctx, cap=1000)
+            >>> for m in pinned["results"]:
+            ...     full = await client.reference(
+            ...         context_id=ctx, memory_id=m["memory_id"]
+            ...     )
+        """
+        arguments: dict[str, Any] = {"context_id": context_id}
+        if cap is not None:
+            arguments["cap"] = cap
+        return await self._call_tool("load_pinned", arguments)
 
     async def list_contexts(self) -> dict[str, Any]:
         """
@@ -555,6 +615,7 @@ class KaguraClient:
         importance: float | None = None,
         tags: list[str] | None = None,
         context_summary: str | None = None,
+        delivery_mode: Literal["always", "on_recall", "on_trigger"] | None = None,
     ) -> dict[str, Any]:
         """Update an existing memory in-place or upsert by external ID.
 
@@ -576,6 +637,11 @@ class KaguraClient:
             importance: Updated importance (0.0-1.0).
             tags: Updated tags.
             context_summary: Updated context summary (max 2000 chars).
+            delivery_mode: Pin or unpin the memory. ``"always"`` pins it
+                (deterministically loaded every turn via :meth:`load_pinned`,
+                promoted to ``scope="persistent"``); ``"on_recall"`` unpins it
+                (back to probabilistic :meth:`recall`; the memory stays
+                persistent). Omit to leave the current delivery mode unchanged.
 
         Returns:
             API response with updated memory info.
@@ -602,6 +668,8 @@ class KaguraClient:
             arguments["tags"] = tags
         if context_summary is not None:
             arguments["context_summary"] = context_summary
+        if delivery_mode is not None:
+            arguments["delivery_mode"] = delivery_mode
         return await self._call_tool("update_memory", arguments)
 
     async def forget(

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -281,10 +281,10 @@ class KaguraClient:
         linked_memory_ids: list[str] | None = None,
         linked_source_uris: list[str] | None = None,
         source_type: Literal["file", "url", "vault", "api", "manual"] | None = None,
-        delivery_mode: Literal["always", "on_recall", "on_trigger"] = "on_recall",
         context_summary: str | None = None,
         details: dict[str, Any] | None = None,
         context: dict[str, Any] | None = None,
+        delivery_mode: Literal["always", "on_recall", "on_trigger"] = "on_recall",
     ) -> dict[str, Any]:
         """Call remember MCP tool.
 
@@ -305,14 +305,6 @@ class KaguraClient:
                 Unresolved URIs are silently skipped server-side.
             source_type: Origin classification. Closed enum per the MCP
                 tool schema; pairs with ``source_uri`` for downstream filters.
-            delivery_mode: When the memory is surfaced. ``"on_recall"``
-                (default) leaves it to probabilistic :meth:`recall`.
-                ``"always"`` pins it to ``scope="persistent"`` on write so it
-                is returned by every :meth:`load_pinned` call (Goal / Guardrail
-                / critical-policy memories). ``"on_trigger"`` is for
-                trigger-delivered memories. The default is sent only when it
-                differs from the server's ``server_default='on_recall'``, so
-                an unset value stays forward-compatible.
             context_summary: Brief explanation (max 2000 chars) of why the
                 memory exists and how to use it. Distinct from ``summary``,
                 which is the search-target text.
@@ -321,6 +313,16 @@ class KaguraClient:
                 payload that the server should store as-is.
             context: Open-ended context metadata JSON. Less structured than
                 ``details``; useful for free-form provenance hints.
+            delivery_mode: When the memory is surfaced. ``"on_recall"``
+                (default) leaves it to probabilistic :meth:`recall`.
+                ``"always"`` pins it to ``scope="persistent"`` on write so it
+                is returned by every :meth:`load_pinned` call (Goal / Guardrail
+                / critical-policy memories). ``"on_trigger"`` is for
+                trigger-delivered memories. The default is sent only when it
+                differs from the server's ``server_default='on_recall'``, so
+                an unset value stays forward-compatible. Keyword-only in
+                practice — keep passing it by name. (Appended at the end of the
+                signature so existing positional callers are unaffected.)
 
         Returns:
             API response with ``memory_id``.
@@ -443,8 +445,11 @@ class KaguraClient:
         The set is **bounded, never silently dropped**: when more pinned
         memories exist than ``cap``, the response ``truncated`` flag is ``True``
         and ``total_available`` reports the real count. Callers loading a
-        complete policy set should check ``truncated`` and raise ``cap`` (or
-        page via :meth:`list_memories`) rather than assume completeness.
+        complete policy set should check ``truncated`` and re-call with a larger
+        ``cap`` (up to the server maximum). Note that :meth:`list_memories` is
+        not a substitute for paging the pinned set — its responses do not carry
+        ``delivery_mode``/pinned state, so it cannot reconstruct the pinned
+        subset; use this method with a sufficient ``cap`` instead.
 
         Args:
             context_id: Target context UUID.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -365,6 +365,141 @@ async def test_remember_with_source_type():
     await client.close()
 
 
+# delivery_mode constant + literal drift guard: assert both the public default
+# and its literal value so a silent rename of either side fails fast.
+_DEFAULT_DELIVERY_MODE = "on_recall"
+
+
+@pytest.mark.asyncio
+async def test_remember_with_delivery_mode_always():
+    """remember() should pass delivery_mode when set to a non-default value."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(context_id="ctx", summary="s", content="c", delivery_mode="always")
+        args = mock.call_args[0][1]
+        assert args["delivery_mode"] == "always"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_delivery_mode_on_trigger():
+    """remember() should pass delivery_mode='on_trigger' through verbatim."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(
+            context_id="ctx", summary="s", content="c", delivery_mode="on_trigger"
+        )
+        args = mock.call_args[0][1]
+        assert args["delivery_mode"] == "on_trigger"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_delivery_mode_default_not_sent():
+    """remember() should omit delivery_mode when left at the default.
+
+    The server applies ``server_default='on_recall'``; not sending the key keeps
+    the SDK forward-compatible and avoids pinning the default into the payload.
+    """
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"memory_id": "abc"}
+        await client.remember(context_id="ctx", summary="s", content="c")
+        args = mock.call_args[0][1]
+        assert "delivery_mode" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_remember_delivery_mode_default_literal():
+    """The remember() delivery_mode default is the literal 'on_recall'."""
+    import inspect
+
+    sig = inspect.signature(KaguraClient.remember)
+    assert sig.parameters["delivery_mode"].default == _DEFAULT_DELIVERY_MODE
+    assert _DEFAULT_DELIVERY_MODE == "on_recall"
+
+
+@pytest.mark.asyncio
+async def test_update_memory_with_delivery_mode():
+    """update_memory() should pass delivery_mode to pin/unpin a memory."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"status": "success"}
+        await client.update_memory(context_id="ctx", memory_id="mid", delivery_mode="always")
+        args = mock.call_args[0][1]
+        assert args["delivery_mode"] == "always"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_update_memory_delivery_mode_not_sent_when_none():
+    """update_memory() should omit delivery_mode when not provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"status": "success"}
+        await client.update_memory(context_id="ctx", memory_id="mid", summary="s")
+        args = mock.call_args[0][1]
+        assert "delivery_mode" not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_minimal():
+    """load_pinned() should call the load_pinned MCP tool with context_id only."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": [], "truncated": False, "total_available": 0}
+        result = await client.load_pinned(context_id="ctx")
+        name, args = mock.call_args[0][0], mock.call_args[0][1]
+        assert name == "load_pinned"
+        assert args == {"context_id": "ctx"}
+        assert result["truncated"] is False
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_with_cap():
+    """load_pinned() should pass cap when provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": [], "truncated": True, "total_available": 50}
+        await client.load_pinned(context_id="ctx", cap=10)
+        args = mock.call_args[0][1]
+        assert args["cap"] == 10
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_cap_not_sent_when_none():
+    """load_pinned() should omit cap when None (server default applies)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": []}
+        await client.load_pinned(context_id="ctx")
+        args = mock.call_args[0][1]
+        assert "cap" not in args
+
+    await client.close()
+
+
 @pytest.mark.asyncio
 async def test_remember_with_context_dict():
     """remember() should pass context dict (free-form provenance metadata)."""


### PR DESCRIPTION
Closes #172

## Summary
- Add `delivery_mode` kwarg to `KaguraClient.remember()` (`"always"|"on_recall"|"on_trigger"`, default `"on_recall"`) — `"always"` pins to persistent on write.
- Add `KaguraClient.load_pinned(context_id, cap=None)` — the deterministic, unranked counterpart to probabilistic `recall()`; returns the complete pinned set, bounded via `truncated`/`total_available`.
- Add `delivery_mode` to `update_memory()` to complete the pin/unpin lifecycle.

## Implementation notes
- All three follow the existing passthrough convention (the `source_type` precedent): keyword-only, additive, no changes to existing signatures.
- `remember()` omits `delivery_mode` from the payload when it equals the default `"on_recall"`, so the server's `server_default='on_recall'` applies and the SDK stays forward-compatible.
- `load_pinned()` is placed right after `recall()` as its deterministic counterpart; its docstring documents the `truncated`/`total_available` bound (never silently dropped) and that results are Layer 1+2 only (fetch full content via `reference(memory_id)`).
- Enum values match the server MCP tool schema (memory-cloud#886, CLOSED).
- CLI surface (`kagura remember --delivery-mode`, a `kagura pinned` wrapper) is deferred to a near follow-up — out of scope per the issue.
- Migration note for kagura-memory-ai-worker: pin Goal/Guardrail memories with `remember(delivery_mode="always")` and load them deterministically every turn via `load_pinned(context_id)` instead of `recall()`.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/172-feat-feat-client-deterministic-delivery-deliv.gate1.md
- ~/.claude/cache/gh-issue-driven/172-feat-feat-client-deterministic-delivery-deliv.gate2.md

🤖 Generated via /gh-issue-driven:ship
