### PR TITLE
refactor(client): unify MCP-error handling across all tool methods (#180)

### DIFF
--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -606,7 +606,19 @@ class KaguraAgent:
             query = query_info.query
             self.logger.action("Recalling memories", f'query="{query}"')
 
-            result = await self.client.recall(ctx, query, k=recall_k, filters=query_info.filters)
+            try:
+                result = await self.client.recall(
+                    ctx, query, k=recall_k, filters=query_info.filters
+                )
+            except KaguraAuthError:
+                raise  # Auth errors are unrecoverable — surface to caller
+            except Exception as e:
+                # recall() raises on MCP domain errors (issue #180). Match the
+                # remember/explore paths: log and skip this query rather than
+                # crashing the whole process() pipeline (and losing the
+                # subsequent remember operations).
+                self.logger.warning(f"Recall failed: {e}")
+                continue
 
             for mem in result.get("results", []):
                 recalled.append(
@@ -706,6 +718,9 @@ class KaguraAgent:
             Selected context_id
 
         Raises:
+            ValueError: No contexts are available to select from.
+            KaguraNotFoundError / KaguraError: The ``list_contexts`` call hit an
+                MCP domain error (issue #180); auto-selection cannot proceed.
             KaguraLLMError: Context selection failed
         """
         self.logger.action("Auto-selecting context")

--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -522,6 +522,8 @@ class KaguraAgent:
         Raises:
             KaguraLLMError: LLM call failed
             KaguraRateLimitError: Rate limit exceeded
+            KaguraAuthError: Authentication failed while building enhanced
+                context — re-raised unrecoverable, not swallowed.
         """
         self.logger.action("Analyzing session with LLM", f"model={self.model}")
 

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1855,15 +1855,12 @@ async def _remember_file_object(
                 "content_type": file_obj.content_type,
             },
         )
-    # remember() surfaces MCP domain errors as a dict (status=="error" /
-    # missing memory_id) rather than raising. Treat those as failures — same
-    # as the ingest path — so the caller's handler can surface the file_id
-    # and exit non-zero instead of printing an error payload as success.
-    if (
-        not isinstance(result, dict)
-        or result.get("status") == "error"
-        or not result.get("memory_id")
-    ):
+    # remember() now raises KaguraError/KaguraNotFoundError on MCP domain
+    # errors (issue #180). A successful response can still in principle lack
+    # memory_id; treat that as a failure so the caller's handler can surface
+    # the file_id and exit non-zero instead of printing an incomplete payload
+    # as success.
+    if not isinstance(result, dict) or not result.get("memory_id"):
         raise KaguraError(f"memory write reported an error: {result}")
     return result
 

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -276,6 +276,28 @@ class KaguraClient:
 
         return {}
 
+    async def _call_tool_checked(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Call an MCP tool and translate domain errors into exceptions (issue #180).
+
+        Wraps :meth:`_call_tool` with :meth:`_raise_for_mcp_error` so a server
+        ``{"status": "error", ...}`` response raises :class:`KaguraNotFoundError`
+        / :class:`KaguraError` instead of being returned as data. This is the
+        single chokepoint every tool method routes through; use it instead of
+        calling :meth:`_call_tool` directly unless a method deliberately wants
+        the raw error dict.
+
+        Args:
+            tool_name: MCP tool name; also used as the operation label in the
+                raised exception's message.
+            arguments: Tool arguments.
+
+        Returns:
+            The parsed tool result (only when the server reported success).
+        """
+        result = await self._call_tool(tool_name, arguments)
+        self._raise_for_mcp_error(result, tool_name)
+        return result
+
     async def remember(
         self,
         context_id: str,
@@ -362,9 +384,7 @@ class KaguraClient:
         if linked_source_uris is not None:
             arguments["linked_source_uris"] = linked_source_uris
 
-        result = await self._call_tool("remember", arguments)
-        self._raise_for_mcp_error(result, "remember")
-        return result
+        return await self._call_tool_checked("remember", arguments)
 
     async def recall(
         self,
@@ -439,9 +459,7 @@ class KaguraClient:
             arguments["search_mode"] = search_mode
         if include_explore_hints:
             arguments["include_explore_hints"] = True
-        result = await self._call_tool("recall", arguments)
-        self._raise_for_mcp_error(result, "recall")
-        return result
+        return await self._call_tool_checked("recall", arguments)
 
     async def recall_upcoming(
         self,
@@ -478,9 +496,7 @@ class KaguraClient:
             arguments["from"] = from_
         if until is not None:
             arguments["until"] = until
-        result = await self._call_tool("recall_upcoming", arguments)
-        self._raise_for_mcp_error(result, "recall_upcoming")
-        return result
+        return await self._call_tool_checked("recall_upcoming", arguments)
 
     async def load_pinned(
         self,
@@ -530,9 +546,7 @@ class KaguraClient:
         arguments: dict[str, Any] = {"context_id": context_id}
         if cap is not None:
             arguments["cap"] = cap
-        result = await self._call_tool("load_pinned", arguments)
-        self._raise_for_mcp_error(result, "load_pinned")
-        return result
+        return await self._call_tool_checked("load_pinned", arguments)
 
     async def feedback(
         self,
@@ -589,9 +603,7 @@ class KaguraClient:
             arguments["query"] = query
         if note is not None:
             arguments["note"] = note
-        result = await self._call_tool("feedback", arguments)
-        self._raise_for_mcp_error(result, "feedback")
-        return result
+        return await self._call_tool_checked("feedback", arguments)
 
     async def set_state(
         self,
@@ -635,9 +647,7 @@ class KaguraClient:
         }
         if ttl_seconds is not None:
             arguments["ttl_seconds"] = ttl_seconds
-        result = await self._call_tool("set_state", arguments)
-        self._raise_for_mcp_error(result, "set_state")
-        return result
+        return await self._call_tool_checked("set_state", arguments)
 
     async def get_state(
         self,
@@ -667,9 +677,7 @@ class KaguraClient:
         arguments: dict[str, Any] = {"context_id": context_id}
         if key is not None:
             arguments["key"] = key
-        result = await self._call_tool("get_state", arguments)
-        self._raise_for_mcp_error(result, "get_state")
-        return result
+        return await self._call_tool_checked("get_state", arguments)
 
     async def list_contexts(self) -> dict[str, Any]:
         """
@@ -678,9 +686,7 @@ class KaguraClient:
         Returns:
             API response with available contexts
         """
-        result = await self._call_tool("list_contexts", {})
-        self._raise_for_mcp_error(result, "list_contexts")
-        return result
+        return await self._call_tool_checked("list_contexts", {})
 
     async def list_tags(
         self,
@@ -735,8 +741,7 @@ class KaguraClient:
         }
         if prefix:
             arguments["prefix"] = prefix
-        result = await self._call_tool("list_tags", arguments)
-        self._raise_for_mcp_error(result, "list_tags")
+        result = await self._call_tool_checked("list_tags", arguments)
         return ListTagsResponse.model_validate(result)
 
     async def get_tool_definitions(self) -> list[dict[str, Any]]:
@@ -781,9 +786,7 @@ class KaguraClient:
             "depth": depth,
             "min_weight": min_weight,
         }
-        result = await self._call_tool("explore", arguments)
-        self._raise_for_mcp_error(result, "explore")
-        return result
+        return await self._call_tool_checked("explore", arguments)
 
     async def reference(
         self,
@@ -808,9 +811,7 @@ class KaguraClient:
             "context_id": context_id,
             "memory_id": memory_id,
         }
-        result = await self._call_tool("reference", arguments)
-        self._raise_for_mcp_error(result, "reference")
-        return result
+        return await self._call_tool_checked("reference", arguments)
 
     async def update_memory(
         self,
@@ -878,9 +879,7 @@ class KaguraClient:
             arguments["context_summary"] = context_summary
         if delivery_mode is not None:
             arguments["delivery_mode"] = delivery_mode
-        result = await self._call_tool("update_memory", arguments)
-        self._raise_for_mcp_error(result, "update_memory")
-        return result
+        return await self._call_tool_checked("update_memory", arguments)
 
     async def forget(
         self,
@@ -910,9 +909,7 @@ class KaguraClient:
         if query:
             arguments["query"] = query
             arguments["k"] = k
-        result = await self._call_tool("forget", arguments)
-        self._raise_for_mcp_error(result, "forget")
-        return result
+        return await self._call_tool_checked("forget", arguments)
 
     async def create_context(
         self,
@@ -967,9 +964,7 @@ class KaguraClient:
             arguments["resource_id"] = resource_id
         if embedding_model is not None:
             arguments["embedding_model"] = embedding_model
-        result = await self._call_tool("create_context", arguments)
-        self._raise_for_mcp_error(result, "create_context")
-        return result
+        return await self._call_tool_checked("create_context", arguments)
 
     async def delete_context(self, context_id: str) -> dict[str, Any]:
         """Soft-delete a context and all its memories.
@@ -980,9 +975,7 @@ class KaguraClient:
         Returns:
             API response with deletion confirmation.
         """
-        result = await self._call_tool("delete_context", {"context_id": context_id})
-        self._raise_for_mcp_error(result, "delete_context")
-        return result
+        return await self._call_tool_checked("delete_context", {"context_id": context_id})
 
     async def update_context(
         self,
@@ -1025,9 +1018,7 @@ class KaguraClient:
             arguments["is_public"] = is_public
         if is_locked is not None:
             arguments["is_locked"] = is_locked
-        result = await self._call_tool("update_context", arguments)
-        self._raise_for_mcp_error(result, "update_context")
-        return result
+        return await self._call_tool_checked("update_context", arguments)
 
     async def setup_resource(
         self,
@@ -1070,9 +1061,7 @@ class KaguraClient:
             arguments["summary"] = summary
         if description is not None:
             arguments["description"] = description
-        result = await self._call_tool("setup_resource", arguments)
-        self._raise_for_mcp_error(result, "setup_resource")
-        return result
+        return await self._call_tool_checked("setup_resource", arguments)
 
     async def merge_contexts(
         self,
@@ -1106,9 +1095,7 @@ class KaguraClient:
         }
         if delete_source:
             arguments["delete_source"] = True
-        result = await self._call_tool("merge_contexts", arguments)
-        self._raise_for_mcp_error(result, "merge_contexts")
-        return result
+        return await self._call_tool_checked("merge_contexts", arguments)
 
     async def list_edges(
         self,
@@ -1148,8 +1135,7 @@ class KaguraClient:
             arguments["edge_types"] = edge_types
         if limit is not None:
             arguments["limit"] = limit
-        result = await self._call_tool("list_edges", arguments)
-        self._raise_for_mcp_error(result, "list_edges")
+        result = await self._call_tool_checked("list_edges", arguments)
         return [Edge.model_validate(e) for e in result.get("edges", [])]
 
     async def create_edge(
@@ -1203,8 +1189,7 @@ class KaguraClient:
             "weight": weight,
             "confidence": confidence,
         }
-        result = await self._call_tool("create_edge", arguments)
-        self._raise_for_mcp_error(result, "create_edge")
+        result = await self._call_tool_checked("create_edge", arguments)
         return Edge.model_validate(result.get("edge", result))
 
     async def update_edge(
@@ -1244,8 +1229,7 @@ class KaguraClient:
             arguments["weight"] = weight
         if edge_type is not None:
             arguments["edge_type"] = edge_type
-        result = await self._call_tool("update_edge", arguments)
-        self._raise_for_mcp_error(result, "update_edge")
+        result = await self._call_tool_checked("update_edge", arguments)
         return Edge.model_validate(result.get("edge", result))
 
     async def delete_edge(
@@ -1273,8 +1257,7 @@ class KaguraClient:
             "source_id": source_id,
             "target_id": target_id,
         }
-        result = await self._call_tool("delete_edge", arguments)
-        self._raise_for_mcp_error(result, "delete_edge")
+        result = await self._call_tool_checked("delete_edge", arguments)
         return bool(result.get("deleted", True))
 
     async def get_usage(self) -> UsageInfo:
@@ -1283,8 +1266,7 @@ class KaguraClient:
         Returns:
             UsageInfo with plan, memories, contexts, members, and MCP call limits.
         """
-        result = await self._call_tool("get_usage", {})
-        self._raise_for_mcp_error(result, "get_usage")
+        result = await self._call_tool_checked("get_usage", {})
         return UsageInfo.model_validate(result)
 
     async def get_context_info(
@@ -1305,8 +1287,7 @@ class KaguraClient:
             "context_id": context_id,
             "include_details": include_details,
         }
-        result = await self._call_tool("get_context_info", arguments)
-        self._raise_for_mcp_error(result, "get_context_info")
+        result = await self._call_tool_checked("get_context_info", arguments)
         return ContextInfo.model_validate(result)
 
     async def _get_context_info_cached(self, context_id: str) -> ContextInfo | None:
@@ -1402,9 +1383,7 @@ class KaguraClient:
             arguments["reranker_provider"] = reranker_provider
         if reranker_model is not None:
             arguments["reranker_model"] = reranker_model
-        result = await self._call_tool("update_search_config", arguments)
-        self._raise_for_mcp_error(result, "update_search_config")
-        return result
+        return await self._call_tool_checked("update_search_config", arguments)
 
     async def get_server_info(self) -> ServerInfo:
         """Get server name, version, environment, and feature flags.
@@ -1626,11 +1605,10 @@ class KaguraClient:
             KaguraNotFoundError: Context not found.
             KaguraError: Other server-side error.
         """
-        result = await self._call_tool(
+        result = await self._call_tool_checked(
             "get_sleep_history",
             {"context_id": context_id, "limit": limit},
         )
-        self._raise_for_mcp_error(result, "get_sleep_history")
         return [SleepReport.model_validate(r) for r in result["reports"]]
 
     async def get_sleep_report(
@@ -1653,11 +1631,10 @@ class KaguraClient:
             KaguraNotFoundError: Report not found or not owned by caller.
             KaguraError: Other server-side error.
         """
-        result = await self._call_tool(
+        result = await self._call_tool_checked(
             "get_sleep_report",
             {"context_id": context_id, "report_id": report_id},
         )
-        self._raise_for_mcp_error(result, "get_sleep_report")
         # The MCP tool wraps the report fields under a "report" key;
         # flatten so SleepReportDetail (a SleepReport subclass) validates
         # naturally without forcing callers through an extra ``.report.``
@@ -1695,11 +1672,10 @@ class KaguraClient:
                 server-side error. The exception message includes the
                 server-side error code for triage.
         """
-        result = await self._call_tool(
+        result = await self._call_tool_checked(
             "rollback_sleep_run",
             {"context_id": context_id, "report_id": report_id},
         )
-        self._raise_for_mcp_error(result, "rollback_sleep_run")
         return RollbackResult.model_validate(result)
 
     async def list_embedding_models(self) -> EmbeddingModelsResponse:

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -58,6 +58,13 @@ class KaguraClient:
         KaguraAuthError: Authentication failed
         KaguraConnectionError: Connection to server failed
         KaguraRateLimitError: Rate limit exceeded
+
+    MCP tool methods additionally translate the server's structured domain
+    errors (``{"status": "error", ...}``) into exceptions rather than
+    returning them as data (issue #180): a missing context/memory/report
+    raises :class:`KaguraNotFoundError`, and any other domain error raises
+    :class:`KaguraError`. Callers should use ``try/except`` rather than
+    inspecting ``result["status"]``.
     """
 
     def __init__(
@@ -355,7 +362,9 @@ class KaguraClient:
         if linked_source_uris is not None:
             arguments["linked_source_uris"] = linked_source_uris
 
-        return await self._call_tool("remember", arguments)
+        result = await self._call_tool("remember", arguments)
+        self._raise_for_mcp_error(result, "remember")
+        return result
 
     async def recall(
         self,
@@ -430,7 +439,9 @@ class KaguraClient:
             arguments["search_mode"] = search_mode
         if include_explore_hints:
             arguments["include_explore_hints"] = True
-        return await self._call_tool("recall", arguments)
+        result = await self._call_tool("recall", arguments)
+        self._raise_for_mcp_error(result, "recall")
+        return result
 
     async def recall_upcoming(
         self,
@@ -467,7 +478,9 @@ class KaguraClient:
             arguments["from"] = from_
         if until is not None:
             arguments["until"] = until
-        return await self._call_tool("recall_upcoming", arguments)
+        result = await self._call_tool("recall_upcoming", arguments)
+        self._raise_for_mcp_error(result, "recall_upcoming")
+        return result
 
     async def load_pinned(
         self,
@@ -517,7 +530,9 @@ class KaguraClient:
         arguments: dict[str, Any] = {"context_id": context_id}
         if cap is not None:
             arguments["cap"] = cap
-        return await self._call_tool("load_pinned", arguments)
+        result = await self._call_tool("load_pinned", arguments)
+        self._raise_for_mcp_error(result, "load_pinned")
+        return result
 
     async def feedback(
         self,
@@ -663,7 +678,9 @@ class KaguraClient:
         Returns:
             API response with available contexts
         """
-        return await self._call_tool("list_contexts", {})
+        result = await self._call_tool("list_contexts", {})
+        self._raise_for_mcp_error(result, "list_contexts")
+        return result
 
     async def list_tags(
         self,
@@ -764,7 +781,9 @@ class KaguraClient:
             "depth": depth,
             "min_weight": min_weight,
         }
-        return await self._call_tool("explore", arguments)
+        result = await self._call_tool("explore", arguments)
+        self._raise_for_mcp_error(result, "explore")
+        return result
 
     async def reference(
         self,
@@ -789,7 +808,9 @@ class KaguraClient:
             "context_id": context_id,
             "memory_id": memory_id,
         }
-        return await self._call_tool("reference", arguments)
+        result = await self._call_tool("reference", arguments)
+        self._raise_for_mcp_error(result, "reference")
+        return result
 
     async def update_memory(
         self,
@@ -857,7 +878,9 @@ class KaguraClient:
             arguments["context_summary"] = context_summary
         if delivery_mode is not None:
             arguments["delivery_mode"] = delivery_mode
-        return await self._call_tool("update_memory", arguments)
+        result = await self._call_tool("update_memory", arguments)
+        self._raise_for_mcp_error(result, "update_memory")
+        return result
 
     async def forget(
         self,
@@ -887,7 +910,9 @@ class KaguraClient:
         if query:
             arguments["query"] = query
             arguments["k"] = k
-        return await self._call_tool("forget", arguments)
+        result = await self._call_tool("forget", arguments)
+        self._raise_for_mcp_error(result, "forget")
+        return result
 
     async def create_context(
         self,
@@ -942,7 +967,9 @@ class KaguraClient:
             arguments["resource_id"] = resource_id
         if embedding_model is not None:
             arguments["embedding_model"] = embedding_model
-        return await self._call_tool("create_context", arguments)
+        result = await self._call_tool("create_context", arguments)
+        self._raise_for_mcp_error(result, "create_context")
+        return result
 
     async def delete_context(self, context_id: str) -> dict[str, Any]:
         """Soft-delete a context and all its memories.
@@ -953,7 +980,9 @@ class KaguraClient:
         Returns:
             API response with deletion confirmation.
         """
-        return await self._call_tool("delete_context", {"context_id": context_id})
+        result = await self._call_tool("delete_context", {"context_id": context_id})
+        self._raise_for_mcp_error(result, "delete_context")
+        return result
 
     async def update_context(
         self,
@@ -996,7 +1025,9 @@ class KaguraClient:
             arguments["is_public"] = is_public
         if is_locked is not None:
             arguments["is_locked"] = is_locked
-        return await self._call_tool("update_context", arguments)
+        result = await self._call_tool("update_context", arguments)
+        self._raise_for_mcp_error(result, "update_context")
+        return result
 
     async def setup_resource(
         self,
@@ -1039,7 +1070,9 @@ class KaguraClient:
             arguments["summary"] = summary
         if description is not None:
             arguments["description"] = description
-        return await self._call_tool("setup_resource", arguments)
+        result = await self._call_tool("setup_resource", arguments)
+        self._raise_for_mcp_error(result, "setup_resource")
+        return result
 
     async def merge_contexts(
         self,
@@ -1073,7 +1106,9 @@ class KaguraClient:
         }
         if delete_source:
             arguments["delete_source"] = True
-        return await self._call_tool("merge_contexts", arguments)
+        result = await self._call_tool("merge_contexts", arguments)
+        self._raise_for_mcp_error(result, "merge_contexts")
+        return result
 
     async def list_edges(
         self,
@@ -1249,6 +1284,7 @@ class KaguraClient:
             UsageInfo with plan, memories, contexts, members, and MCP call limits.
         """
         result = await self._call_tool("get_usage", {})
+        self._raise_for_mcp_error(result, "get_usage")
         return UsageInfo.model_validate(result)
 
     async def get_context_info(
@@ -1270,6 +1306,7 @@ class KaguraClient:
             "include_details": include_details,
         }
         result = await self._call_tool("get_context_info", arguments)
+        self._raise_for_mcp_error(result, "get_context_info")
         return ContextInfo.model_validate(result)
 
     async def _get_context_info_cached(self, context_id: str) -> ContextInfo | None:
@@ -1365,7 +1402,9 @@ class KaguraClient:
             arguments["reranker_provider"] = reranker_provider
         if reranker_model is not None:
             arguments["reranker_model"] = reranker_model
-        return await self._call_tool("update_search_config", arguments)
+        result = await self._call_tool("update_search_config", arguments)
+        self._raise_for_mcp_error(result, "update_search_config")
+        return result
 
     async def get_server_info(self) -> ServerInfo:
         """Get server name, version, environment, and feature flags.

--- a/src/kagura_memory/ingest/ingestor.py
+++ b/src/kagura_memory/ingest/ingestor.py
@@ -850,14 +850,8 @@ class FileIngestor:
                 )
             )
             return None
-        if not isinstance(result, dict) or result.get("status") == "error":
-            errors.append(
-                IngestErrorRecord(
-                    step="remember",
-                    message=f"overview write reported error: {result}",
-                )
-            )
-            return None
+        # remember() raises on MCP domain errors (issue #180); the try/except
+        # above records those. A success response may still lack memory_id.
         memory_id = result.get("memory_id")
         if not memory_id:
             errors.append(
@@ -930,15 +924,9 @@ class FileIngestor:
                         )
                     )
                     return
-            if not isinstance(result, dict) or result.get("status") == "error":
-                errors.append(
-                    IngestErrorRecord(
-                        step="remember",
-                        section_index=idx,
-                        message=f"section write reported error: {result}",
-                    )
-                )
-                return
+            # remember() raises on MCP domain errors (issue #180); the
+            # try/except above records those. A success response may still
+            # lack memory_id.
             memory_id = result.get("memory_id")
             if memory_id:
                 results[idx] = str(memory_id)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -653,6 +653,42 @@ async def test_execute_recalls_explore_auth_error():
     await agent.close()
 
 
+@pytest.mark.asyncio
+async def test_execute_recalls_swallows_recall_error():
+    """recall() raising an MCP domain error (issue #180) must be logged and
+    skipped, not propagated — the agent stays fault-tolerant."""
+    from kagura_memory.exceptions import KaguraNotFoundError
+
+    agent = KaguraAgent(api_key="test", model="gpt-test")
+
+    with patch.object(agent.client, "recall", new_callable=AsyncMock) as mock_recall:
+        mock_recall.side_effect = KaguraNotFoundError("context_not_found")
+
+        recalled, explored, actions = await agent._execute_recalls(
+            "ctx", [RecallQuery(query="test")], deep=True
+        )
+
+        assert recalled == []
+        assert explored == []
+        assert actions == []  # failed query contributes no action
+
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_execute_recalls_propagates_recall_auth_error():
+    """A KaguraAuthError from recall() is unrecoverable and must surface."""
+    agent = KaguraAgent(api_key="test", model="gpt-test")
+
+    with patch.object(agent.client, "recall", new_callable=AsyncMock) as mock_recall:
+        mock_recall.side_effect = KaguraAuthError("bad key")
+
+        with pytest.raises(KaguraAuthError):
+            await agent._execute_recalls("ctx", [RecallQuery(query="test")], deep=False)
+
+    await agent.close()
+
+
 # ============================================================================
 # _analyze_session tests
 # ============================================================================

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2224,6 +2224,59 @@ async def test_get_state_surfaces_server_error():
 
 
 # ============================================================================
+# Issue #180 — unified MCP-error translation across the raw-dict family
+# ============================================================================
+
+# Every MCP tool method must translate a server {"status": "error", ...}
+# response into a typed exception instead of returning it as data. Each entry
+# invokes one method with minimal args; the patched _call_tool returns a
+# context_not_found error, so the method must raise KaguraNotFoundError.
+_ERROR_TRANSLATING_METHODS = [
+    ("remember", lambda c: c.remember(context_id="c", summary="s", content="x")),
+    ("recall", lambda c: c.recall(context_id="c", query="q")),
+    ("recall_upcoming", lambda c: c.recall_upcoming(context_id="c")),
+    ("load_pinned", lambda c: c.load_pinned(context_id="c")),
+    ("list_contexts", lambda c: c.list_contexts()),
+    ("explore", lambda c: c.explore(context_id="c", memory_id="m")),
+    ("reference", lambda c: c.reference(context_id="c", memory_id="m")),
+    ("update_memory", lambda c: c.update_memory(context_id="c", memory_id="m", summary="s")),
+    ("forget", lambda c: c.forget(context_id="c", memory_id="m")),
+    ("delete_context", lambda c: c.delete_context(context_id="c")),
+    ("update_context", lambda c: c.update_context(context_id="c", display_name="d")),
+    ("setup_resource", lambda c: c.setup_resource(resource_id="r")),
+    ("merge_contexts", lambda c: c.merge_contexts(source_id="a", target_id="b")),
+    ("update_search_config", lambda c: c.update_search_config(context_id="c")),
+    ("get_usage", lambda c: c.get_usage()),
+    ("get_context_info", lambda c: c.get_context_info(context_id="c")),
+    # create_context calls list_contexts() first; the mocked error surfaces there.
+    ("create_context", lambda c: c.create_context(name="n")),
+]
+
+
+@pytest.mark.parametrize(
+    "invoke",
+    [m[1] for m in _ERROR_TRANSLATING_METHODS],
+    ids=[m[0] for m in _ERROR_TRANSLATING_METHODS],
+)
+@pytest.mark.asyncio
+async def test_mcp_methods_raise_on_server_error(invoke):
+    """Issue #180: raw-dict tool methods translate MCP errors into exceptions, not data."""
+    client = _make_initialized_client()
+
+    try:
+        with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+            mock.return_value = {
+                "status": "error",
+                "error": "context_not_found",
+                "message": "Context not found.",
+            }
+            with pytest.raises(KaguraNotFoundError):
+                await invoke(client)
+    finally:
+        await client.close()
+
+
+# ============================================================================
 # get_server_info / check_server_version
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Resolves #180 with **Option A**: every `KaguraClient` MCP tool method now raises
on a server `{"status": "error", ...}` response instead of returning it as data.
Previously only the model/bool-returning methods did this; the raw-dict family
silently returned error dicts, so an autonomous consumer could mistake an error
for success.

Closes #180.

## ⚠️ Breaking change

Callers must use `try/except` (catching `KaguraNotFoundError` / `KaguraError`)
rather than inspecting `result["status"] == "error"`. Documented once at the
`KaguraClient` class level. Appropriate for a 0.x minor.

**Migration:**
```python
# Before
result = await client.remember(...)
if result.get("status") == "error":
    handle_error(result)

# After
try:
    result = await client.remember(...)
except KaguraNotFoundError:
    ...
except KaguraError:
    ...
```

## Changes

- **`_call_tool_checked(name, args)`** — new single chokepoint (`_call_tool` +
  `_raise_for_mcp_error`). Every tool method routes through it, so error
  translation is owned in one place and future methods inherit it for free.
- **17 methods converted**: the raw-dict family (`remember`, `recall`,
  `recall_upcoming`, `load_pinned`, `explore`, `reference`, `update_memory`,
  `forget`, `create_context`, `delete_context`, `update_context`,
  `setup_resource`, `merge_contexts`, `update_search_config`, `list_contexts`)
  plus `get_usage`/`get_context_info` (an error dict there previously raised a
  pydantic `ValidationError`; now a typed `KaguraError`).
- **Consumers updated**: dead `status == "error"` checks removed from `cli.py`
  and the two `ingestor.py` `remember()` sites (their `try/except` already
  records the raise).
- **Agent fault-tolerance preserved** (review fix): `KaguraAgent._execute_recalls`
  now wraps `recall()` (re-raise `KaguraAuthError`, else log + skip) so a failed
  recall no longer crashes `process()` and drops the subsequent `remember`
  operations — matching the sibling `remember`/`explore` paths.

## Review trail

`/quality` (1068 tests, ruff, pyright) → two `/code-review` rounds (Haiku
finders/verifiers, Opus fixes): round 1 caught the agent `recall` regression;
round 2 converged with only a doc fix. `/simplify` outcome applied (the
`_call_tool_checked` extraction).

## Test plan

- `uv run pytest` — 1068 pass (new: parametrized error-path test across all 17
  converted methods + 2 agent recall-failure regression tests)
- `uv run ruff check` / `ruff format` / `uv run pyright src/` — clean

## Follow-up (out of scope)

- Pre-existing latent `KeyError` in `create_context`'s quota-exceeded message
  (`contexts["count"]`/`["limit"]` accessed without `.get`); unrelated to error
  unification — worth a separate trivial fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)