### PR TITLE
fix(client): create_context quota message can KeyError on missing count/limit (#183)

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -947,7 +947,8 @@ class KaguraClient:
             from .exceptions import KaguraQuotaError
 
             raise KaguraQuotaError(
-                f"Context limit reached ({contexts['count']}/{contexts['limit']}). "
+                f"Context limit reached ({contexts.get('count', '?')}/"
+                f"{contexts.get('limit', '?')}). "
                 "Delete unused contexts or upgrade your plan."
             )
 

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -946,9 +946,15 @@ class KaguraClient:
         if not contexts.get("can_create", True):
             from .exceptions import KaguraQuotaError
 
+            # Use ``.get`` then coerce None → "?" so a quota response that is
+            # missing count/limit OR carries them as null (both forms of server
+            # schema drift) still yields a clean message, never KeyError or a
+            # literal "None" (issue #183). A real 0 is preserved as "0".
+            count = contexts.get("count")
+            limit = contexts.get("limit")
             raise KaguraQuotaError(
-                f"Context limit reached ({contexts.get('count', '?')}/"
-                f"{contexts.get('limit', '?')}). "
+                f"Context limit reached ({'?' if count is None else count}/"
+                f"{'?' if limit is None else limit}). "
                 "Delete unused contexts or upgrade your plan."
             )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1042,14 +1042,24 @@ async def test_create_context_quota_exceeded():
 
 
 @pytest.mark.asyncio
-async def test_create_context_quota_exceeded_missing_count_limit():
-    """create_context() must raise KaguraQuotaError (not KeyError) when the quota
-    response omits count/limit (issue #183) — the message uses safe ``.get`` access."""
+@pytest.mark.parametrize(
+    "quota_response",
+    [
+        # count/limit keys absent entirely
+        {"status": "success", "contexts": [], "can_create": False},
+        # count/limit present but null (JSON null — a distinct schema-drift form)
+        {"status": "success", "contexts": [], "can_create": False, "count": None, "limit": None},
+    ],
+    ids=["missing-keys", "null-values"],
+)
+async def test_create_context_quota_exceeded_missing_count_limit(quota_response):
+    """create_context() must raise KaguraQuotaError with a clean "(?/?)" message
+    (not KeyError, not "(None/None)") when the quota response omits count/limit
+    OR carries them as null (issue #183) — the message coerces both to "?"."""
     client = _make_initialized_client()
 
     with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
-        # can_create=False but no count/limit keys (server schema drift / partial payload)
-        mock.return_value = {"status": "success", "contexts": [], "can_create": False}
+        mock.return_value = quota_response
 
         with pytest.raises(KaguraQuotaError, match=r"Context limit reached \(\?/\?\)"):
             await client.create_context(name="over-limit")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1042,6 +1042,22 @@ async def test_create_context_quota_exceeded():
 
 
 @pytest.mark.asyncio
+async def test_create_context_quota_exceeded_missing_count_limit():
+    """create_context() must raise KaguraQuotaError (not KeyError) when the quota
+    response omits count/limit (issue #183) — the message uses safe ``.get`` access."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        # can_create=False but no count/limit keys (server schema drift / partial payload)
+        mock.return_value = {"status": "success", "contexts": [], "can_create": False}
+
+        with pytest.raises(KaguraQuotaError, match=r"Context limit reached \(\?/\?\)"):
+            await client.create_context(name="over-limit")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_update_context_with_resource_id_and_is_public():
     """update_context() should pass resource_id and is_public."""
     client = _make_initialized_client()


### PR DESCRIPTION
Closes #183

## Summary
- `KaguraClient.create_context`'s quota-exceeded message used direct indexing
  (`contexts['count']`/`['limit']`) while the `can_create` guard used `.get()`,
  so a success response missing those keys raised `KeyError` instead of the
  intended `KaguraQuotaError`.
- Extract the values via `.get()` and coerce `None` → `"?"`, so both a missing
  key and an explicit JSON `null` (two forms of server schema drift) render a
  clean `(?/?)` message; a real `0` is preserved.

## Implementation notes
- `src/kagura_memory/client.py`: quota-message construction in `create_context`.
- `tests/test_client.py`: regression test parametrized over `missing-keys` and
  `null-values`, asserting `KaguraQuotaError` (not `KeyError`/`(None/None)`).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (DX Lead)
- review provider: none (Copilot loop skipped via "without copilot loop")

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/183-fix-fix-client-create-context-quota-message.gate1.md
- ~/.claude/cache/gh-issue-driven/183-fix-fix-client-create-context-quota-message.gate2.md

🤖 Generated via /gh-issue-driven:ship
