### PR TITLE
feat(client): add recall_upcoming + list_memories window params (#170)

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -1262,7 +1262,10 @@ class KaguraClient:
         trigger_until: str | None = None,
         order_by: Literal["created_at", "trigger_from"] | None = None,
     ) -> MemoryListResponse:
-        """List memories newest-first, with optional substring and facet filters.
+        """List memories with optional substring, facet, and time-window filters.
+
+        Ordering is newest-first by default; pass ``order_by="trigger_from"`` to
+        sort Time Memories soonest-scheduled first.
 
         Calls ``GET /api/v1/memory/list``. Without ``context_id`` this returns
         the caller's own memories across all contexts; with ``context_id`` it
@@ -1295,8 +1298,9 @@ class KaguraClient:
                 server default.
 
         Returns:
-            :class:`MemoryListResponse` with ``memories`` (newest-first),
-            ``total`` (matching rows across all pages), and ``has_more``.
+            :class:`MemoryListResponse` with ``memories`` (ordered per
+            ``order_by``; newest-first by default), ``total`` (matching rows
+            across all pages), and ``has_more``.
 
         Raises:
             KaguraAuthError: Authentication failed.

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -1287,11 +1287,15 @@ class KaguraClient:
                 vocabulary; the SDK passes through.
             limit: Maximum results (server accepts 1-500, default: 50).
             offset: Pagination offset (default: 0).
-            trigger_from: Lower bound (naive ISO) on a Time Memory's trigger
-                window — restricts results to ``type="time"`` memories whose
-                window starts at or after this instant. Omit for no lower bound.
-            trigger_until: Upper bound (naive ISO) on the trigger window. Omit
-                for an open-ended window. For a "what's upcoming" view, prefer
+            trigger_from: Lower bound (naive ISO) of a time window. Restricts
+                results to ``type="time"`` memories whose trigger window
+                **overlaps** ``[trigger_from, trigger_until]`` — i.e. a memory
+                may start before ``trigger_from`` and still match as long as its
+                window overlaps the range (not a "starts at or after" filter).
+                Omit for no lower bound.
+            trigger_until: Upper bound (naive ISO) of the time window (same
+                overlap semantics as ``trigger_from``). Omit for an open-ended
+                window. For a "what's upcoming" view, prefer
                 :meth:`recall_upcoming`, which is purpose-built for that query.
             order_by: Sort order — ``"created_at"`` (default, newest-first) or
                 ``"trigger_from"`` (soonest scheduled first). Omit to use the

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -409,6 +409,43 @@ class KaguraClient:
             arguments["include_explore_hints"] = True
         return await self._call_tool("recall", arguments)
 
+    async def recall_upcoming(
+        self,
+        context_id: str,
+        *,
+        from_: str | None = None,
+        until: str | None = None,
+        k: int = 20,
+    ) -> dict[str, Any]:
+        """List Time Memories whose scheduled window overlaps a range, soonest first.
+
+        Calls the ``recall_upcoming`` MCP tool. This is a **deterministic time
+        query** over ``type="time"`` memories — not semantic search and with no
+        Hebbian side-effects — so it is distinct from :meth:`recall`. Create a
+        Time Memory with ``remember(type="time", details={"trigger": {...}})``.
+
+        Args:
+            context_id: Target context UUID.
+            from_: Lower bound as naive ISO (e.g. ``"2026-06-01T00:00:00"``), or
+                the literal ``"now"`` which the server resolves. Omit for no
+                lower bound. (Named ``from_`` because ``from`` is a reserved
+                word; it is sent to the server as ``"from"``.)
+            until: Upper bound as naive ISO. Omit for an open-ended future window.
+            k: Maximum results (default 20, server max 100).
+
+        Returns:
+            API response with ``results`` — ``type="time"`` memories whose window
+            overlaps the range, soonest first.
+        """
+        # `from` is a Python reserved word, so the public param is `from_` but
+        # the MCP tool expects the key `"from"`.
+        arguments: dict[str, Any] = {"context_id": context_id, "k": k}
+        if from_ is not None:
+            arguments["from"] = from_
+        if until is not None:
+            arguments["until"] = until
+        return await self._call_tool("recall_upcoming", arguments)
+
     async def list_contexts(self) -> dict[str, Any]:
         """
         Call list_contexts MCP tool.
@@ -1221,6 +1258,9 @@ class KaguraClient:
         type: str | None = None,
         limit: int = 50,
         offset: int = 0,
+        trigger_from: str | None = None,
+        trigger_until: str | None = None,
+        order_by: Literal["created_at", "trigger_from"] | None = None,
     ) -> MemoryListResponse:
         """List memories newest-first, with optional substring and facet filters.
 
