### PR TITLE
refactor(ingest): extract shared SectionBuilder for heading-based extractors

### DIFF
--- a/src/kagura_memory/ingest/extractors/_util.py
+++ b/src/kagura_memory/ingest/extractors/_util.py
@@ -1,17 +1,92 @@
 """Shared helpers for structural extractors.
 
-Keeps the decompression-bomb ceiling and the source-URI title fallback in
-one place so every extractor enforces the same safety policy and derives
-titles identically.
+Keeps the decompression-bomb ceiling, the source-URI title fallback, and the
+heading-driven section state machine in one place so every extractor enforces
+the same safety policy, derives titles identically, and applies one flush rule.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from urllib.parse import urlsplit
+
+from .._types import ExtractedSection
 
 # Decompression-bomb ceiling on *decoded* text, shared by all extractors. A
 # single source of truth so tuning this security limit touches one line.
 MAX_TOTAL_TEXT_CHARS = 50_000_000  # ~50 MB of decoded text
+
+
+def _default_join(parts: list[str]) -> str:
+    """Newline-join body fragments and strip the outer whitespace.
+
+    The default body normalizer for line/paragraph formats (text, Markdown,
+    DOCX). HTML injects a whitespace-collapsing join instead.
+    """
+    return "\n".join(parts).strip()
+
+
+class SectionBuilder:
+    """Accumulate heading-delimited sections for heading-driven extractors.
+
+    Centralizes the "flush on heading, accumulate body, flush at end" state
+    machine shared by the text/Markdown, HTML, and DOCX extractors — together
+    with the single flush rule (**emit a section only when its joined body text
+    or its heading is non-empty**) and the :class:`ExtractedSection`
+    construction. The per-format body join/normalize is injected via ``join``
+    (default: newline-join then strip; HTML passes a whitespace-collapsing
+    join).
+
+    Content before the first heading is emitted as a leading section with
+    ``heading=None`` and ``depth=1``; ``page_range`` is always ``None`` because
+    these formats are not paginated. ``anchor`` mirrors the heading text.
+
+    Typical use::
+
+        builder = SectionBuilder()
+        for item in source:
+            if is_heading(item):
+                builder.add_heading(heading_text(item), heading_depth(item))
+            else:
+                builder.add_body(body_text(item))
+        return builder.finish()
+    """
+
+    def __init__(self, join: Callable[[list[str]], str] = _default_join) -> None:
+        self._join = join
+        self._sections: list[ExtractedSection] = []
+        self._heading: str | None = None
+        self._depth = 1
+        self._body: list[str] = []
+
+    def add_heading(self, text: str | None, depth: int) -> None:
+        """Flush the current section, then begin a new one at ``text``/``depth``."""
+        self._flush()
+        self._heading = text
+        self._depth = depth
+        self._body = []
+
+    def add_body(self, text: str) -> None:
+        """Append a raw body fragment to the current section (joined on flush)."""
+        self._body.append(text)
+
+    def finish(self) -> list[ExtractedSection]:
+        """Flush the final section and return all accumulated sections."""
+        self._flush()
+        return self._sections
+
+    def _flush(self) -> None:
+        body_text = self._join(self._body)
+        if body_text or self._heading:
+            self._sections.append(
+                ExtractedSection(
+                    heading=self._heading,
+                    body_text=body_text,
+                    page_range=None,
+                    depth=self._depth,
+                    anchor=self._heading,
+                )
+            )
 
 
 def filename_title(source_uri: str | None) -> str | None:

--- a/src/kagura_memory/ingest/extractors/docx.py
+++ b/src/kagura_memory/ingest/extractors/docx.py
@@ -14,7 +14,7 @@ from typing import Any, ClassVar
 from ...exceptions import KaguraIngestError
 from .._types import ExtractedContent, ExtractedSection
 from ._util import MAX_TOTAL_TEXT_CHARS as _MAX_TOTAL_TEXT_CHARS
-from ._util import filename_title
+from ._util import SectionBuilder, filename_title
 
 # DOCX is a ZIP container — guard against zip bombs by capping the number of
 # paragraphs walked and the total decoded text length.
@@ -62,27 +62,13 @@ class DocxExtractor:
 
     @classmethod
     def _split_sections(cls, document: Any) -> list[ExtractedSection]:
-        sections: list[ExtractedSection] = []
-        heading: str | None = None
-        depth = 1
-        body: list[str] = []
+        builder = SectionBuilder()  # default join: "\n".join + strip
         total_chars = 0
         para_count = 0
 
-        def flush() -> None:
-            text = "\n".join(body).strip()
-            if text or heading:
-                sections.append(
-                    ExtractedSection(
-                        heading=heading,
-                        body_text=text,
-                        page_range=None,
-                        depth=depth,
-                        anchor=heading,
-                    )
-                )
-
         for para in document.paragraphs:
+            # Decompression-bomb caps stay inline (format-specific), guarding the
+            # walk before any text is accumulated into the shared builder.
             para_count += 1
             if para_count > _MAX_PARAGRAPHS:
                 raise KaguraIngestError(
@@ -96,14 +82,10 @@ class DocxExtractor:
                 )
             level = cls._heading_level(para)
             if level is not None:
-                flush()
-                heading = text.strip() or None
-                depth = level
-                body = []
+                builder.add_heading(text.strip() or None, level)
             else:
-                body.append(text)
-        flush()
-        return sections
+                builder.add_body(text)
+        return builder.finish()
 
     @staticmethod
     def _heading_level(para: Any) -> int | None:

--- a/src/kagura_memory/ingest/extractors/html.py
+++ b/src/kagura_memory/ingest/extractors/html.py
@@ -13,7 +13,7 @@ from typing import Any, ClassVar
 from ...exceptions import KaguraIngestError
 from .._types import ExtractedContent, ExtractedSection
 from ._util import MAX_TOTAL_TEXT_CHARS as _MAX_TOTAL_TEXT_CHARS
-from ._util import filename_title
+from ._util import SectionBuilder, filename_title
 
 # Cap on input bytes (HTML is not compressed, but a hostile page can still be
 # arbitrarily large). Derived from the shared text ceiling so the safety cap
@@ -67,41 +67,23 @@ class HtmlExtractor:
     def _split_sections(soup: Any) -> list[ExtractedSection]:
         from bs4 import NavigableString, Tag  # type: ignore[import-untyped]
 
-        sections: list[ExtractedSection] = []
-        heading: str | None = None
-        depth = 1
-        body: list[str] = []
-
-        def flush() -> None:
-            text = _WS.sub(" ", " ".join(body)).strip()
-            if text or heading:
-                sections.append(
-                    ExtractedSection(
-                        heading=heading,
-                        body_text=text,
-                        page_range=None,
-                        depth=depth,
-                        anchor=heading,
-                    )
-                )
+        # HTML collapses runs of whitespace (including newlines) to single
+        # spaces, unlike the default newline-join used by text/DOCX.
+        builder = SectionBuilder(join=lambda parts: _WS.sub(" ", " ".join(parts)).strip())
 
         # Walk the <body> only so <head>/<title> text never leaks into the
         # leading section. Fragments without a <body> fall back to the root.
         root = soup.body or soup
         for node in root.descendants:
             if isinstance(node, Tag) and node.name in _HEADING_NAMES:
-                flush()
-                heading = node.get_text(" ", strip=True) or None
-                depth = int(node.name[1])
-                body = []
+                builder.add_heading(node.get_text(" ", strip=True) or None, int(node.name[1]))
             elif isinstance(node, NavigableString):
                 # Skip strings that belong to a heading (already captured) so
                 # heading text is not duplicated into the following body.
                 if node.find_parent(_HEADING_RE) is not None:
                     continue
-                body.append(str(node))
-        flush()
-        return sections
+                builder.add_body(str(node))
+        return builder.finish()
 
     @staticmethod
     def _title(soup: Any, source_uri: str | None) -> str | None:

--- a/src/kagura_memory/ingest/extractors/text.py
+++ b/src/kagura_memory/ingest/extractors/text.py
@@ -15,7 +15,7 @@ from typing import ClassVar
 from ...exceptions import KaguraIngestError
 from .._types import ExtractedContent, ExtractedSection
 from ._util import MAX_TOTAL_TEXT_CHARS as _MAX_TOTAL_TEXT_CHARS
-from ._util import filename_title
+from ._util import SectionBuilder, filename_title
 
 # Every decoded character costs at least one UTF-8 byte (and errors="replace"
 # emits exactly one U+FFFD per undecodable byte), so the decoded length never
@@ -61,31 +61,15 @@ class TextExtractor:
 
     @staticmethod
     def _split_sections(text: str) -> list[ExtractedSection]:
-        sections: list[ExtractedSection] = []
-        heading: str | None = None
-        depth = 1
-        body: list[str] = []
+        builder = SectionBuilder()  # default join: "\n".join + strip
         fence_marker: str | None = None  # the opening run (e.g. "```") while inside a fence
-
-        def flush() -> None:
-            joined = "\n".join(body).strip()
-            if joined or heading:
-                sections.append(
-                    ExtractedSection(
-                        heading=heading,
-                        body_text=joined,
-                        page_range=None,
-                        depth=depth,
-                        anchor=heading,
-                    )
-                )
 
         for line in text.splitlines():
             fence = _FENCE.match(line)
             if fence_marker is None:
                 if fence:
                     fence_marker = fence.group(1)
-                    body.append(line)
+                    builder.add_body(line)
                     continue
             else:
                 # Inside a fence: only a run of the SAME char, at least as long
@@ -98,18 +82,14 @@ class TextExtractor:
                         and not info.strip()
                     ):
                         fence_marker = None
-                body.append(line)
+                builder.add_body(line)
                 continue
             m = _ATX_HEADING.match(line)
             if m:
-                flush()
-                heading = m.group(2).strip() or None
-                depth = len(m.group(1))
-                body = []
+                builder.add_heading(m.group(2).strip() or None, len(m.group(1)))
             else:
-                body.append(line)
-        flush()
-        return sections
+                builder.add_body(line)
+        return builder.finish()
 
     @staticmethod
     def _title(sections: list[ExtractedSection], source_uri: str | None) -> str | None:

--- a/tests/test_ingest_section_builder.py
+++ b/tests/test_ingest_section_builder.py
@@ -1,0 +1,110 @@
+"""Tests for the shared SectionBuilder used by heading-driven extractors (#204).
+
+SectionBuilder centralizes the "flush on heading, accumulate body, flush at end"
+state machine that the text/Markdown, HTML, and DOCX extractors share. These
+tests pin the flush rule and the per-format body-join seam; the extractor-level
+behavior is covered (unchanged) by the existing test_ingest_*_extractor suites.
+"""
+
+from __future__ import annotations
+
+import re
+
+from kagura_memory.ingest.extractors._util import SectionBuilder
+
+
+def test_empty_builder_yields_no_sections() -> None:
+    assert SectionBuilder().finish() == []
+
+
+def test_body_only_no_heading_yields_one_leading_section() -> None:
+    b = SectionBuilder()
+    b.add_body("hello")
+    b.add_body("world")
+    sections = b.finish()
+    assert len(sections) == 1
+    s = sections[0]
+    assert s.heading is None
+    assert s.depth == 1  # leading section defaults to depth 1
+    assert s.anchor is None
+    assert s.page_range is None
+    assert s.body_text == "hello\nworld"
+
+
+def test_heading_with_empty_body_is_emitted() -> None:
+    """flush rule: a non-empty heading emits even with no body."""
+    b = SectionBuilder()
+    b.add_heading("Intro", 2)
+    sections = b.finish()
+    assert len(sections) == 1
+    assert sections[0].heading == "Intro"
+    assert sections[0].body_text == ""
+    assert sections[0].depth == 2
+    assert sections[0].anchor == "Intro"
+
+
+def test_neither_body_nor_heading_yields_no_section() -> None:
+    """flush rule: an empty body AND a None heading emits nothing."""
+    b = SectionBuilder()
+    b.add_heading(None, 1)  # heading explicitly None, no body
+    assert b.finish() == []
+
+
+def test_leading_body_then_heading_yields_two_sections() -> None:
+    b = SectionBuilder()
+    b.add_body("preamble")
+    b.add_heading("Section 1", 1)
+    b.add_body("content")
+    sections = b.finish()
+    assert [(s.heading, s.body_text, s.depth) for s in sections] == [
+        (None, "preamble", 1),
+        ("Section 1", "content", 1),
+    ]
+
+
+def test_heading_before_any_body_has_no_spurious_leading_section() -> None:
+    """A heading as the very first item must not emit an empty leading section."""
+    b = SectionBuilder()
+    b.add_heading("Top", 1)
+    b.add_body("body")
+    sections = b.finish()
+    assert len(sections) == 1
+    assert sections[0].heading == "Top"
+    assert sections[0].body_text == "body"
+
+
+def test_depth_and_anchor_track_each_heading() -> None:
+    b = SectionBuilder()
+    b.add_heading("H1", 1)
+    b.add_body("a")
+    b.add_heading("H3", 3)
+    b.add_body("b")
+    sections = b.finish()
+    assert [(s.depth, s.anchor) for s in sections] == [(1, "H1"), (3, "H3")]
+
+
+def test_default_join_is_newline_join_then_strip() -> None:
+    b = SectionBuilder()
+    b.add_body("  line1  ")
+    b.add_body("line2")
+    # newline-join then outer strip (inner whitespace preserved)
+    assert b.finish()[0].body_text == "line1  \nline2"
+
+
+def test_custom_join_is_applied() -> None:
+    """HTML passes a whitespace-collapsing join; the builder must honor it."""
+    ws = re.compile(r"\s+")
+    b = SectionBuilder(join=lambda parts: ws.sub(" ", " ".join(parts)).strip())
+    b.add_body("a\n   b")
+    b.add_body("  c ")
+    assert b.finish()[0].body_text == "a b c"
+
+
+def test_finish_is_terminal_snapshot() -> None:
+    """finish() flushes the current section; calling it returns the built list."""
+    b = SectionBuilder()
+    b.add_heading("Only", 1)
+    b.add_body("x")
+    first = b.finish()
+    assert len(first) == 1
+    assert first[0].heading == "Only"


### PR DESCRIPTION
## Summary

Closes #204.

The `text`/`markdown`, `html`, and `docx` extractors each duplicated the same "flush on heading, accumulate body, flush at end" section state machine, including a near-identical `flush()` closure that built an `ExtractedSection` and the flush rule *"emit a section only when its joined body or its heading is non-empty"*. This extracts that into a `SectionBuilder` helper in `extractors/_util.py`, parameterized by the body-join function:

- `add_heading(text, depth)` — flush current, start new
- `add_body(text)` — accumulate
- `finish()` — final flush, return sections

Each extractor is now just its iteration + heading-detection loop driving the builder. The default join is `"\n".join(...).strip()` (text/docx); HTML injects a whitespace-collapsing join.

## Behavior

No functional change. Per the issue scope, only the three heading-driven extractors are touched — `pptx`/`xlsx` (one section per slide/sheet) and `pdf`/`epub` (outline-driven) are out of scope. The docx decompression-bomb caps remain inline (format-specific).

## Tests

- New `tests/test_ingest_section_builder.py` pins the flush rule (empty body + heading → emit; body + no heading → emit; neither → no section), the leading-section semantics, depth/anchor tracking, and the default vs custom join.
- Existing `test_ingest_text_extractor` / `test_ingest_html_extractor` / `test_ingest_docx_extractor` pass **unchanged** (behavior-equivalence proof).
- `ruff`, `ruff format --check`, and `pyright src/` are green.

> Note: this branch is based on `main`; the repo currently has pre-existing Windows-only test failures (auth file-mode/fcntl/POSIX-path tests) unrelated to this change — they pass on the Linux CI. They are addressed by a separate review branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
