### PR TITLE
fix(auth): lock-guard delete_profile against token loss (#190)

### DIFF
--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -379,13 +379,24 @@ def delete_profile(
     profile_name: str,
     path: Path | None = None,
 ) -> None:
-    """Remove a profile and save. No-op if the profile is absent."""
+    """Remove a profile and save. No-op if the profile is absent.
+
+    The read-modify-write is wrapped in the same cross-process advisory
+    :func:`kagura_memory._filelock.file_lock` as :func:`update_profile`, so a
+    ``kagura auth logout`` (delete) racing a concurrent token refresh (update)
+    in a sibling ``kagura-mcp`` process cannot clobber a freshly written token
+    (#190). The absent-profile early return runs *inside* the lock so the
+    membership check and the save observe one consistent snapshot (no TOCTOU).
+    """
+    from .._filelock import file_lock
+
     path = _resolve_path(path)
-    cf = load_credentials_file(path)
-    if profile_name not in cf.profiles:
-        return
-    cf.delete_profile(profile_name)
-    save_credentials_file(cf, path)
+    with file_lock(path, exclusive=True):
+        cf = load_credentials_file(path)
+        if profile_name not in cf.profiles:
+            return
+        cf.delete_profile(profile_name)
+        save_credentials_file(cf, path)
 
 
 def delete_credentials_file(path: Path | None = None) -> None:

--- a/tests/test_auth_credentials.py
+++ b/tests/test_auth_credentials.py
@@ -770,3 +770,59 @@ def test_update_profile_is_file_lock_guarded(tmp_path: Path, monkeypatch: pytest
 
     assert calls == [True]  # acquired exactly once, exclusively
     assert load_credentials_file(path).get_profile().access_token == "locked-write"
+
+
+def test_delete_profile_is_file_lock_guarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """delete_profile wraps its read-modify-write in the cross-process file lock.
+
+    Without the lock, a logout (delete) racing a concurrent token refresh (update)
+    in a sibling kagura-mcp process can clobber a freshly written token (#190).
+    """
+    import kagura_memory._filelock as fl
+    from kagura_memory.auth.credentials import delete_profile
+
+    path = tmp_path / "creds.json"
+    cf = CredentialsFile()
+    cf.set_profile("alice", _sample_creds())
+    cf.set_profile("bob", _sample_creds())
+    save_credentials_file(cf, path)
+
+    calls: list[bool] = []
+    real_file_lock = fl.file_lock
+
+    def spy_file_lock(target: Path, *, exclusive: bool = True):
+        calls.append(exclusive)
+        return real_file_lock(target, exclusive=exclusive)
+
+    monkeypatch.setattr(fl, "file_lock", spy_file_lock)
+
+    delete_profile("alice", path)
+
+    assert calls == [True]  # acquired exactly once, exclusively
+    assert "alice" not in load_credentials_file(path).profiles
+    assert "bob" in load_credentials_file(path).profiles
+
+
+def test_delete_profile_no_op_is_lock_guarded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The absent-profile early return still happens under the lock (no TOCTOU)."""
+    import kagura_memory._filelock as fl
+    from kagura_memory.auth.credentials import delete_profile
+
+    path = tmp_path / "creds.json"
+    cf = CredentialsFile()
+    cf.set_profile("alice", _sample_creds())
+    save_credentials_file(cf, path)
+
+    calls: list[bool] = []
+    real_file_lock = fl.file_lock
+
+    def spy_file_lock(target: Path, *, exclusive: bool = True):
+        calls.append(exclusive)
+        return real_file_lock(target, exclusive=exclusive)
+
+    monkeypatch.setattr(fl, "file_lock", spy_file_lock)
+
+    delete_profile("does-not-exist", path)
+
+    assert calls == [True]  # lock acquired before the membership check
+    assert "alice" in load_credentials_file(path).profiles


### PR DESCRIPTION
Closes #190

## Summary
- `delete_profile` did an unlocked load→check→delete→save while `update_profile` wraps the same sequence in the cross-process advisory `file_lock`. A `kagura auth logout` (delete) racing a concurrent token refresh (update) in a sibling `kagura-mcp` process could overwrite a freshly written token and corrupt `credentials.json`.
- Wrapped the read-modify-write in `file_lock(path, exclusive=True)`, mirroring `update_profile` exactly.
- Moved the absent-profile early return *inside* the lock so the membership check and the save observe one consistent snapshot (no TOCTOU).

## Implementation notes
- `_resolve_path(path)` stays outside the lock (same ordering as `update_profile`); the lock is on the sibling `credentials.json.lock`, so it never races the atomic `os.replace` in `save_credentials_file`.
- Added two regression tests mirroring `test_update_profile_is_file_lock_guarded`: one asserts the lock is acquired exactly once (`exclusive=True`) and deletes the right profile; the other asserts the lock is held *before* the absent-profile early return.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green · qa-lead: green · cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