@@ -1244,6 +1284,15 @@ class KaguraClient:
                 vocabulary; the SDK passes through.
             limit: Maximum results (server accepts 1-500, default: 50).
             offset: Pagination offset (default: 0).
+            trigger_from: Lower bound (naive ISO) on a Time Memory's trigger
+                window — restricts results to ``type="time"`` memories whose
+                window starts at or after this instant. Omit for no lower bound.
+            trigger_until: Upper bound (naive ISO) on the trigger window. Omit
+                for an open-ended window. For a "what's upcoming" view, prefer
+                :meth:`recall_upcoming`, which is purpose-built for that query.
+            order_by: Sort order — ``"created_at"`` (default, newest-first) or
+                ``"trigger_from"`` (soonest scheduled first). Omit to use the
+                server default.
 
         Returns:
             :class:`MemoryListResponse` with ``memories`` (newest-first),
@@ -1267,6 +1316,12 @@ class KaguraClient:
             params["scope"] = scope
         if type is not None:
             params["type"] = type
+        if trigger_from is not None:
+            params["trigger_from"] = trigger_from
+        if trigger_until is not None:
+            params["trigger_until"] = trigger_until
+        if order_by is not None:
+            params["order_by"] = order_by
         return await self._rest_get("/api/v1/memory/list", MemoryListResponse, params=params)
 
     @staticmethod

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1768,6 +1768,98 @@ async def test_list_memories_strips_q_and_omits_when_blank():
     await client.close()
 
 
