### PR TITLE
fix(client): rename merge_contexts MCP params to context_id (#196)

### DIFF
--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -1097,8 +1097,8 @@ class KaguraClient:
         if source_id == target_id:
             raise ValueError("source_id and target_id must be different")
         arguments: dict[str, Any] = {
-            "source_id": source_id,
-            "target_id": target_id,
+            "source_context_id": source_id,
+            "target_context_id": target_id,
         }
         if delete_source:
             arguments["delete_source"] = True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1286,15 +1286,19 @@ async def test_update_context_is_locked():
 
 @pytest.mark.asyncio
 async def test_merge_contexts():
-    """merge_contexts() should call tool with source and target IDs."""
+    """merge_contexts() should call tool with source/target context IDs."""
     client = _make_initialized_client()
 
     with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
         mock.return_value = {"merged": 42, "source_id": "src", "target_id": "tgt"}
         result = await client.merge_contexts(source_id="src", target_id="tgt")
         args = mock.call_args[0][1]
-        assert args["source_id"] == "src"
-        assert args["target_id"] == "tgt"
+        # memory-cloud #990 renamed the MCP params to disambiguate them from
+        # the edge tools' source_id/target_id (which are memory UUIDs).
+        assert args["source_context_id"] == "src"
+        assert args["target_context_id"] == "tgt"
+        assert "source_id" not in args
+        assert "target_id" not in args
         assert "delete_source" not in args
         assert result["merged"] == 42
 


### PR DESCRIPTION
Closes #196 — Update KaguraClient.merge_contexts() to send the renamed MCP arguments source_context_id/target_context_id instead of the old source_id/target_id, matching the memory-cloud 990 param rename that disambiguates context UUIDs from the edge tools' memory UUIDs. Caller-facing kwargs stay source_id/target_id (no breaking change for SDK consumers); only the MCP wire payload changes. The test_merge_contexts regression test now asserts the new keys are present and the old keys are absent. Gate2 (advisor-only): cso green, qa-lead green, cto green. Generated via /gh-issue-driven:ship