### PR TITLE
fix(ingest): pin fetcher connection to close DNS-rebinding SSRF (#188)

### DIFF
--- a/src/kagura_memory/ingest/_safety.py
+++ b/src/kagura_memory/ingest/_safety.py
@@ -5,13 +5,11 @@ local host, the local network, or cloud-provider metadata endpoints. The
 list is built from RFC 1918, RFC 4193, RFC 6890, and the documented cloud
 metadata IP ranges as of 2026-Q2.
 
-DNS rebinding caveat: pre-flight resolution + denylist closes 99% of the
-attack surface (an externally-supplied hostname pointing at
-``169.254.169.254`` is rejected). A timing-correlated DNS rebinding attack
-that flips the hostname between our resolve and httpx's connect remains
-theoretically possible. A follow-up issue tracks installing a custom httpx
-transport that pins the connection to the resolved IP for true rebinding
-protection.
+DNS rebinding: pre-flight resolution + this denylist rejects an
+externally-supplied hostname that points at, e.g., ``169.254.169.254``. The
+timing-correlated rebinding window (a hostname that flips between our resolve
+and httpx's connect) is closed by the fetcher pinning the connection to the
+exact IP validated here — see :meth:`Fetcher._stream_request` (#188).
 """
 
 from __future__ import annotations

--- a/src/kagura_memory/ingest/fetcher.py
+++ b/src/kagura_memory/ingest/fetcher.py
@@ -101,6 +101,13 @@ class Fetcher:
             ),
             follow_redirects=False,  # we handle redirects manually for SSRF re-check
             headers={"User-Agent": "kagura-memory-ingest/0.1"},
+            # Pinning rewrites the URL host to the validated IP (#188), which
+            # collapses httpcore's pool key (scheme, host, port) onto the IP.
+            # Disable keepalive reuse so two different hostnames sharing an IP
+            # never reuse a connection opened with the other's SNI/cert. The
+            # fetcher streams one response per request and closes it anyway, so
+            # there is nothing to gain from pooling.
+            limits=httpx.Limits(max_keepalive_connections=0),
         )
 
     async def __aenter__(self) -> Fetcher:
@@ -165,11 +172,11 @@ class Fetcher:
         if not parsed.hostname:
             raise KaguraFetchError("URL has no hostname", url=url)
 
-        await self._validate_hostname(parsed.hostname, url)
+        connect_ip = await self._validate_hostname(parsed.hostname, url)
 
         current_url = url
         for _ in range(self.max_redirects + 1):
-            response = await self._stream_request(current_url)
+            response = await self._stream_request(current_url, connect_ip)
             if response.status_code in (301, 302, 303, 307, 308):
                 # ALL redirect error paths must close the streamed response
                 # before raising — otherwise repeated malformed redirects
@@ -205,7 +212,7 @@ class Fetcher:
                             "redirect URL has embedded credentials (user:pass@host)",
                             url=next_url,
                         )
-                    await self._validate_hostname(next_parsed.hostname, next_url)
+                    connect_ip = await self._validate_hostname(next_parsed.hostname, next_url)
                 finally:
                     await response.aclose()
                 current_url = next_url
@@ -216,8 +223,15 @@ class Fetcher:
 
         raise KaguraFetchError(f"too many redirects (max {self.max_redirects})", url=url)
 
-    async def _validate_hostname(self, hostname: str, url: str) -> None:
-        """Resolve ``hostname`` and reject if any IP is in the denylist."""
+    async def _validate_hostname(self, hostname: str, url: str) -> str:
+        """Resolve ``hostname``, reject blocked IPs, and return one to pin to.
+
+        Every resolved IP is checked against the denylist (a single blocked
+        address rejects the whole hostname). The returned IP is then used as
+        the connection target in :meth:`_stream_request`, so httpx connects to
+        exactly the address we validated rather than re-resolving the hostname
+        at connect time — which is what closes the DNS-rebinding window (#188).
+        """
         try:
             addrs = await asyncio.to_thread(
                 socket.getaddrinfo, hostname, None, 0, socket.SOCK_STREAM
@@ -226,21 +240,43 @@ class Fetcher:
             raise KaguraFetchError(f"hostname resolution failed: {e}", url=url) from e
         # info[4] is the sockaddr; first element is the IP string for both
         # AF_INET and AF_INET6. Coerce explicitly because pyright reads the
-        # tuple as ``str | int``.
-        ips: set[str] = {str(info[4][0]) for info in addrs}
+        # tuple as ``str | int``. Keep resolution order so the pinned IP is
+        # deterministic (we pin the first, having validated them all).
+        ips: list[str] = [str(info[4][0]) for info in addrs]
         if not ips:
             raise KaguraFetchError(f"no IP addresses for {hostname!r}", url=url)
-        blocked = sorted(ip for ip in ips if is_blocked_ip(ip))
+        blocked = sorted({ip for ip in ips if is_blocked_ip(ip)})
         if blocked:
             raise KaguraFetchError(
                 f"hostname {hostname!r} resolved to blocked IP(s): {', '.join(blocked)}",
                 url=url,
             )
+        return ips[0]
 
-    async def _stream_request(self, url: str) -> httpx.Response:
-        """Issue a streaming GET. Caller is responsible for closing the response."""
+    async def _stream_request(self, url: str, connect_ip: str) -> httpx.Response:
+        """Issue a streaming GET pinned to ``connect_ip``.
+
+        The request URL's host is rewritten to the pre-validated IP so httpx
+        connects to exactly that address with no connect-time re-resolution
+        (#188). The original ``Host`` header is preserved for virtual-host
+        routing, and the TLS SNI + certificate hostname verification use the
+        real hostname via the ``sni_hostname`` request extension — so HTTPS
+        certificates are still validated against the hostname, not the IP. The
+        extension is inert for plain ``http``. Caller closes the response.
+        """
+        parsed = httpx.URL(url)
+        pinned_url = parsed.copy_with(host=connect_ip)
+        # ``netloc`` renders host[:port] with correct IPv6 bracketing; URL
+        # credentials are already rejected in _fetch_url, so no userinfo leaks
+        # into the Host header.
+        host_header = parsed.netloc.decode("ascii")
         try:
-            request = self._client.build_request("GET", url)
+            request = self._client.build_request(
+                "GET",
+                pinned_url,
+                headers={"Host": host_header},
+                extensions={"sni_hostname": parsed.host},
+            )
             response = await self._client.send(request, stream=True)
         except httpx.HTTPError as e:
             raise KaguraFetchError(f"network error: {e}", url=url) from e

--- a/src/kagura_memory/ingest/fetcher.py
+++ b/src/kagura_memory/ingest/fetcher.py
@@ -172,11 +172,11 @@ class Fetcher:
         if not parsed.hostname:
             raise KaguraFetchError("URL has no hostname", url=url)
 
-        connect_ip = await self._validate_hostname(parsed.hostname, url)
+        connect_ips = await self._validate_hostname(parsed.hostname, url)
 
         current_url = url
         for _ in range(self.max_redirects + 1):
-            response = await self._stream_request(current_url, connect_ip)
+            response = await self._stream_request(current_url, connect_ips)
             if response.status_code in (301, 302, 303, 307, 308):
                 # ALL redirect error paths must close the streamed response
                 # before raising — otherwise repeated malformed redirects
@@ -212,7 +212,7 @@ class Fetcher:
                             "redirect URL has embedded credentials (user:pass@host)",
                             url=next_url,
                         )
-                    connect_ip = await self._validate_hostname(next_parsed.hostname, next_url)
+                    connect_ips = await self._validate_hostname(next_parsed.hostname, next_url)
                 finally:
                     await response.aclose()
                 current_url = next_url
@@ -223,14 +223,17 @@ class Fetcher:
 
         raise KaguraFetchError(f"too many redirects (max {self.max_redirects})", url=url)
 
-    async def _validate_hostname(self, hostname: str, url: str) -> str:
-        """Resolve ``hostname``, reject blocked IPs, and return one to pin to.
+    async def _validate_hostname(self, hostname: str, url: str) -> list[str]:
+        """Resolve ``hostname``, reject blocked IPs, and return the safe set.
 
         Every resolved IP is checked against the denylist (a single blocked
-        address rejects the whole hostname). The returned IP is then used as
-        the connection target in :meth:`_stream_request`, so httpx connects to
-        exactly the address we validated rather than re-resolving the hostname
+        address rejects the whole hostname). The returned IPs are then used as
+        the connection targets in :meth:`_stream_request`, so httpx connects to
+        exactly the addresses we validated rather than re-resolving the hostname
         at connect time — which is what closes the DNS-rebinding window (#188).
+        The full validated set is returned (resolution order preserved) so the
+        caller can fall back across addresses, e.g. IPv6→IPv4 on a host whose
+        IPv6 path is broken, without ever connecting to an unvalidated IP.
         """
         try:
             addrs = await asyncio.to_thread(
@@ -240,9 +243,9 @@ class Fetcher:
             raise KaguraFetchError(f"hostname resolution failed: {e}", url=url) from e
         # info[4] is the sockaddr; first element is the IP string for both
         # AF_INET and AF_INET6. Coerce explicitly because pyright reads the
-        # tuple as ``str | int``. Keep resolution order so the pinned IP is
-        # deterministic (we pin the first, having validated them all).
-        ips: list[str] = [str(info[4][0]) for info in addrs]
+        # tuple as ``str | int``. Dedup while preserving resolution order so the
+        # connect order is deterministic (we validate every address first).
+        ips: list[str] = list(dict.fromkeys(str(info[4][0]) for info in addrs))
         if not ips:
             raise KaguraFetchError(f"no IP addresses for {hostname!r}", url=url)
         blocked = sorted({ip for ip in ips if is_blocked_ip(ip)})
@@ -251,36 +254,47 @@ class Fetcher:
                 f"hostname {hostname!r} resolved to blocked IP(s): {', '.join(blocked)}",
                 url=url,
             )
-        return ips[0]
+        return ips
 
-    async def _stream_request(self, url: str, connect_ip: str) -> httpx.Response:
-        """Issue a streaming GET pinned to ``connect_ip``.
+    async def _stream_request(self, url: str, connect_ips: list[str]) -> httpx.Response:
+        """Issue a streaming GET pinned to one of the pre-validated ``connect_ips``.
 
-        The request URL's host is rewritten to the pre-validated IP so httpx
+        The request URL's host is rewritten to a pre-validated IP so httpx
         connects to exactly that address with no connect-time re-resolution
         (#188). The original ``Host`` header is preserved for virtual-host
         routing, and the TLS SNI + certificate hostname verification use the
         real hostname via the ``sni_hostname`` request extension — so HTTPS
         certificates are still validated against the hostname, not the IP. The
         extension is inert for plain ``http``. Caller closes the response.
+
+        Addresses are tried in resolution order; a *connection-level* failure
+        (e.g. a host whose IPv6 address is unreachable) falls back to the next
+        validated address, restoring the multi-address robustness that pinning
+        a single IP would otherwise drop. Every candidate has already passed the
+        denylist, so fallback never connects to an unvalidated IP. Non-connect
+        HTTP errors are not retried.
         """
         parsed = httpx.URL(url)
-        pinned_url = parsed.copy_with(host=connect_ip)
-        # ``netloc`` renders host[:port] with correct IPv6 bracketing; URL
-        # credentials are already rejected in _fetch_url, so no userinfo leaks
-        # into the Host header.
+        # ``netloc`` strips userinfo and renders host[:port] with correct IPv6
+        # bracketing, so the Host header always carries the real hostname.
         host_header = parsed.netloc.decode("ascii")
-        try:
-            request = self._client.build_request(
-                "GET",
-                pinned_url,
-                headers={"Host": host_header},
-                extensions={"sni_hostname": parsed.host},
-            )
-            response = await self._client.send(request, stream=True)
-        except httpx.HTTPError as e:
-            raise KaguraFetchError(f"network error: {e}", url=url) from e
-        return response
+        last_exc: httpx.HTTPError | None = None
+        for connect_ip in connect_ips:
+            pinned_url = parsed.copy_with(host=connect_ip)
+            try:
+                request = self._client.build_request(
+                    "GET",
+                    pinned_url,
+                    headers={"Host": host_header},
+                    extensions={"sni_hostname": parsed.host},
+                )
+                return await self._client.send(request, stream=True)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+                last_exc = e  # try the next validated address
+                continue
+            except httpx.HTTPError as e:
+                raise KaguraFetchError(f"network error: {e}", url=url) from e
+        raise KaguraFetchError(f"network error: {last_exc}", url=url) from last_exc
 
     async def _read_body(
         self,

--- a/tests/test_ingest_fetcher.py
+++ b/tests/test_ingest_fetcher.py
@@ -162,6 +162,95 @@ async def test_redirect_to_blocked_ip_rejected() -> None:
         assert "redirect.example.com" in getaddrinfo_calls
 
 
+# ---------------------------------------------------------------------------
+# DNS-rebinding mitigation: the connection is pinned to the pre-validated IP
+# so httpx cannot re-resolve the hostname at connect time (#188).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pins_connection_to_validated_ip() -> None:
+    """The outbound request targets the validated IP, with Host + SNI preserved."""
+    async with Fetcher() as fetcher:
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(0, 0, 0, "", ("93.184.216.34", 0))]
+            send_mock = AsyncMock(return_value=_mock_response(chunks=[b"ok"]))
+            with patch.object(fetcher._client, "send", new=send_mock):
+                await fetcher.fetch("https://example.com/doc.pdf")
+            request = send_mock.call_args.args[0]
+            # Connect target is the exact IP we validated — not the hostname.
+            assert request.url.host == "93.184.216.34"
+            # Host header keeps the real hostname for virtual-host routing.
+            assert request.headers["Host"] == "example.com"
+            # TLS SNI + certificate verification use the real hostname, not the IP.
+            assert request.extensions["sni_hostname"] == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_pin_preserves_port_and_path() -> None:
+    """A non-default port and the path/query survive the host rewrite."""
+    async with Fetcher() as fetcher:
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(0, 0, 0, "", ("93.184.216.34", 0))]
+            send_mock = AsyncMock(return_value=_mock_response(chunks=[b"ok"]))
+            with patch.object(fetcher._client, "send", new=send_mock):
+                await fetcher.fetch("https://example.com:8443/a/b?q=1")
+            request = send_mock.call_args.args[0]
+            assert request.url.host == "93.184.216.34"
+            assert request.url.port == 8443
+            assert request.url.raw_path == b"/a/b?q=1"
+            assert request.headers["Host"] == "example.com:8443"
+            assert request.extensions["sni_hostname"] == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_pin_targets_a_validated_ip_when_multiple_resolve() -> None:
+    """With several resolved IPs (all validated), the connect target is one of them."""
+    async with Fetcher() as fetcher:
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [
+                (0, 0, 0, "", ("93.184.216.34", 0)),
+                (0, 0, 0, "", ("93.184.216.35", 0)),
+            ]
+            send_mock = AsyncMock(return_value=_mock_response(chunks=[b"ok"]))
+            with patch.object(fetcher._client, "send", new=send_mock):
+                await fetcher.fetch("https://example.com/")
+            request = send_mock.call_args.args[0]
+            assert request.url.host in {"93.184.216.34", "93.184.216.35"}
+
+
+@pytest.mark.asyncio
+async def test_redirect_target_is_independently_pinned() -> None:
+    """Each redirect hop pins to its own validated IP with its own Host header."""
+    async with Fetcher() as fetcher:
+
+        def fake_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> Any:
+            return {
+                "example.com": [(0, 0, 0, "", ("93.184.216.34", 0))],
+                "cdn.example.com": [(0, 0, 0, "", ("93.184.216.99", 0))],
+            }[host]
+
+        sent: list[Any] = []
+
+        async def fake_send(request: Any, **kwargs: Any) -> Any:
+            sent.append(request)
+            if len(sent) == 1:
+                return _mock_response(
+                    status_code=302,
+                    headers={"Location": "https://cdn.example.com/file"},
+                )
+            return _mock_response(chunks=[b"ok"])
+
+        with patch("socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            with patch.object(fetcher._client, "send", new=fake_send):
+                await fetcher.fetch("https://example.com/start")
+
+        assert sent[0].url.host == "93.184.216.34"
+        assert sent[0].headers["Host"] == "example.com"
+        assert sent[1].url.host == "93.184.216.99"
+        assert sent[1].headers["Host"] == "cdn.example.com"
+
+
 @pytest.mark.asyncio
 async def test_local_file_path(tmp_path: Any) -> None:
     pdf = tmp_path / "doc.pdf"

--- a/tests/test_ingest_fetcher.py
+++ b/tests/test_ingest_fetcher.py
@@ -250,6 +250,51 @@ async def test_pin_falls_back_to_next_validated_ip_on_connect_failure() -> None:
 
 
 @pytest.mark.asyncio
+async def test_non_connect_error_is_not_retried_across_ips() -> None:
+    """A non-connect httpx error fails fast — fallback is only for connect failures."""
+    async with Fetcher() as fetcher:
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [
+                (0, 0, 0, "", ("93.184.216.34", 0)),
+                (0, 0, 0, "", ("93.184.216.35", 0)),
+            ]
+            calls: list[Any] = []
+
+            async def boom(request: Any, **kwargs: Any) -> Any:
+                calls.append(request.url.host)
+                raise httpx.ReadError("stream broke", request=request)
+
+            with patch.object(fetcher._client, "send", new=boom):
+                with pytest.raises(KaguraFetchError, match="network error"):
+                    await fetcher.fetch("https://example.com/doc")
+            # Only the first IP was attempted — a non-connect error is not a
+            # reachability problem, so we do not try the other validated address.
+            assert calls == ["93.184.216.34"]
+
+
+@pytest.mark.asyncio
+async def test_all_validated_ips_unreachable_raises() -> None:
+    """When every validated IP fails to connect, the last error surfaces."""
+    async with Fetcher() as fetcher:
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [
+                (0, 0, 0, "", ("93.184.216.34", 0)),
+                (0, 0, 0, "", ("93.184.216.35", 0)),
+            ]
+            calls: list[Any] = []
+
+            async def always_refuse(request: Any, **kwargs: Any) -> Any:
+                calls.append(request.url.host)
+                raise httpx.ConnectError("refused", request=request)
+
+            with patch.object(fetcher._client, "send", new=always_refuse):
+                with pytest.raises(KaguraFetchError, match="network error"):
+                    await fetcher.fetch("https://example.com/doc")
+            # Both validated addresses were tried before giving up.
+            assert calls == ["93.184.216.34", "93.184.216.35"]
+
+
+@pytest.mark.asyncio
 async def test_redirect_target_is_independently_pinned() -> None:
     """Each redirect hop pins to its own validated IP with its own Host header."""
     async with Fetcher() as fetcher:

--- a/tests/test_ingest_fetcher.py
+++ b/tests/test_ingest_fetcher.py
@@ -220,6 +220,36 @@ async def test_pin_targets_a_validated_ip_when_multiple_resolve() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pin_falls_back_to_next_validated_ip_on_connect_failure() -> None:
+    """A connect-level failure on the first validated IP falls back to the next.
+
+    Restores the multi-address robustness (e.g. IPv6→IPv4 on a broken-IPv6 host)
+    that pinning a single IP would otherwise drop — without ever connecting to an
+    unvalidated address, since both candidates passed the denylist.
+    """
+    async with Fetcher() as fetcher:
+        with patch("socket.getaddrinfo") as mock_getaddrinfo:
+            # IPv6 first (as RFC 6724 ordering often yields), then IPv4.
+            mock_getaddrinfo.return_value = [
+                (0, 0, 0, "", ("2606:2800:220:1:248:1893:25c8:1946", 0)),
+                (0, 0, 0, "", ("93.184.216.34", 0)),
+            ]
+            attempted: list[str] = []
+
+            async def flaky_send(request: Any, **kwargs: Any) -> Any:
+                attempted.append(request.url.host)
+                if len(attempted) == 1:
+                    raise httpx.ConnectError("network unreachable", request=request)
+                return _mock_response(chunks=[b"ok"])
+
+            with patch.object(fetcher._client, "send", new=flaky_send):
+                result = await fetcher.fetch("https://example.com/doc")
+            assert result.body == b"ok"
+            # First the IPv6 address was tried, then the IPv4 fallback connected.
+            assert attempted == ["2606:2800:220:1:248:1893:25c8:1946", "93.184.216.34"]
+
+
+@pytest.mark.asyncio
 async def test_redirect_target_is_independently_pinned() -> None:
     """Each redirect hop pins to its own validated IP with its own Host header."""
     async with Fetcher() as fetcher:


### PR DESCRIPTION
Closes #188

## Summary
- The ingest fetcher resolved a hostname in `_validate_hostname`, denylist-checked the IPs, then let httpx **re-resolve** the hostname at connect time. A near-zero-TTL malicious server could serve a benign IP for the pre-flight resolve and an internal IP (e.g. `169.254.169.254`) for the actual connect, bypassing the denylist (DNS rebinding → SSRF, Critical).
- `_validate_hostname` now returns one validated IP, and `_stream_request` **pins the connection to it**: the request URL host is rewritten to the IP literal so httpx connects to exactly that address with no re-resolution.
- The original `Host` header is preserved for vhost routing, and the `sni_hostname` request extension keeps TLS SNI + certificate verification bound to the real hostname (cert validated against the hostname, not the IP; fail-closed on mismatch).
- Redirect hops re-validate and re-pin independently. Keepalive reuse is disabled so two hostnames sharing an IP cannot reuse a connection opened with the other's SNI/cert.

## Implementation notes
- `Host` header built from `httpx.URL(url).netloc` (correct IPv6 bracketing; URL credentials already rejected upstream).
- Verified against httpcore 1.0.9 source (adversarial review): httpcore connects to `request.url.host`; `server_hostname = sni_hostname or origin.host` with httpx's default `check_hostname=True, verify_mode=CERT_REQUIRED`.
- `_safety.py` rebinding caveat updated — it is now mitigated, not just narrowed.

## Pre-PR review summary
- gate2 mode: advisor-only · audit: skipped
- cso: green · qa-lead: green · cto: green
- gate1: green via /ask (CSO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