+@pytest.mark.asyncio
+async def test_list_memories_window_params_forwarded():
+    """list_memories() forwards trigger_from / trigger_until / order_by."""
+    client = _make_initialized_client()
+
+    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _memory_list_response_mock()
+        await client.list_memories(
+            context_id="ctx-1",
+            trigger_from="2026-06-01T00:00:00",
+            trigger_until="2026-07-01T00:00:00",
+            order_by="trigger_from",
+        )
+        params = mock_get.call_args.kwargs["params"]
+        assert params["trigger_from"] == "2026-06-01T00:00:00"
+        assert params["trigger_until"] == "2026-07-01T00:00:00"
+        assert params["order_by"] == "trigger_from"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_memories_window_params_omitted_when_none():
+    """list_memories() omits the window params when not provided."""
+    client = _make_initialized_client()
+
+    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = _memory_list_response_mock()
+        await client.list_memories(context_id="ctx-1")
+        params = mock_get.call_args.kwargs["params"]
+        assert "trigger_from" not in params
+        assert "trigger_until" not in params
+        assert "order_by" not in params
+
+    await client.close()
+
+
+# ============================================================================
+# recall_upcoming (Time Memory, MCP)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_minimal():
+    """recall_upcoming() calls the recall_upcoming MCP tool with context_id only."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": []}
+        await client.recall_upcoming(context_id="ctx")
+        name, args = mock.call_args[0][0], mock.call_args[0][1]
+        assert name == "recall_upcoming"
+        assert args == {"context_id": "ctx", "k": 20}
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_maps_from_keyword_to_from_key():
+    """recall_upcoming() maps the from_ param to the reserved-word "from" key."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": []}
+        await client.recall_upcoming(
+            context_id="ctx", from_="now", until="2026-07-01T00:00:00", k=5
+        )
+        args = mock.call_args[0][1]
+        assert args["from"] == "now"
+        assert "from_" not in args
+        assert args["until"] == "2026-07-01T00:00:00"
+        assert args["k"] == 5
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_omits_bounds_when_none():
+    """recall_upcoming() omits from/until when not provided (k always sent)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {"results": []}
+        await client.recall_upcoming(context_id="ctx")
+        args = mock.call_args[0][1]
+        assert "from" not in args
+        assert "until" not in args
+        assert args["k"] == 20
+
+    await client.close()
+
+
 # ============================================================================
 # get_server_info / check_server_version
 # ============================================================================

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1818,7 +1818,7 @@ async def test_recall_upcoming_minimal():
     with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
         mock.return_value = {"results": []}
         await client.recall_upcoming(context_id="ctx")
-        name, args = mock.call_args[0][0], mock.call_args[0][1]
+        name, args = mock.call_args.args[0], mock.call_args.args[1]
         assert name == "recall_upcoming"
         assert args == {"context_id": "ctx", "k": 20}
 
@@ -1835,7 +1835,7 @@ async def test_recall_upcoming_maps_from_keyword_to_from_key():
         await client.recall_upcoming(
             context_id="ctx", from_="now", until="2026-07-01T00:00:00", k=5
         )
-        args = mock.call_args[0][1]
+        args = mock.call_args.args[1]
         assert args["from"] == "now"
         assert "from_" not in args
         assert args["until"] == "2026-07-01T00:00:00"
@@ -1852,7 +1852,7 @@ async def test_recall_upcoming_omits_bounds_when_none():
     with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
         mock.return_value = {"results": []}
         await client.recall_upcoming(context_id="ctx")
-        args = mock.call_args[0][1]
+        args = mock.call_args.args[1]
         assert "from" not in args
         assert "until" not in args
         assert args["k"] == 20

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1812,7 +1812,7 @@ async def test_list_memories_window_params_omitted_when_none():
 
 @pytest.mark.asyncio
 async def test_recall_upcoming_minimal():
-    """recall_upcoming() calls the recall_upcoming MCP tool with context_id only."""
+    """recall_upcoming() with no bounds sends only context_id + the default k."""
     client = _make_initialized_client()
 
     with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1773,20 +1773,21 @@ async def test_list_memories_window_params_forwarded():
     """list_memories() forwards trigger_from / trigger_until / order_by."""
     client = _make_initialized_client()
 
-    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
-        mock_get.return_value = _memory_list_response_mock()
-        await client.list_memories(
-            context_id="ctx-1",
-            trigger_from="2026-06-01T00:00:00",
-            trigger_until="2026-07-01T00:00:00",
-            order_by="trigger_from",
-        )
-        params = mock_get.call_args.kwargs["params"]
-        assert params["trigger_from"] == "2026-06-01T00:00:00"
-        assert params["trigger_until"] == "2026-07-01T00:00:00"
-        assert params["order_by"] == "trigger_from"
-
-    await client.close()
+    try:
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _memory_list_response_mock()
+            await client.list_memories(
+                context_id="ctx-1",
+                trigger_from="2026-06-01T00:00:00",
+                trigger_until="2026-07-01T00:00:00",
+                order_by="trigger_from",
+            )
+            params = mock_get.call_args.kwargs["params"]
+            assert params["trigger_from"] == "2026-06-01T00:00:00"
+            assert params["trigger_until"] == "2026-07-01T00:00:00"
+            assert params["order_by"] == "trigger_from"
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -1794,15 +1795,16 @@ async def test_list_memories_window_params_omitted_when_none():
     """list_memories() omits the window params when not provided."""
     client = _make_initialized_client()
 
-    with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
-        mock_get.return_value = _memory_list_response_mock()
-        await client.list_memories(context_id="ctx-1")
-        params = mock_get.call_args.kwargs["params"]
-        assert "trigger_from" not in params
-        assert "trigger_until" not in params
-        assert "order_by" not in params
-
-    await client.close()
+    try:
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _memory_list_response_mock()
+            await client.list_memories(context_id="ctx-1")
+            params = mock_get.call_args.kwargs["params"]
+            assert "trigger_from" not in params
+            assert "trigger_until" not in params
+            assert "order_by" not in params
+    finally:
+        await client.close()
 
 
 # ============================================================================
@@ -1815,14 +1817,15 @@ async def test_recall_upcoming_minimal():
     """recall_upcoming() with no bounds sends only context_id + the default k."""
     client = _make_initialized_client()
 
-    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
-        mock.return_value = {"results": []}
-        await client.recall_upcoming(context_id="ctx")
-        name, args = mock.call_args.args[0], mock.call_args.args[1]
-        assert name == "recall_upcoming"
-        assert args == {"context_id": "ctx", "k": 20}
-
-    await client.close()
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"results": []}
+            await client.recall_upcoming(context_id="ctx")
+            name, args = mock.call_args.args[0], mock.call_args.args[1]
+            assert name == "recall_upcoming"
+            assert args == {"context_id": "ctx", "k": 20}
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -1830,18 +1833,19 @@ async def test_recall_upcoming_maps_from_keyword_to_from_key():
     """recall_upcoming() maps the from_ param to the reserved-word "from" key."""
     client = _make_initialized_client()
 
-    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
-        mock.return_value = {"results": []}
-        await client.recall_upcoming(
-            context_id="ctx", from_="now", until="2026-07-01T00:00:00", k=5
-        )
-        args = mock.call_args.args[1]
-        assert args["from"] == "now"
-        assert "from_" not in args
-        assert args["until"] == "2026-07-01T00:00:00"
-        assert args["k"] == 5
-
-    await client.close()
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"results": []}
+            await client.recall_upcoming(
+                context_id="ctx", from_="now", until="2026-07-01T00:00:00", k=5
+            )
+            args = mock.call_args.args[1]
+            assert args["from"] == "now"
+            assert "from_" not in args
+            assert args["until"] == "2026-07-01T00:00:00"
+            assert args["k"] == 5
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -1849,15 +1853,16 @@ async def test_recall_upcoming_omits_bounds_when_none():
     """recall_upcoming() omits from/until when not provided (k always sent)."""
     client = _make_initialized_client()
 
-    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
-        mock.return_value = {"results": []}
-        await client.recall_upcoming(context_id="ctx")
-        args = mock.call_args.args[1]
-        assert "from" not in args
-        assert "until" not in args
-        assert args["k"] == 20
-
-    await client.close()
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"results": []}
+            await client.recall_upcoming(context_id="ctx")
+            args = mock.call_args.args[1]
+            assert "from" not in args
+            assert "until" not in args
+            assert args["k"] == 20
+    finally:
+        await client.close()
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #170

## Summary
- Add `KaguraClient.recall_upcoming(context_id, *, from_=None, until=None, k=20)` — deterministic time query over `type="time"` memories via the `recall_upcoming` MCP tool, soonest first, distinct from probabilistic `recall()`.
- Add `trigger_from` / `trigger_until` (naive-ISO window bounds) and `order_by` (`"created_at"` | `"trigger_from"`) to `list_memories()`.
- Reaches read parity with memory-cloud Time Memory (memory-cloud#877, #880).

## Implementation notes
- `recall_upcoming` follows the `recall()` `_call_tool` pattern and is placed right after it as its deterministic counterpart. Params are keyword-only (`*`).
- `from` is a Python reserved word, so the public param is `from_` and is mapped to the `"from"` key in the MCP arguments (documented inline + in the docstring; a dedicated test pins this mapping). `"now"` is forwarded verbatim and resolved server-side.
- `list_memories()` window params are appended to the signature (existing params unchanged → backward compatible) and forwarded as REST params only when set, matching the existing `scope`/`type` pattern. `order_by` is typed `Literal["created_at","trigger_from"]`.
- CLI `kagura upcoming` deferred (optional per the issue), consistent with #172.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/170-feat-feat-client-add-recall-upcoming-list-mem.gate1.md
- ~/.claude/cache/gh-issue-driven/170-feat-feat-client-add-recall-upcoming-list-mem.gate2.md

🤖 Generated via /gh-issue-driven:ship
