### PR TITLE
fix(cli): pin file I/O and stdout to UTF-8 for cp932 Windows

### DIFF
--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -119,11 +119,31 @@ def _run_client_command(
         raise click.ClickException(_exc_message(e)) from e
 
 
+def _force_utf8_io() -> None:
+    """Pin stdout/stderr to UTF-8 so non-ASCII output cannot crash the CLI.
+
+    On Japanese/Chinese Windows the console codec defaults to cp932/cp950/gbk,
+    where status glyphs (e.g. the check mark printed by ``kagura auth refresh``)
+    raised ``UnicodeEncodeError`` and aborted the command (issue #197). UTF-8
+    represents every character; ``errors="replace"`` is a belt-and-braces
+    backstop for any stream that still cannot be reconfigured to UTF-8.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, LookupError, OSError):
+            # Stream is detached or refuses reconfiguration; leave it as-is.
+            pass
+
+
 @click.group()
 @click.version_option(package_name="kagura-memory", prog_name="kagura")
 def main():
     """Kagura Memory Cloud CLI - AI-driven memory management."""
-    pass
+    _force_utf8_io()
 
 
 # Register the `kagura auth` sub-group (OAuth2 device-flow). Defined in

--- a/src/kagura_memory/config.py
+++ b/src/kagura_memory/config.py
@@ -25,14 +25,18 @@ def load_config() -> dict[str, Any]:
     if local_config.exists():
         try:
             config = json.loads(local_config.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON in .kagura.json: {e}") from e
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise ValueError(
+                f"Invalid JSON or encoding in .kagura.json (expected UTF-8): {e}"
+            ) from e
     # 2. Try home directory if not found locally
     elif (home_config := Path.home() / ".kagura.json").exists():
         try:
             config = json.loads(home_config.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON in ~/.kagura.json: {e}") from e
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise ValueError(
+                f"Invalid JSON or encoding in ~/.kagura.json (expected UTF-8): {e}"
+            ) from e
     # 3. Fall back to environment variables
     else:
         config = {

--- a/src/kagura_memory/config.py
+++ b/src/kagura_memory/config.py
@@ -24,13 +24,13 @@ def load_config() -> dict[str, Any]:
     local_config = Path(".kagura.json")
     if local_config.exists():
         try:
-            config = json.loads(local_config.read_text())
+            config = json.loads(local_config.read_text(encoding="utf-8"))
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in .kagura.json: {e}") from e
     # 2. Try home directory if not found locally
     elif (home_config := Path.home() / ".kagura.json").exists():
         try:
-            config = json.loads(home_config.read_text())
+            config = json.loads(home_config.read_text(encoding="utf-8"))
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in ~/.kagura.json: {e}") from e
     # 3. Fall back to environment variables

--- a/src/kagura_memory/setup_claude.py
+++ b/src/kagura_memory/setup_claude.py
@@ -86,16 +86,22 @@ Ask the user what to remember if $ARGUMENTS is empty.
 
 
 def _read_json_safe(path: Path) -> dict[str, Any]:
-    """Read a JSON file, returning {} on missing file or parse error."""
+    """Read a UTF-8 JSON file, returning {} on missing/unreadable/parse error.
+
+    Reads are pinned to UTF-8 so config is decoded identically on every
+    locale (issue #197: the OS default codec is cp932 on Japanese Windows,
+    which raised UnicodeDecodeError on UTF-8 content). A foreign-encoding or
+    otherwise corrupt file falls back to an empty dict rather than crashing.
+    """
     try:
-        return json.loads(path.read_text())
-    except (FileNotFoundError, json.JSONDecodeError):
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
         return {}
 
 
 def _write_json(path: Path, data: dict[str, Any]) -> None:
-    """Write a dict as formatted JSON."""
-    path.write_text(json.dumps(data, indent=2) + "\n")
+    """Write a dict as formatted UTF-8 JSON (locale-independent, issue #197)."""
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
 
 
 def _validate_not_empty(value: str, name: str) -> str:
@@ -429,7 +435,7 @@ def _install_skills(project_dir: Path, context_id: str) -> list[Path]:
         ("kagura-remember.md", SKILL_REMEMBER),
     ]:
         path = commands_dir / filename
-        path.write_text(template.format(context_id=context_id))
+        path.write_text(template.format(context_id=context_id), encoding="utf-8")
         paths.append(path)
 
     return paths
@@ -439,7 +445,7 @@ def _check_gitignore(project_dir: Path) -> list[str]:
     """Check which secret files are missing from .gitignore."""
     secret_files = [".kagura.json", ".mcp.json"]
     try:
-        content = (project_dir / ".gitignore").read_text()
+        content = (project_dir / ".gitignore").read_text(encoding="utf-8")
     except FileNotFoundError:
         return secret_files
     return [f for f in secret_files if f not in content]
@@ -478,14 +484,9 @@ def run_setup_claude(
 
     project = Path(project_dir).resolve()
 
-    # Load existing config from project dir (not cwd)
-    existing_config: dict[str, Any] = {}
-    project_config = project / ".kagura.json"
-    if project_config.exists():
-        try:
-            existing_config = json.loads(project_config.read_text())
-        except (json.JSONDecodeError, OSError):
-            pass
+    # Load existing config from project dir (not cwd). _read_json_safe pins
+    # UTF-8 and swallows missing/foreign-encoding/corrupt files (issue #197).
+    existing_config = _read_json_safe(project / ".kagura.json")
 
     # 1. API Key
     resolved_api_key = api_key or existing_config.get("api_key")

--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -1095,3 +1095,30 @@ def test_logout_warns_about_env_var(monkeypatch, patched_default_path: Path):
 
     assert result.exit_code == 0
     assert "KAGURA_API_KEY" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Issue #197 — non-UTF-8 (cp932) stdout must not crash the success echo
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_success_echo_survives_cp932_stdout(patched_default_path: Path, monkeypatch):
+    """`auth refresh` prints a check glyph absent from cp932; on a Japanese
+    Windows console (cp932 stdout) that raised UnicodeEncodeError. The CLI must
+    reconfigure stdout to UTF-8 so the success path completes cleanly."""
+    import kagura_memory.auth.cli as auth_cli
+
+    monkeypatch.setattr(auth_cli, "make_oauth_client", lambda *a, **k: _async_ctx())
+    monkeypatch.setattr(
+        auth_cli,
+        "refresh_access_token",
+        AsyncMock(return_value=_mock_token_response(access_token="atok-rotated")),
+    )
+    _seed_credentials(patched_default_path.parent.parent, _make_creds())
+
+    # charset="cp932": writing U+2713 to this stream raised UnicodeEncodeError
+    # before the fix (the glyph is not representable in cp932).
+    result = CliRunner(charset="cp932").invoke(main, ["auth", "refresh"])
+
+    assert result.exception is None, result.exception
+    assert result.exit_code == 0

--- a/tests/test_cli_encoding.py
+++ b/tests/test_cli_encoding.py
@@ -83,3 +83,16 @@ class TestLoadConfigEncoding:
         result = load_config()
         assert result["model"] == _JP
         assert captured["encoding"] == "utf-8"
+
+    def test_load_config_non_utf8_local_raises_clear_error(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        import pytest
+
+        for key in ("KAGURA_API_KEY", "KAGURA_MCP_URL", "KAGURA_MODEL", "KAGURA_CONTEXT_ID"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.chdir(tmp_path)
+        # cp932-encoded content (the issue #197 scenario): invalid UTF-8 bytes.
+        (tmp_path / ".kagura.json").write_bytes(bytes([0x92, 0x93, 0xFF]))
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_config()

--- a/tests/test_cli_encoding.py
+++ b/tests/test_cli_encoding.py
@@ -1,0 +1,85 @@
+"""Regression tests for cp932/locale-independent CLI encoding (issue #197).
+
+On Japanese/Chinese Windows the OS default text codec is cp932/cp950/gbk, so
+file I/O that omits encoding=utf-8 decodes/encodes wrongly or crashes with
+UnicodeDecodeError. These tests pin the JSON config I/O to UTF-8 and are written
+to be red before the fix and green after, independent of the host locale.
+"""
+
+import json
+from pathlib import Path
+
+from kagura_memory.config import load_config
+from kagura_memory.setup_claude import _read_json_safe, _write_json
+
+_JP = "日本語"  # Japanese text (multibyte UTF-8)
+# Lone high bytes: invalid UTF-8, so read_text(encoding=utf-8) raises UnicodeDecodeError.
+_BAD_UTF8 = bytes([0x92, 0x93, 0xFF]) + b" not valid utf-8"
+
+
+def _spy_encoding(monkeypatch, method_name):
+    """Patch Path.<method_name> to record the encoding kwarg it received."""
+    captured = {}
+    original = getattr(Path, method_name)
+
+    def spy(self, *args, **kwargs):
+        captured["encoding"] = kwargs.get("encoding")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, method_name, spy)
+    return captured
+
+
+class TestSetupClaudeJsonEncoding:
+    def test_read_json_safe_falls_back_on_undecodable_bytes(self, tmp_path: Path) -> None:
+        """The 0x92 byte from the issue report is invalid UTF-8 as a lone byte.
+
+        Before the fix _read_json_safe caught only FileNotFoundError /
+        JSONDecodeError, so the UnicodeDecodeError propagated and crashed setup.
+        """
+        path = tmp_path / "settings.json"
+        path.write_bytes(_BAD_UTF8)
+        assert _read_json_safe(path) == {}
+
+    def test_read_json_safe_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert _read_json_safe(tmp_path / "nope.json") == {}
+
+    def test_read_json_safe_decodes_multibyte_utf8(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.json"
+        data = dict(note=_JP)
+        path.write_bytes(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+        assert _read_json_safe(path) == data
+
+    def test_read_json_safe_uses_utf8_encoding(self, tmp_path: Path, monkeypatch) -> None:
+        path = tmp_path / "cfg.json"
+        path.write_text(json.dumps(dict()), encoding="utf-8")
+        captured = _spy_encoding(monkeypatch, "read_text")
+        _read_json_safe(path)
+        assert captured["encoding"] == "utf-8"
+
+    def test_write_json_uses_utf8_encoding(self, tmp_path: Path, monkeypatch) -> None:
+        path = tmp_path / "cfg.json"
+        captured = _spy_encoding(monkeypatch, "write_text")
+        _write_json(path, dict(note=_JP))
+        assert captured["encoding"] == "utf-8"
+
+    def test_write_json_round_trips_through_read(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.json"
+        data = dict(note=_JP, n=1)
+        _write_json(path, data)
+        assert _read_json_safe(path) == data
+
+
+class TestLoadConfigEncoding:
+    def test_load_config_reads_local_as_utf8(self, tmp_path: Path, monkeypatch) -> None:
+        for key in ("KAGURA_API_KEY", "KAGURA_MCP_URL", "KAGURA_MODEL", "KAGURA_CONTEXT_ID"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.chdir(tmp_path)
+        data = dict(api_key="k", model=_JP)
+        (tmp_path / ".kagura.json").write_bytes(
+            json.dumps(data, ensure_ascii=False).encode("utf-8")
+        )
+        captured = _spy_encoding(monkeypatch, "read_text")
+        result = load_config()
+        assert result["model"] == _JP
+        assert captured["encoding"] == "utf-8"

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -344,7 +344,7 @@ class TestInstallSkills:
         assert len(paths) == 2
         for p in paths:
             assert p.exists()
-            content = p.read_text()
+            content = p.read_text(encoding="utf-8")
             assert "ctx-1" in content
 
     def test_skill_filenames(self, project_dir: Path) -> None:


### PR DESCRIPTION
Closes #197.

## What

`kagura setup claude` crashed with `UnicodeDecodeError` and `kagura auth refresh` with `UnicodeEncodeError` on Japanese/Chinese Windows, where the OS default text codec is cp932/cp950/gbk instead of UTF-8.

- **setup_claude**: read/write all JSON, skill templates, and `.gitignore` as UTF-8; `_read_json_safe` now catches `(OSError, ValueError)` so a foreign-encoding or corrupt file falls back to `{}` (`UnicodeDecodeError` is a `ValueError`). `run_setup_claude` reuses the hardened `_read_json_safe`.
- **config**: read `.kagura.json` as UTF-8 regardless of locale.
- **cli**: `_force_utf8_io()` reconfigures stdout/stderr to UTF-8 in the root group so non-ASCII status glyphs (e.g. the refresh check mark) cannot abort a command.
- Repo-wide audit: no remaining text I/O lacks `encoding=`.

## Tests

- New locale-independent regression tests for the read/write/decode paths (`tests/test_cli_encoding.py`) and the cp932-stdout refresh crash (`tests/test_auth_cli.py`).
- `#197`-area suite green: `test_setup_claude` / `test_cli_encoding` / `test_auth_cli` -> 115 passed.

## Note for reviewers

The full suite shows 16 failures on this Windows host -- `test_auth_credentials` (POSIX 0600/0700 modes), `test_filelock` (`fcntl`), `test_ingest_safety` (`/etc`, `/proc`, `/var/log` paths), and `test_ingest_audio`. These are **pre-existing, environment-specific failures: they fail identically on `main`** and touch none of the files in this PR. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
