### PR TITLE
feat(auth): safer multi-profile defaults (auth use + ambiguity warning + strict)

### DIFF
--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -22,15 +22,74 @@ one-way.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-from .auth.credentials import KaguraOAuth, get_shared_state
+from .auth.credentials import KaguraOAuth, get_shared_state, load_credentials_file
 from .config import load_config
 from .exceptions import KaguraAuthError
 
+if TYPE_CHECKING:
+    from .auth.credentials import _SharedCredentialsState
+
 _DEFAULT_MCP_URL = "https://memory.kagura-ai.com/mcp"
+
+_logger = logging.getLogger("kagura_memory")
+
+# Profiles already warned about this process, so the multi-profile ambiguity
+# note (issue #203) fires at most once per active profile per process rather
+# than on every client construction. Reset by :func:`reset_profile_warnings`.
+_warned_profiles: set[str] = set()
+
+
+def reset_profile_warnings() -> None:
+    """Clear the once-per-process ambiguity-warning dedup set (test hook)."""
+    _warned_profiles.clear()
+
+
+def _strict_profile_required() -> bool:
+    """True when ``KAGURA_REQUIRE_PROFILE`` opts into strict resolution (#203)."""
+    return os.getenv("KAGURA_REQUIRE_PROFILE", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _check_profile_ambiguity(state: _SharedCredentialsState) -> None:
+    """Warn (or, under strict mode, raise) on an implicit multi-profile default.
+
+    Only fires when resolution fell back to ``default_profile`` (no explicit
+    ``profile`` arg and no ``KAGURA_PROFILE``) AND more than one profile is
+    configured — a single-profile setup is unambiguous and stays silent. The
+    note names the active profile + workspace so a misdirected write to the
+    wrong account is caught. Honors ``KAGURA_REQUIRE_PROFILE`` (issue #203).
+    """
+    cf = load_credentials_file()
+    if len(cf.profiles) < 2:
+        return  # single profile: unambiguous
+
+    name = state.profile_name
+    creds = state.credentials
+    workspace = creds.workspace_name or creds.workspace_id or "unknown workspace"
+
+    if _strict_profile_required():
+        available = ", ".join(sorted(cf.profiles))
+        raise KaguraAuthError(
+            f"Multiple profiles configured and none selected; refusing to use the "
+            f"implicit default '{name}' because KAGURA_REQUIRE_PROFILE is set.\n"
+            f"  Select one explicitly: kagura auth use <name>, --profile <name>, "
+            f"or KAGURA_PROFILE=<name>\n"
+            f"  Available profiles: {available}"
+        )
+
+    if name not in _warned_profiles:
+        _warned_profiles.add(name)
+        _logger.warning(
+            "kagura: using profile '%s' (workspace '%s') — set a default with "
+            "'kagura auth use <name>' or pass --profile to silence this notice.",
+            name,
+            workspace,
+        )
+
 
 # Which precedence branch produced a ``_StaticAuth``. CLI-layer code uses
 # this to resolve ``workspace_id`` from the same source as ``api_key`` —
@@ -130,6 +189,11 @@ def _resolve_auth(
     target_profile = profile or os.getenv("KAGURA_PROFILE")
     state = get_shared_state(profile=target_profile)
     if state is not None:
+        if target_profile is None:
+            # No explicit selection — resolution fell back to default_profile.
+            # Warn (or hard-error under strict mode) when the default is
+            # ambiguous because multiple profiles are configured (issue #203).
+            _check_profile_ambiguity(state)
         return _OAuthAuth(
             oauth=KaguraOAuth(state),
             mcp_url=mcp_url or state.credentials.mcp_url,

--- a/src/kagura_memory/_auth.py
+++ b/src/kagura_memory/_auth.py
@@ -38,10 +38,12 @@ _DEFAULT_MCP_URL = "https://memory.kagura-ai.com/mcp"
 
 _logger = logging.getLogger("kagura_memory")
 
-# Profiles already warned about this process, so the multi-profile ambiguity
-# note (issue #203) fires at most once per active profile per process rather
-# than on every client construction. Reset by :func:`reset_profile_warnings`.
-_warned_profiles: set[str] = set()
+# (credentials-file path, profile name) pairs already warned about this process,
+# so the multi-profile ambiguity note (issue #203) fires at most once per active
+# profile per file per process rather than on every client construction. Keyed by
+# path too so two different credential files that share a default name (e.g.
+# "default") don't suppress each other. Reset by :func:`reset_profile_warnings`.
+_warned_profiles: set[tuple[str, str]] = set()
 
 
 def reset_profile_warnings() -> None:
@@ -81,8 +83,9 @@ def _check_profile_ambiguity(state: _SharedCredentialsState) -> None:
             f"  Available profiles: {available}"
         )
 
-    if name not in _warned_profiles:
-        _warned_profiles.add(name)
+    warn_key = (str(state.path), name)
+    if warn_key not in _warned_profiles:
+        _warned_profiles.add(warn_key)
         _logger.warning(
             "kagura: using profile '%s' (workspace '%s') — set a default with "
             "'kagura auth use <name>' or pass --profile to silence this notice.",

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -411,7 +411,13 @@ def auth_use(name: str) -> None:
     if name not in cf.profiles:
         available = ", ".join(sorted(cf.profiles)) or "(none — run: kagura auth login)"
         raise click.ClickException(f"Profile '{name}' not found. Available: {available}")
-    set_default_profile(name)
+    try:
+        # set_default_profile re-checks under the cross-process lock; a concurrent
+        # logout between the read above and the write would raise KeyError —
+        # surface it as a clean CLI error, not a traceback.
+        set_default_profile(name)
+    except KeyError as e:
+        raise click.ClickException(f"Profile '{name}' no longer exists.") from e
     creds = cf.profiles[name]
     workspace = creds.workspace_name or creds.workspace_id or "unknown workspace"
     click.echo(f"Default profile set to '{name}' (workspace '{workspace}').")

--- a/src/kagura_memory/auth/cli.py
+++ b/src/kagura_memory/auth/cli.py
@@ -1,10 +1,11 @@
 """Click sub-commands for ``kagura auth``.
 
-Six commands form the public surface:
+Seven commands form the public surface:
 
 * ``login``   — RFC 8628 device flow, persist a profile.
 * ``status``  — print the current profile (token redacted).
 * ``list``    — list every stored profile (no secrets); mark the default.
+* ``use``     — set the default profile deliberately (``kubectl use-context``).
 * ``logout``  — revoke + delete a profile (or the whole file).
 * ``refresh`` — rotate ``access_token``; optional scope expansion.
 * ``token``   — emit ``access_token`` to stdout for CI/scripts.
@@ -48,6 +49,7 @@ from .credentials import (
     load_credentials_file,
     reset_state_cache,
     save_credentials_file,
+    set_default_profile,
     update_profile,
 )
 from .device_flow import (
@@ -394,6 +396,31 @@ def _print_mcp_json_mode(project_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 # list
 # ---------------------------------------------------------------------------
+
+
+@auth.command(name="use")
+@click.argument("name")
+def auth_use(name: str) -> None:
+    """Set the default profile used when no --profile / KAGURA_PROFILE is given.
+
+    \b
+    Like 'kubectl config use-context' / 'gcloud config set account': makes the
+    active account a deliberate choice instead of "whoever logged in first".
+    """
+    cf = load_credentials_file()
+    if name not in cf.profiles:
+        available = ", ".join(sorted(cf.profiles)) or "(none — run: kagura auth login)"
+        raise click.ClickException(f"Profile '{name}' not found. Available: {available}")
+    set_default_profile(name)
+    creds = cf.profiles[name]
+    workspace = creds.workspace_name or creds.workspace_id or "unknown workspace"
+    click.echo(f"Default profile set to '{name}' (workspace '{workspace}').")
+    env_profile = os.getenv("KAGURA_PROFILE")
+    if env_profile:
+        click.echo(
+            f"  Note: KAGURA_PROFILE='{env_profile}' is set and overrides this "
+            "default for commands run in this environment."
+        )
 
 
 @auth.command(name="list")

--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -375,6 +375,29 @@ def update_profile(
         save_credentials_file(cf, path)
 
 
+def set_default_profile(profile_name: str, path: Path | None = None) -> None:
+    """Set ``default_profile`` to an existing profile (backs ``kagura auth use``).
+
+    Unlike :func:`CredentialsFile.set_profile`'s implicit first-wins promotion,
+    this is a *deliberate* default selection. The read-modify-write is wrapped in
+    the same cross-process advisory :func:`kagura_memory._filelock.file_lock` as
+    :func:`update_profile` so a concurrent refresh/login cannot clobber it.
+
+    Raises:
+        KeyError: If ``profile_name`` is not an existing profile — selecting a
+            non-existent default would silently break resolution.
+    """
+    from .._filelock import file_lock
+
+    path = _resolve_path(path)
+    with file_lock(path, exclusive=True):
+        cf = load_credentials_file(path)
+        if profile_name not in cf.profiles:
+            raise KeyError(profile_name)
+        cf.default_profile = profile_name
+        save_credentials_file(cf, path)
+
+
 def delete_profile(
     profile_name: str,
     path: Path | None = None,

--- a/tests/test_auth_profile_defaults.py
+++ b/tests/test_auth_profile_defaults.py
@@ -1,0 +1,154 @@
+"""Safer multi-profile defaults: `auth use`, ambiguity warning, opt-in strict (#203)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from kagura_memory._auth import _resolve_auth, reset_profile_warnings
+from kagura_memory.auth import credentials as creds_mod
+from kagura_memory.auth.cli import auth as auth_group
+from kagura_memory.auth.credentials import (
+    CredentialsFile,
+    OAuthCredentials,
+    load_credentials_file,
+    reset_state_cache,
+    save_credentials_file,
+    set_default_profile,
+)
+from kagura_memory.exceptions import KaguraAuthError
+
+
+def _creds(workspace_name: str = "ws") -> OAuthCredentials:
+    return OAuthCredentials(
+        server="https://test.example.com",
+        mcp_url="https://test.example.com/mcp",
+        client_id="kagura-cli",
+        access_token="atok",
+        refresh_token="rtok",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope="memory:read",
+        workspace_id="ws-id",
+        workspace_name=workspace_name,
+        user_email="u@example.com",
+        issued_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def creds_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    p = tmp_path / "credentials.json"
+    monkeypatch.setattr(creds_mod, "DEFAULT_CREDENTIALS_PATH", p)
+    monkeypatch.delenv("KAGURA_API_KEY", raising=False)
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.delenv("KAGURA_REQUIRE_PROFILE", raising=False)
+    reset_state_cache()
+    reset_profile_warnings()
+    return p
+
+
+def _write_profiles(path: Path, names: list[str], default: str | None = None) -> None:
+    cf = CredentialsFile()
+    for n in names:
+        cf.set_profile(n, _creds(workspace_name=f"ws-{n}"))
+    if default:
+        cf.default_profile = default
+    save_credentials_file(cf, path)
+
+
+# --- set_default_profile -----------------------------------------------------
+
+
+def test_set_default_profile_sets_existing(creds_path: Path) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    set_default_profile("personal")
+    assert load_credentials_file(creds_path).default_profile == "personal"
+
+
+def test_set_default_profile_raises_on_missing(creds_path: Path) -> None:
+    _write_profiles(creds_path, ["work"])
+    with pytest.raises(KeyError):
+        set_default_profile("nope")
+
+
+# --- ambiguity warning (B) ---------------------------------------------------
+
+
+def test_warns_once_on_multi_profile_implicit_default(creds_path, caplog) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    with caplog.at_level(logging.WARNING, logger="kagura_memory"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)  # second call: deduped
+    msgs = [r.getMessage() for r in caplog.records if "using profile 'work'" in r.getMessage()]
+    assert len(msgs) == 1  # once per process, not per client construction
+    assert "ws-work" in msgs[0]  # names the workspace
+
+
+def test_no_warning_single_profile(creds_path, caplog) -> None:
+    _write_profiles(creds_path, ["only"])
+    with caplog.at_level(logging.WARNING, logger="kagura_memory"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+    assert not [r for r in caplog.records if "using profile" in r.getMessage()]
+
+
+def test_no_warning_when_profile_explicit(creds_path, caplog) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    with caplog.at_level(logging.WARNING, logger="kagura_memory"):
+        _resolve_auth(api_key=None, mcp_url=None, profile="personal")
+    assert not [r for r in caplog.records if "using profile" in r.getMessage()]
+
+
+def test_no_warning_when_env_profile_set(creds_path, caplog, monkeypatch) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    monkeypatch.setenv("KAGURA_PROFILE", "personal")
+    with caplog.at_level(logging.WARNING, logger="kagura_memory"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+    assert not [r for r in caplog.records if "using profile" in r.getMessage()]
+
+
+# --- strict mode (C) ---------------------------------------------------------
+
+
+def test_strict_mode_raises_on_ambiguous(creds_path, monkeypatch) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    monkeypatch.setenv("KAGURA_REQUIRE_PROFILE", "1")
+    with pytest.raises(KaguraAuthError, match="KAGURA_REQUIRE_PROFILE"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+
+
+def test_strict_mode_allows_single_profile(creds_path, monkeypatch) -> None:
+    _write_profiles(creds_path, ["only"])
+    monkeypatch.setenv("KAGURA_REQUIRE_PROFILE", "1")
+    result = _resolve_auth(api_key=None, mcp_url=None, profile=None)
+    assert result.workspace_id == "ws-id"  # unambiguous → no raise
+
+
+def test_strict_mode_allows_explicit_profile(creds_path, monkeypatch) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    monkeypatch.setenv("KAGURA_REQUIRE_PROFILE", "1")
+    result = _resolve_auth(api_key=None, mcp_url=None, profile="personal")
+    assert result.workspace_id == "ws-id"
+
+
+# --- CLI: auth use -----------------------------------------------------------
+
+
+def test_cli_auth_use_sets_default(creds_path) -> None:
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    result = CliRunner().invoke(auth_group, ["use", "personal"])
+    assert result.exit_code == 0, result.output
+    assert "Default profile set to 'personal'" in result.output
+    assert load_credentials_file(creds_path).default_profile == "personal"
+
+
+def test_cli_auth_use_unknown_profile_errors(creds_path) -> None:
+    _write_profiles(creds_path, ["work"])
+    result = CliRunner().invoke(auth_group, ["use", "ghost"])
+    assert result.exit_code != 0
+    assert "not found" in result.output
+    assert "work" in result.output  # lists available profiles

--- a/tests/test_auth_profile_defaults.py
+++ b/tests/test_auth_profile_defaults.py
@@ -176,3 +176,27 @@ def test_cli_auth_use_unknown_profile_errors(creds_path) -> None:
     assert result.exit_code != 0
     assert "not found" in result.output
     assert "work" in result.output  # lists available profiles
+
+
+def test_cli_auth_use_notes_env_profile_override(creds_path, monkeypatch) -> None:
+    """When KAGURA_PROFILE is set, `auth use` warns it overrides the new default."""
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    monkeypatch.setenv("KAGURA_PROFILE", "work")
+    result = CliRunner().invoke(auth_group, ["use", "personal"])
+    assert result.exit_code == 0, result.output
+    assert "KAGURA_PROFILE" in result.output
+    assert "overrides" in result.output
+
+
+def test_cli_auth_use_handles_concurrent_delete(creds_path, monkeypatch) -> None:
+    """A logout racing the locked write (KeyError) surfaces a clean CLI error."""
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+
+    def _raise_keyerror(_name: str) -> None:
+        raise KeyError(_name)
+
+    monkeypatch.setattr("kagura_memory.auth.cli.set_default_profile", _raise_keyerror)
+    result = CliRunner().invoke(auth_group, ["use", "personal"])
+    assert result.exit_code != 0
+    assert "no longer exists" in result.output
+    assert "Traceback" not in result.output  # clean ClickException, not a crash

--- a/tests/test_auth_profile_defaults.py
+++ b/tests/test_auth_profile_defaults.py
@@ -135,6 +135,30 @@ def test_strict_mode_allows_explicit_profile(creds_path, monkeypatch) -> None:
     assert result.workspace_id == "ws-id"
 
 
+def test_strict_raise_not_suppressed_by_prior_warning(creds_path, caplog, monkeypatch) -> None:
+    """A prior non-strict warning must not let the dedup set swallow a strict raise."""
+    _write_profiles(creds_path, ["work", "personal"], default="work")
+    with caplog.at_level(logging.WARNING, logger="kagura_memory"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+    assert any("using profile 'work'" in r.getMessage() for r in caplog.records)
+    monkeypatch.setenv("KAGURA_REQUIRE_PROFILE", "1")
+    with pytest.raises(KaguraAuthError, match="KAGURA_REQUIRE_PROFILE"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+
+
+def test_stale_default_profile_fails_closed(creds_path, monkeypatch) -> None:
+    """default_profile pointing at a missing profile fails closed (characterization).
+
+    With real profiles present but the default name stale, resolution finds no
+    OAuth state and falls through; with no api_key/.kagura.json fallback it
+    raises rather than silently picking another account.
+    """
+    _write_profiles(creds_path, ["work", "personal"], default="ghost")
+    monkeypatch.setattr("kagura_memory._auth.load_config", lambda: {})
+    with pytest.raises(KaguraAuthError, match="No credentials found"):
+        _resolve_auth(api_key=None, mcp_url=None, profile=None)
+
+
 # --- CLI: auth use -----------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #203.

With multiple OAuth profiles, the active default was chosen implicitly and silently ("whoever logged in first"), making it easy to operate on the wrong account. This ships the issue's **A + B as default, C as opt-in** recommendation:

- **A. `kagura auth use <name>`** — deliberately set `default_profile` (like `kubectl config use-context` / `gcloud config set account`). Backed by `credentials.set_default_profile()`, which validates the profile exists and writes under the cross-process file lock.
- **B. Ambiguity warning** — when resolution falls back to `default_profile` (no `--profile`, no `KAGURA_PROFILE`) **and** more than one profile is configured, `_resolve_auth` emits a one-line **stderr** warning (via the `kagura_memory` logger) naming the active profile + workspace. Fires **once per process per (file, profile)**; silent on single-profile setups and whenever a profile is explicitly selected.
- **C. Opt-in strict** — `KAGURA_REQUIRE_PROFILE=1` turns that ambiguous fallback into a hard `KaguraAuthError` instead of a warning. Off by default (matches AWS/gcloud/kubectl ergonomics).

First-wins bootstrap (`CredentialsFile.set_profile`) is intentionally **kept** so single-profile UX is unchanged — this is non-breaking. B/C live in the shared `_resolve_auth` path, so they apply uniformly to `KaguraClient` / `ResourceClient` / `FilesClient`.

## Design

Gate1 design review (DX lens) resolved the "remove first-wins?" tension: keep first-wins for bootstrap, make the multi-profile fallback non-silent via B, and route the note through the logger (stderr via logging's last-resort handler) so machine-readable stdout — `kagura auth token`, `--json` — stays clean.

## Tests

`tests/test_auth_profile_defaults.py` (14 tests): `set_default_profile` (set/raise), warning fires once / never on single-profile / never on explicit selection / never with `KAGURA_PROFILE`, strict raises on ambiguity but allows single/explicit, strict not suppressed by a prior warning, stale-default fails closed, and the `auth use` CLI (success + unknown-profile error). An independent adversarial review pass produced two follow-up fixes (path-keyed dedup; `auth use` TOCTOU → clean `ClickException`).

`ruff`, `ruff format --check`, `pyright src/` all green.

> Note: branch is based on `main`; the repo has pre-existing Windows-only test failures (auth file-mode/POSIX-path tests) unrelated to this change — green on Linux CI, addressed by a separate review branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
