### PR TITLE
feat(client): agent memory substrate — trust_tier, feedback, state lane

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -382,6 +382,14 @@ class KaguraClient:
                 - ``tags_match``: ``"any"`` (default) or ``"all"`` for AND logic
                 - ``created_after`` / ``created_before``: ISO 8601 datetime
                 - ``updated_after`` / ``updated_before``: ISO 8601 datetime
+                - ``trust_tier``: ``"trusted"`` EXCLUDES external/connector-ingested
+                  memories from the results (opt-in; default recall returns them).
+                  Pass it for behaviour-influencing reads where untrusted content
+                  must not be treated as instructions (OWASP LLM01/LLM03). Trust is
+                  **server-derived from server-stamped provenance** (memory-cloud
+                  #887): passing ``source_type`` on :meth:`remember` records origin
+                  but no longer establishes trust — the client is untrusted by
+                  contract, so it cannot mark its own writes ``"trusted"``.
             search_mode: Search strategy — "hybrid" (default), "semantic", or "keyword"
             context_ids: Search across multiple contexts (2–20 IDs).
                 When provided, ``context_id`` is not required.
@@ -510,6 +518,124 @@ class KaguraClient:
         if cap is not None:
             arguments["cap"] = cap
         return await self._call_tool("load_pinned", arguments)
+
+    async def feedback(
+        self,
+        context_id: str,
+        memory_id: str,
+        helpful: bool,
+        *,
+        query: str | None = None,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Record whether a recalled memory was useful for a query.
+
+        Calls the ``feedback`` MCP tool. This is an **append-only usefulness
+        signal** that lets SDK consumers (ai-worker, agents) teach the substrate
+        which :meth:`recall` results were on-target. Each call appends a new
+        event, so repeated or contradicting signals are kept as a time series
+        rather than overwriting.
+
+        Feedback is a **separate lane from knowledge**: it is not embedded and is
+        structurally excluded from :meth:`recall`, so rating a result never
+        pollutes the search space. Anyone who can read the context may record it.
+
+        Args:
+            context_id: Context UUID (the recalled memory's context).
+            memory_id: UUID of the recalled memory being rated.
+            helpful: ``True`` if the memory was useful for the query,
+                ``False`` if not.
+            query: Optional recall query this feedback is about (max 1024 chars).
+            note: Optional free-text note, e.g. why the result was wrong
+                (max 2000 chars).
+
+        Returns:
+            API response acknowledging the recorded feedback event.
+
+        Example:
+            >>> hits = await client.recall(context_id=ctx, query="auth flow")
+            >>> await client.feedback(
+            ...     context_id=ctx,
+            ...     memory_id=hits["results"][0]["memory_id"],
+            ...     helpful=True,
+            ...     query="auth flow",
+            ... )
+        """
+        arguments: dict[str, Any] = {
+            "context_id": context_id,
+            "memory_id": memory_id,
+            "helpful": helpful,
+        }
+        if query is not None:
+            arguments["query"] = query
+        if note is not None:
+            arguments["note"] = note
+        return await self._call_tool("feedback", arguments)
+
+    async def set_state(
+        self,
+        context_id: str,
+        key: str,
+        value: Any,
+        ttl_seconds: int | None = None,
+    ) -> dict[str, Any]:
+        """Set ephemeral agent run-state at ``(context_id, key)``.
+
+        Calls the ``set_state`` MCP tool. This is the write side of a
+        **TTL-bounded key/value lane for autonomous-agent run state** (current
+        task, step, scratch flags) — kept deliberately **separate from
+        memories**: state is not embedded and is structurally excluded from
+        :meth:`recall`, so transient run-state never pollutes the knowledge
+        search space. Writing upserts the value for the key.
+
+        Use this for transient run state, **not** durable knowledge — use
+        :meth:`remember` for knowledge.
+
+        Args:
+            context_id: Target context UUID (state is scoped to this context).
+            key: State key (max 255 chars). Re-using a key overwrites its value.
+            value: Arbitrary JSON value to store (object, array, string, number,
+                or boolean).
+            ttl_seconds: Optional TTL in seconds (server clamps to 2592000 =
+                30 days). Omit for no expiry.
+
+        Returns:
+            API response acknowledging the upsert.
+        """
+        arguments: dict[str, Any] = {
+            "context_id": context_id,
+            "key": key,
+            "value": value,
+        }
+        if ttl_seconds is not None:
+            arguments["ttl_seconds"] = ttl_seconds
+        return await self._call_tool("set_state", arguments)
+
+    async def get_state(
+        self,
+        context_id: str,
+        key: str | None = None,
+    ) -> dict[str, Any]:
+        """Read ephemeral agent run-state.
+
+        Calls the ``get_state`` MCP tool — the read side of the session-state
+        lane (see :meth:`set_state`). Supply ``key`` to read one value, or omit
+        it to list all live keys for the context. Expired entries are never
+        returned. This lane is excluded from :meth:`recall` by design.
+
+        Args:
+            context_id: Target context UUID.
+            key: Optional state key. Omit to list all live ``(key, value)``
+                entries for the context.
+
+        Returns:
+            API response with the value for ``key``, or all live entries when
+            ``key`` is omitted.
+        """
+        arguments: dict[str, Any] = {"context_id": context_id}
+        if key is not None:
+            arguments["key"] = key
+        return await self._call_tool("get_state", arguments)
 
     async def list_contexts(self) -> dict[str, Any]:
         """

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -583,6 +583,7 @@ class KaguraClient:
         context_id: str,
         key: str,
         value: Any,
+        *,
         ttl_seconds: int | None = None,
     ) -> dict[str, Any]:
         """Set ephemeral agent run-state at ``(context_id, key)``.

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -552,6 +552,10 @@ class KaguraClient:
         Returns:
             API response acknowledging the recorded feedback event.
 
+        Raises:
+            KaguraNotFoundError: Context or memory not found.
+            KaguraError: Other server-side error.
+
         Example:
             >>> hits = await client.recall(context_id=ctx, query="auth flow")
             >>> await client.feedback(
@@ -570,7 +574,9 @@ class KaguraClient:
             arguments["query"] = query
         if note is not None:
             arguments["note"] = note
-        return await self._call_tool("feedback", arguments)
+        result = await self._call_tool("feedback", arguments)
+        self._raise_for_mcp_error(result, "feedback")
+        return result
 
     async def set_state(
         self,
@@ -601,6 +607,10 @@ class KaguraClient:
 
         Returns:
             API response acknowledging the upsert.
+
+        Raises:
+            KaguraNotFoundError: Context not found.
+            KaguraError: Other server-side error.
         """
         arguments: dict[str, Any] = {
             "context_id": context_id,
@@ -609,7 +619,9 @@ class KaguraClient:
         }
         if ttl_seconds is not None:
             arguments["ttl_seconds"] = ttl_seconds
-        return await self._call_tool("set_state", arguments)
+        result = await self._call_tool("set_state", arguments)
+        self._raise_for_mcp_error(result, "set_state")
+        return result
 
     async def get_state(
         self,
@@ -631,11 +643,17 @@ class KaguraClient:
         Returns:
             API response with the value for ``key``, or all live entries when
             ``key`` is omitted.
+
+        Raises:
+            KaguraNotFoundError: Context not found.
+            KaguraError: Other server-side error.
         """
         arguments: dict[str, Any] = {"context_id": context_id}
         if key is not None:
             arguments["key"] = key
-        return await self._call_tool("get_state", arguments)
+        result = await self._call_tool("get_state", arguments)
+        self._raise_for_mcp_error(result, "get_state")
+        return result
 
     async def list_contexts(self) -> dict[str, Any]:
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2169,6 +2169,60 @@ async def test_get_state_lists_all_when_key_omitted():
         await client.close()
 
 
+@pytest.mark.asyncio
+async def test_feedback_surfaces_server_error():
+    """feedback() must raise on a server-side error rather than returning the error dict."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {
+                "status": "error",
+                "error": "memory_not_found",
+                "message": "Memory not found.",
+            }
+            with pytest.raises(KaguraNotFoundError, match="feedback"):
+                await client.feedback(context_id="ctx", memory_id="missing", helpful=True)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_set_state_surfaces_server_error():
+    """set_state() must raise on a server-side error rather than returning the error dict."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {
+                "status": "error",
+                "error": "context_not_found",
+                "message": "Context not found.",
+            }
+            with pytest.raises(KaguraNotFoundError, match="set_state"):
+                await client.set_state(context_id="missing", key="k", value="v")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_state_surfaces_server_error():
+    """get_state() must raise on a server-side error rather than returning the error dict."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {
+                "status": "error",
+                "error": "context_not_found",
+                "message": "Context not found.",
+            }
+            with pytest.raises(KaguraNotFoundError, match="get_state"):
+                await client.get_state(context_id="missing")
+    finally:
+        await client.close()
+
+
 # ============================================================================
 # get_server_info / check_server_version
 # ============================================================================

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2001,6 +2001,175 @@ async def test_recall_upcoming_omits_bounds_when_none():
 
 
 # ============================================================================
+# recall trust_tier filter (provenance, #173)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_recall_passes_trust_tier_filter():
+    """recall() should pass a trust_tier filter straight through to the tool."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"results": []}
+            await client.recall(context_id="ctx", query="auth", filters={"trust_tier": "trusted"})
+            args = mock.call_args[0][1]
+            assert args["filters"] == {"trust_tier": "trusted"}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_recall_omits_filters_when_not_given():
+    """recall() should not send a filters key when no filters are provided."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"results": []}
+            await client.recall(context_id="ctx", query="auth")
+            args = mock.call_args[0][1]
+            assert "filters" not in args
+    finally:
+        await client.close()
+
+
+# ============================================================================
+# feedback (retrieval signal, #174)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_feedback_minimal():
+    """feedback() should send context_id, memory_id, and helpful only."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"status": "ok"}
+            result = await client.feedback(context_id="ctx", memory_id="mem", helpful=True)
+            name, args = mock.call_args[0][0], mock.call_args[0][1]
+            assert name == "feedback"
+            assert args == {"context_id": "ctx", "memory_id": "mem", "helpful": True}
+            assert result["status"] == "ok"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_with_query_and_note():
+    """feedback() should pass optional query and note when provided."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"status": "ok"}
+            await client.feedback(
+                context_id="ctx",
+                memory_id="mem",
+                helpful=False,
+                query="auth flow",
+                note="off-topic result",
+            )
+            args = mock.call_args[0][1]
+            assert args["helpful"] is False
+            assert args["query"] == "auth flow"
+            assert args["note"] == "off-topic result"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_omits_optionals_when_none():
+    """feedback() should omit query and note when not provided."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"status": "ok"}
+            await client.feedback(context_id="ctx", memory_id="mem", helpful=True)
+            args = mock.call_args[0][1]
+            assert "query" not in args
+            assert "note" not in args
+    finally:
+        await client.close()
+
+
+# ============================================================================
+# set_state / get_state (agent session-state lane, #175)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_set_state_minimal():
+    """set_state() should send context_id, key, and value without a TTL."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"status": "ok"}
+            await client.set_state(context_id="ctx", key="step", value={"n": 3, "phase": "build"})
+            name, args = mock.call_args[0][0], mock.call_args[0][1]
+            assert name == "set_state"
+            assert args == {
+                "context_id": "ctx",
+                "key": "step",
+                "value": {"n": 3, "phase": "build"},
+            }
+            assert "ttl_seconds" not in args
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_set_state_with_ttl():
+    """set_state() should pass ttl_seconds when provided."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"status": "ok"}
+            await client.set_state(context_id="ctx", key="lock", value=True, ttl_seconds=300)
+            args = mock.call_args[0][1]
+            assert args["ttl_seconds"] == 300
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_state_single_key():
+    """get_state() should send the key when reading one value."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"key": "step", "value": {"n": 3}}
+            await client.get_state(context_id="ctx", key="step")
+            name, args = mock.call_args[0][0], mock.call_args[0][1]
+            assert name == "get_state"
+            assert args == {"context_id": "ctx", "key": "step"}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_state_lists_all_when_key_omitted():
+    """get_state() should omit key to list all live entries for the context."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {"entries": []}
+            await client.get_state(context_id="ctx")
+            args = mock.call_args[0][1]
+            assert args == {"context_id": "ctx"}
+            assert "key" not in args
+    finally:
+        await client.close()
+
+
+# ============================================================================
 # get_server_info / check_server_version
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Completes the remaining SDK surface of epic #171 (AI agent memory substrate),
now that the upstream memory-cloud APIs (#887/#888/#889) have shipped. Three thin,
typed `KaguraClient` methods plus a security docstring on `recall`.

Closes #173, #174, #175.

## Changes

- **#173 — `trust_tier` recall filter (provenance).** Documents the typed
  `recall(filters={"trust_tier": "trusted"})` filter and the trust boundary:
  trust is **server-derived from server-stamped provenance** — passing
  `source_type` records origin but no longer establishes trust (client is
  untrusted by contract). OWASP LLM01/LLM03 guidance included.
- **#174 — `feedback(context_id, memory_id, helpful, *, query=, note=)`.**
  Append-only retrieval-usefulness signal; not embedded, excluded from `recall()`.
- **#175 — `set_state(context_id, key, value, *, ttl_seconds=)` / `get_state(context_id, key=)`.**
  TTL-bounded agent session-state lane, structurally excluded from `recall()` so
  ephemeral run-state never pollutes the knowledge search space.

All three translate MCP `{"status": "error"}` responses into
`KaguraNotFoundError`/`KaguraError` via the existing `_raise_for_mcp_error`
helper — the right behavior for an agent-facing surface, where an autonomous
consumer may never inspect a returned error dict.

## Review trail

Branch passed `/quality` (158 tests, ruff, pyright), two `/code-review` rounds
(which drove the error-translation hardening and the `set_state` keyword-only
`ttl_seconds` fix), `/simplify` (clean), and `/self-review` (clean, verdict Ready).

## Follow-up

- #180 — unify MCP-error handling across the whole raw-dict method family
  (`load_pinned`/`recall`/`remember`/…). This PR's new methods raise on errors
  while those older released methods still pass error dicts through; #180 tracks
  resolving that family-wide.

## Test plan

- `uv run pytest` — 158 client tests pass (12 new: happy-path, optional-omission,
  and error-path coverage for each new method + `trust_tier` pass-through)
- `uv run ruff check src/ tests/` · `uv run ruff format` · `uv run pyright src/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)