### PR TITLE
test(cli): unify auth_cli import and cover _force_utf8_io branches

### DIFF
--- a/tests/test_auth_cli.py
+++ b/tests/test_auth_cli.py
@@ -1106,11 +1106,11 @@ def test_refresh_success_echo_survives_cp932_stdout(patched_default_path: Path, 
     """`auth refresh` prints a check glyph absent from cp932; on a Japanese
     Windows console (cp932 stdout) that raised UnicodeEncodeError. The CLI must
     reconfigure stdout to UTF-8 so the success path completes cleanly."""
-    import kagura_memory.auth.cli as auth_cli
+    from kagura_memory.auth import cli as cli_mod
 
-    monkeypatch.setattr(auth_cli, "make_oauth_client", lambda *a, **k: _async_ctx())
+    monkeypatch.setattr(cli_mod, "make_oauth_client", lambda *a, **k: _async_ctx())
     monkeypatch.setattr(
-        auth_cli,
+        cli_mod,
         "refresh_access_token",
         AsyncMock(return_value=_mock_token_response(access_token="atok-rotated")),
     )

--- a/tests/test_cli_encoding.py
+++ b/tests/test_cli_encoding.py
@@ -7,8 +7,10 @@ to be red before the fix and green after, independent of the host locale.
 """
 
 import json
+import sys
 from pathlib import Path
 
+from kagura_memory.cli import _force_utf8_io
 from kagura_memory.config import load_config
 from kagura_memory.setup_claude import _read_json_safe, _write_json
 
@@ -96,3 +98,42 @@ class TestLoadConfigEncoding:
         (tmp_path / ".kagura.json").write_bytes(bytes([0x92, 0x93, 0xFF]))
         with pytest.raises(ValueError, match="Invalid JSON"):
             load_config()
+
+
+class _RecordingStream:
+    """Stand-in stream that records reconfigure() kwargs and can raise."""
+
+    def __init__(self, raise_exc: Exception | None = None) -> None:
+        self.calls: list[dict] = []
+        self._raise = raise_exc
+
+    def reconfigure(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+        if self._raise is not None:
+            raise self._raise
+
+
+class _NoReconfigureStream:
+    """Stand-in stream lacking a reconfigure() method (e.g. a plain pipe)."""
+
+
+class TestForceUtf8Io:
+    def test_reconfigures_streams_to_utf8(self, monkeypatch) -> None:
+        out, err = _RecordingStream(), _RecordingStream()
+        monkeypatch.setattr(sys, "stdout", out)
+        monkeypatch.setattr(sys, "stderr", err)
+        _force_utf8_io()
+        assert out.calls == [{"encoding": "utf-8", "errors": "replace"}]
+        assert err.calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+    def test_skips_stream_without_reconfigure(self, monkeypatch) -> None:
+        # Exercises the `reconfigure is None` branch — must not raise.
+        monkeypatch.setattr(sys, "stdout", _NoReconfigureStream())
+        monkeypatch.setattr(sys, "stderr", _NoReconfigureStream())
+        _force_utf8_io()
+
+    def test_swallows_reconfigure_errors(self, monkeypatch) -> None:
+        # Exercises the except branch — a detached/locked stream must not crash.
+        monkeypatch.setattr(sys, "stdout", _RecordingStream(raise_exc=OSError("detached")))
+        monkeypatch.setattr(sys, "stderr", _RecordingStream(raise_exc=LookupError("bad codec")))
+        _force_utf8_io()


### PR DESCRIPTION
Follow-up to the automated review comments on #199 (now merged).

## Fixes

1. **Mixed import (github-code-quality)** — `tests/test_auth_cli.py`'s cp932 refresh test imported `import kagura_memory.auth.cli as auth_cli`, inconsistent with the file's existing `from kagura_memory.auth import cli as cli_mod` convention (14 other call sites). Unified on the existing style. (The bot's suggested `as auth_cli` alias would have introduced a *third* spelling; this matches what the file already uses.)

2. **Codecov patch gap (cli.py 70%)** — added `TestForceUtf8Io` in `tests/test_cli_encoding.py` covering the three previously-uncovered branches of `_force_utf8_io`: a successful `reconfigure`, the `reconfigure is None` skip (plain pipe / no-method stream), and the swallowed `(ValueError, LookupError, OSError)` failure (detached/locked stream).

Tests-only; no production behavior change. `test_cli_encoding` + the fixed `auth_cli` test → 12 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
