### PR TITLE
fix: cross-platform correctness, robustness bugs & doc accuracy (review pass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This SDK connects your Python code to [Kagura Memory Cloud](https://github.com/k
 | **`KaguraClient`** | MCP (JSON-RPC) | Direct memory ops — remember, recall, explore, reference, forget |
 | **`ResourceClient`** | REST API | External data ingestion — push data from Slack, CI/CD, CRM into Kagura |
 | **`FilesClient`** | REST + presigned PUT | File uploads with sha256 integrity binding (R2) |
-| **`FileIngestor`** | CLI + SDK | Document ingestion — PDF text → memory graph + R2 archive (Phase 1; image/PPT/Excel in Phase 2) |
+| **`FileIngestor`** | CLI + SDK | Document ingestion — PDF/Office/HTML/EPUB, audio & YouTube transcripts → memory graph + R2 archive |
 
 ## 60-second demo
 
@@ -49,7 +49,7 @@ kagura recall "report findings" -k 5        # search across sections
 kagura files download-url <file_id>          # short-lived GET on the original
 ```
 
-Phase 1 ingests **text only**. A vision provider (Gemini 2.5 Flash by default) is configured and validated, but the orchestrator does not currently call it — no extractor in Phase 1 emits images, so neither `_image.preprocess()` nor `Provider.describe_image()` is invoked. Image-based OCR memories land in Phase 2. Pass `--no-vision` to skip provider configuration entirely, or `--dry-run` to see token / cost estimates without calling an LLM.
+Ingestion extracts **text** — from PDFs, Office/HTML/EPUB documents, audio/video transcripts, and YouTube captions. Images embedded in a document are detected and counted (`IngestResult.skipped_images`) but not yet OCR'd: a vision provider (Gemini 2.5 Flash by default) is configured and validated, but the orchestrator does not currently invoke `Provider.describe_image()` — image-to-text memories are a planned follow-up. Pass `--no-vision` to skip provider configuration entirely, or `--dry-run` to see token / cost estimates without calling an LLM.
 
 ## Installation
 
@@ -304,7 +304,7 @@ Runnable: [`examples/files_upload.py`](examples/files_upload.py).
 
 | SDK | Min memory-cloud | Notes |
 |---|---|---|
-| 0.27.0 – 0.29.x | 0.17.1 | **Agent memory substrate.** `load_pinned` + `delivery_mode` pin-on-write, `recall_upcoming`, `feedback`, `set_state`/`get_state`, and the `trust_tier` recall filter each need a memory-cloud carrying the matching [#885](https://github.com/kagura-ai/memory-cloud/issues/885) agent-substrate APIs (≈ v0.23.0+); against an older server those specific tools return an MCP "tool not found". `MIN_SERVER_VERSION` stays **0.17.1** — the rest of the SDK still works on 0.17.1+. **v0.29.0 also changed error handling (breaking): MCP tool methods now raise `KaguraNotFoundError`/`KaguraError` instead of returning `{"status":"error"}` dicts** (see the KaguraClient error-handling note above). |
+| 0.27.0 – 0.31.x | 0.17.1 | **Agent memory substrate.** `load_pinned` + `delivery_mode` pin-on-write, `recall_upcoming`, `feedback`, `set_state`/`get_state`, and the `trust_tier` recall filter each need a memory-cloud carrying the matching [#885](https://github.com/kagura-ai/memory-cloud/issues/885) agent-substrate APIs (≈ v0.23.0+); against an older server those specific tools return an MCP "tool not found". `MIN_SERVER_VERSION` stays **0.17.1** — the rest of the SDK still works on 0.17.1+. **v0.29.0 also changed error handling (breaking): MCP tool methods now raise `KaguraNotFoundError`/`KaguraError` instead of returning `{"status":"error"}` dicts** (see the KaguraClient error-handling note above). |
 | 0.15.0 – 0.20.x | 0.15.1 | `FilesClient` + R2 checksum binding. `list_tags()` additionally needs **0.15.4** — `MIN_SERVER_VERSION` is intentionally not bumped, only that one method requires the newer server. |
 | 0.14.x | 0.15.1 | `FilesClient` + R2 checksum binding (`x-amz-checksum-sha256` on PUT) |
 | 0.13.x | 0.13.0 | Pre-`FilesClient` |
@@ -327,6 +327,8 @@ kagura auth login --no-browser                       # SSH / headless
 kagura auth login --profile work                     # named profile for a second workspace
 
 kagura auth status                                   # show profile, server, expiry, scope
+kagura auth list                                     # list all stored profiles (default marked *)
+kagura auth list --json                              # machine-readable profile list
 kagura auth refresh                                  # manual token rotation
 kagura auth refresh --scope "memory:write"           # incremental consent (re-runs device flow)
 kagura auth token                                    # raw access_token to stdout (CI use)
@@ -423,8 +425,8 @@ kagura ingest https://example.com/report.pdf --tags "Q1,research"
 # Preview cost / sections without calling any LLM
 kagura ingest ./report.pdf --dry-run
 
-# Skip vision-provider configuration entirely (Phase 1 already ingests
-# text only; this becomes meaningful once Phase 2 image extraction lands)
+# Skip vision-provider configuration entirely (images are not OCR'd yet, so
+# this just avoids validating a vision provider you don't need)
 kagura ingest ./report.pdf --no-vision
 
 # Storage: skip the R2 archive (no file_id stamped on the overview memory)
@@ -440,7 +442,7 @@ For the SDK-level `FileIngestor` API, see [`examples/ingest_pdf.py`](examples/in
 
 Provider configuration (env vars, picked up automatically via `litellm`):
 - `ANTHROPIC_API_KEY` — text summarization (default model `claude-sonnet-4-6` via the `claude` preset)
-- `GEMINI_API_KEY` — reserved for vision OCR (default model `gemini/gemini-2.5-flash` via the `gemini` preset); not invoked in Phase 1
+- `GEMINI_API_KEY` — audio/video transcription (default model `gemini/gemini-2.5-flash` via the `gemini` preset); also the default vision provider for image OCR, which is configured but not yet invoked (see above)
 - Override per invocation: `--text-provider {claude|gemini|ollama}`, `--vision-provider {claude|gemini|ollama}`
 
 ## Claude Code Integration

--- a/src/kagura_memory/_http.py
+++ b/src/kagura_memory/_http.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import re
 from importlib.metadata import version as _pkg_version
-from typing import Any
+from typing import Any, NoReturn
 
 import httpx
+
+from .exceptions import (
+    KaguraAuthError,
+    KaguraConnectionError,
+    KaguraRateLimitError,
+    _exc_message,
+)
 
 SDK_VERSION: str = _pkg_version("kagura-memory")
 """Package version string, shared across client modules."""
@@ -54,6 +61,44 @@ def extract_detail(response: httpx.Response) -> str:
     if isinstance(detail, list):
         return _format_validation_errors(detail)
     return ""
+
+
+def _retry_after_seconds(response: httpx.Response) -> int | None:
+    """Parse a numeric ``Retry-After`` header (delta-seconds), else ``None``.
+
+    Only the integer-seconds form is honored; an HTTP-date ``Retry-After`` (rare
+    for rate limits) is treated as absent rather than mis-parsed.
+    """
+    raw = response.headers.get("Retry-After")
+    if raw is None:
+        return None
+    raw = raw.strip()
+    return int(raw) if raw.isdigit() else None
+
+
+def raise_for_kagura_status(e: httpx.HTTPStatusError) -> NoReturn:
+    """Translate an httpx ``HTTPStatusError`` into the matching Kagura error.
+
+    Maps ``401`` → :class:`~kagura_memory.exceptions.KaguraAuthError`, ``429`` →
+    :class:`~kagura_memory.exceptions.KaguraRateLimitError` (honoring a numeric
+    ``Retry-After`` header), and every other status →
+    :class:`~kagura_memory.exceptions.KaguraConnectionError`. The server-supplied
+    ``detail`` (a FastAPI string or validation-error list) is appended when
+    present — surfacing e.g. which field failed a 422 — otherwise the
+    exception's own message is used so the status is never left bare. This
+    function always raises.
+    """
+    response = e.response
+    status = response.status_code
+    if status == 401:
+        raise KaguraAuthError("Authentication failed. Check your API key.") from e
+    detail = extract_detail(response) or _exc_message(e)
+    if status == 429:
+        raise KaguraRateLimitError(
+            f"Rate limit exceeded (HTTP 429): {detail}",
+            retry_after=_retry_after_seconds(response),
+        ) from e
+    raise KaguraConnectionError(f"HTTP {status}: {detail}") from e
 
 
 def _format_validation_errors(errors: list[Any]) -> str:

--- a/src/kagura_memory/agent.py
+++ b/src/kagura_memory/agent.py
@@ -296,7 +296,10 @@ class KaguraAgent:
             count = len(data) if isinstance(data, list) else "N/A"
             self.logger.detail(f"Cached {label}", f"{count} items" if count != "N/A" else "")
 
-        return data
+        # Return a copy on the miss path too: callers must never get a live
+        # reference into the cache (the hit path above already deep-copies), or
+        # a downstream mutation would silently corrupt the cached entry.
+        return copy.deepcopy(data)
 
     async def _get_tools_with_cache(self) -> list[dict[str, Any]]:
         """
@@ -378,10 +381,13 @@ class KaguraAgent:
         if not usage:
             return None
 
+        # Coerce ``or 0``: a provider may expose the attribute set to ``None``
+        # (getattr's default only applies when the attribute is absent), which
+        # would fail LLMUsage's int validation — mirror the Ollama path above.
         return LLMUsage(
-            prompt_tokens=getattr(usage, "prompt_tokens", 0),
-            completion_tokens=getattr(usage, "completion_tokens", 0),
-            total_tokens=getattr(usage, "total_tokens", 0),
+            prompt_tokens=getattr(usage, "prompt_tokens", 0) or 0,
+            completion_tokens=getattr(usage, "completion_tokens", 0) or 0,
+            total_tokens=getattr(usage, "total_tokens", 0) or 0,
             model=self.model,
         )
 
@@ -425,6 +431,9 @@ class KaguraAgent:
             except Exception as e:
                 if attempt == self.max_retries - 1:
                     raise KaguraLLMError(f"Unexpected LLM error: {e}") from e
+                self.logger.warning(
+                    f"LLM call failed (attempt {attempt + 1}/{self.max_retries}), retrying: {e}"
+                )
                 await asyncio.sleep(2**attempt)
 
         raise KaguraLLMError("Max retries exceeded")
@@ -500,10 +509,36 @@ class KaguraAgent:
         except httpx.RequestError as e:
             raise KaguraLLMError(f"Ollama connection failed: {e}") from e
 
-        body = resp.json()
+        # With stream=True, Ollama returns newline-delimited JSON chunks rather
+        # than a single object, so resp.json() would fail; merge them first.
+        body = self._merge_ollama_stream(resp.text) if self._ollama_stream else resp.json()
         content = body.get("message", {}).get("content", "")
         data = json.loads(content or "{}")
         return data, body
+
+    @staticmethod
+    def _merge_ollama_stream(raw: str) -> dict[str, Any]:
+        """Collapse Ollama's newline-delimited streaming chunks into one body.
+
+        With ``stream: true`` Ollama emits one JSON object per line: the message
+        content is split across chunks and the token counts arrive on the final
+        ``done`` chunk. Concatenate the content and keep the last chunk's other
+        fields, so the merged dict matches the non-streaming response shape and
+        :meth:`_extract_usage` still finds ``prompt_eval_count`` / ``eval_count``.
+        """
+        merged: dict[str, Any] = {}
+        parts: list[str] = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            chunk = json.loads(line)
+            piece = chunk.get("message", {}).get("content", "")
+            if piece:
+                parts.append(piece)
+            merged = chunk
+        merged["message"] = {"role": "assistant", "content": "".join(parts)}
+        return merged
 
     async def _analyze_session(
         self, session: Session, use_enhanced_context: bool = True
@@ -622,22 +657,25 @@ class KaguraAgent:
                 self.logger.warning(f"Recall failed: {e}")
                 continue
 
-            for mem in result.get("results", []):
-                recalled.append(
-                    Memory(
-                        memory_id=mem["memory_id"],
-                        summary=mem["summary"],
-                        score=mem.get("score", 0.0),
-                    )
+            query_results = [
+                Memory(
+                    memory_id=mem["memory_id"],
+                    summary=mem["summary"],
+                    score=mem.get("score", 0.0),
                 )
+                for mem in result.get("results", [])
+            ]
+            recalled.extend(query_results)
 
             actions.append(f"recall: {query}")
-            self.logger.detail("Found memories", len(recalled))
+            self.logger.detail("Found memories", len(query_results))
 
-            # Deep mode: explore if results found
-            if deep and recalled:
-                self.logger.action("Deep exploration", f"seed={recalled[0].memory_id}")
-                seed_id = recalled[0].memory_id
+            # Deep mode: explore from THIS query's top hit. Seeding from
+            # ``recalled[0]`` would always re-explore the first query's first
+            # result on every later iteration (the list accumulates).
+            if deep and query_results:
+                seed_id = query_results[0].memory_id
+                self.logger.action("Deep exploration", f"seed={seed_id}")
 
                 try:
                     explore_result = await self.client.explore(

--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -359,11 +359,11 @@ def update_profile(
     The read-modify-write is serialized two ways: the in-process
     :class:`asyncio.Lock` held in :class:`_SharedCredentialsState` coalesces
     refreshes within a single process, and a cross-process advisory
-    :func:`kagura_memory._filelock.file_lock` (POSIX ``fcntl``; a no-op on
-    Windows pending a follow-up) wraps the load→set→save so concurrent writers
-    in *different* processes — e.g. multiple ``kagura-mcp`` proxy children —
-    cannot lose an update. The lock is on a sibling ``credentials.json.lock``,
-    not the file itself, so it never races the atomic ``os.replace`` in
+    :func:`kagura_memory._filelock.file_lock` (POSIX ``fcntl`` or Windows
+    ``msvcrt``) wraps the load→set→save so concurrent writers in *different*
+    processes — e.g. multiple ``kagura-mcp`` proxy children — cannot lose an
+    update. The lock is on a sibling ``credentials.json.lock``, not the file
+    itself, so it never races the atomic ``os.replace`` in
     :func:`save_credentials_file`.
     """
     from .._filelock import file_lock

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -366,10 +366,10 @@ def explore(context_id, memory_id, depth, min_weight):
     default="gemini",
     show_default=True,
     help=(
-        "Vision LLM provider used when image content is extracted "
-        "(Phase 2+). Phase 1 extractors do not yet emit images, so this "
-        "setting is currently a no-op. Pass --no-vision to skip image "
-        "handling configuration entirely."
+        "Vision LLM provider for image OCR. Images are detected but not yet "
+        "OCR'd (the orchestrator does not call describe_image), so this "
+        "setting is currently a no-op. Pass --no-vision to skip vision-"
+        "provider configuration entirely."
     ),
 )
 @click.option(
@@ -501,11 +501,12 @@ def ingest_file(
 
       pip install 'kagura-memory[ingest-pdf]'
 
-    Phase 1 ingests text content only. The vision pipeline (Gemini 2.5 Flash
-    by default) is configured but the bundled PDF extractor does not yet
-    emit page images — image-based OCR memories land in Phase 2. Pass
-    --no-vision to skip vision-provider configuration entirely (no
-    image bytes will be sent to any provider once Phase 2 lands).
+    Text is extracted from documents (PDF/Office/HTML/EPUB), audio/video
+    transcripts, and YouTube captions. Images embedded in a document are
+    detected and counted but not yet OCR'd: a vision provider (Gemini 2.5
+    Flash by default) is configured but the orchestrator does not call
+    describe_image() yet. Pass --no-vision to skip vision-provider
+    configuration entirely.
 
     Examples:
       kagura ingest https://example.com/report.pdf

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -1267,6 +1267,13 @@ class KaguraClient:
             "target_id": target_id,
         }
         result = await self._call_tool_checked("delete_edge", arguments)
+        # The server confirms a delete with {"status": "success"} and NO
+        # "deleted" key; a missing edge comes back as a status=="error" response
+        # that _call_tool_checked already raised above. So reaching here means
+        # deletion was confirmed — the default True is load-bearing and must not
+        # be "fixed" to False (that would report failure on every real delete).
+        # The .get() still honors an explicit "deleted" flag should the server
+        # contract ever add one. (Verified against memory-cloud edge.py.)
         return bool(result.get("deleted", True))
 
     async def get_usage(self) -> UsageInfo:

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -902,7 +902,14 @@ class KaguraClient:
 
         Returns:
             API response with deletion results
+
+        Raises:
+            ValueError: If neither ``memory_id`` nor ``query`` is provided —
+                ``forget`` always targets a specific memory or a search; an
+                unqualified call would be an ambiguous no-op.
         """
+        if not memory_id and not query:
+            raise ValueError("Provide either memory_id or query")
         arguments: dict[str, Any] = {"context_id": context_id}
         if memory_id:
             arguments["memory_id"] = memory_id

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -9,9 +9,8 @@ import httpx
 from pydantic import BaseModel as _BaseModel
 
 from ._auth import _resolve_auth, _StaticAuth
-from ._http import SDK_VERSION, base_url_from_mcp, validate_https_url
+from ._http import SDK_VERSION, base_url_from_mcp, raise_for_kagura_status, validate_https_url
 from .exceptions import (
-    KaguraAuthError,
     KaguraConnectionError,
     KaguraError,
     KaguraNotFoundError,
@@ -165,9 +164,7 @@ class KaguraClient:
                 raise KaguraConnectionError("No session ID returned from server")
 
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise KaguraAuthError("Authentication failed. Check your API key.") from e
-            raise KaguraConnectionError(f"HTTP {e.response.status_code}: {_exc_message(e)}") from e
+            raise_for_kagura_status(e)
         except httpx.RequestError as e:
             raise KaguraConnectionError(f"Connection failed: {_exc_message(e)}") from e
 
@@ -209,9 +206,7 @@ class KaguraClient:
             return data.get("result", {})
 
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise KaguraAuthError("Authentication failed") from e
-            raise KaguraConnectionError(f"HTTP {e.response.status_code}") from e
+            raise_for_kagura_status(e)
         except httpx.RequestError as e:
             raise KaguraConnectionError(f"Connection failed: {_exc_message(e)}") from e
 
@@ -237,9 +232,7 @@ class KaguraClient:
             response.raise_for_status()
             return model.model_validate(response.json())
         except httpx.HTTPStatusError as e:
-            if e.response.status_code == 401:
-                raise KaguraAuthError("Authentication failed. Check your API key.") from e
-            raise KaguraConnectionError(f"HTTP {e.response.status_code}") from e
+            raise_for_kagura_status(e)
         except httpx.RequestError as e:
             raise KaguraConnectionError(f"Connection failed: {_exc_message(e)}") from e
         except (ValueError, TypeError) as e:
@@ -431,8 +424,10 @@ class KaguraClient:
             API response with results list
 
         Raises:
-            ValueError: If neither ``context_id`` nor ``context_ids`` is provided,
-                or ``context_ids`` has fewer than 2 or more than 20 IDs.
+            ValueError: If ``query`` is empty/whitespace; if neither
+                ``context_id`` nor ``context_ids`` is provided; if
+                ``context_ids`` has fewer than 2 or more than 20 IDs; or if
+                ``search_mode`` is not one of "hybrid"/"semantic"/"keyword".
         """
         if not isinstance(query, str) or not query.strip():
             raise ValueError("query must be a non-empty string")

--- a/src/kagura_memory/ingest/__init__.py
+++ b/src/kagura_memory/ingest/__init__.py
@@ -1,22 +1,29 @@
 """File ingestion module for Kagura Memory SDK (Issue #80).
 
-Convert URLs and local files (PDF, image — Phase 1) into structured Memory
-Cloud memories. The high-level entry point is :class:`FileIngestor`; the
-``kagura ingest`` CLI subcommand is a thin wrapper around it.
+Convert URLs and local files into structured Memory Cloud memories. The
+high-level entry point is :class:`FileIngestor`; the ``kagura ingest`` CLI
+subcommand is a thin wrapper around it.
+
+Supported inputs: PDF, plain text / Markdown, HTML, DOCX, XLSX, PPTX, EPUB,
+images (vision), audio/video transcription, and YouTube transcripts; a URL may
+optionally be rendered with a headless browser for JS-heavy pages. Each
+parser's heavy dependency is opt-in via a ``kagura-memory[ingest-*]`` extra.
 
 The public surface is intentionally small:
 
 * :class:`FileIngestor` — orchestrator
 * :class:`Fetcher` — SSRF-hardened URL/file fetch
 * :class:`Provider` — text/vision LLM Protocol (implementations: Claude, Gemini, Ollama)
-* :class:`Extractor` — structural-extractor Protocol (implementations: PDF)
+* :class:`Extractor` — structural-extractor Protocol (implementations: PDF,
+  text/Markdown, HTML, DOCX, XLSX, PPTX, EPUB)
 
 Result types (:class:`IngestResult`, :class:`CostBreakdown`,
 :class:`IngestErrorRecord`) live in :mod:`kagura_memory.models` and are
 re-exported at the package root for convenience.
 
-Heavy parsing dependencies (``pymupdf``, ``pillow``) are lazy-imported
-inside the concrete extractors. Importing this module never triggers them.
+Heavy parsing dependencies (``pymupdf``, ``pillow``, ``beautifulsoup4``,
+``python-docx``, ``openpyxl``, ``python-pptx``) are lazy-imported inside the
+concrete extractors. Importing this module never triggers them.
 """
 
 from .extractors.base import Extractor

--- a/src/kagura_memory/ingest/__init__.py
+++ b/src/kagura_memory/ingest/__init__.py
@@ -5,9 +5,12 @@ high-level entry point is :class:`FileIngestor`; the ``kagura ingest`` CLI
 subcommand is a thin wrapper around it.
 
 Supported inputs: PDF, plain text / Markdown, HTML, DOCX, XLSX, PPTX, EPUB,
-images (vision), audio/video transcription, and YouTube transcripts; a URL may
-optionally be rendered with a headless browser for JS-heavy pages. Each
-parser's heavy dependency is opt-in via a ``kagura-memory[ingest-*]`` extra.
+audio/video transcription, and YouTube transcripts; a URL may optionally be
+rendered with a headless browser for JS-heavy pages. Each parser's heavy
+dependency is opt-in via a ``kagura-memory[ingest-*]`` extra. Images embedded
+in documents are detected and counted but not yet OCR'd — a vision
+:class:`Provider` exists (``describe_image``) but the orchestrator does not
+call it yet, so such images are reported via ``IngestResult.skipped_images``.
 
 The public surface is intentionally small:
 

--- a/src/kagura_memory/ingest/_audio.py
+++ b/src/kagura_memory/ingest/_audio.py
@@ -285,9 +285,12 @@ async def transcribe_audio(
 
     Sends ``body`` inline (base64) to Gemini via ``litellm.acompletion`` and
     parses the returned ``{segments: [{start, end, text}]}`` JSON into
-    time-windowed sections. Robust to a truncated/partial JSON response: one
-    retry is performed before giving up, after which a malformed transcript
-    raises :class:`KaguraIngestError` pointing at the ffmpeg follow-up.
+    time-windowed sections. Truncation is handled two ways: a transient bad
+    decode (malformed JSON) gets one retry before giving up, while a hard
+    output-token truncation — the model reporting ``finish_reason="length"`` —
+    fails fast, because re-sending the identical request cannot recover. Either
+    way an unusable transcript raises :class:`KaguraIngestError` pointing at the
+    ffmpeg follow-up.
 
     Args:
         body: Raw audio/video bytes.
@@ -358,6 +361,17 @@ async def transcribe_audio(
         attempt_usage = _extract_usage(response, model=model)
         total_prompt += attempt_usage.prompt_tokens
         total_completion += attempt_usage.completion_tokens
+        if _extract_finish_reason(response) == "length":
+            # The model hit its output-token cap. The JSON may still parse, but
+            # the transcript is truncated — and re-sending the identical request
+            # would just truncate again, so fail fast rather than burn a
+            # pointless (billable) retry that cannot recover.
+            raise KaguraIngestError(
+                "transcript was truncated by the model's output-token limit "
+                f"({_DEFAULT_MAX_OUTPUT_TOKENS} tokens) — the audio is too long "
+                "for a single request. Try a shorter clip; splitting long media "
+                "with ffmpeg is a planned follow-up."
+            )
         try:
             segments = _parse_segments(raw)
         except _TranscriptParseError as e:
@@ -403,6 +417,18 @@ def _extract_content(response: Any) -> str:
         return str(response.choices[0].message.content or "")
     except (AttributeError, IndexError, TypeError):
         return ""
+
+
+def _extract_finish_reason(response: Any) -> str | None:
+    """Return the first choice's ``finish_reason``, or ``None`` if unavailable.
+
+    ``"length"`` means the model stopped because it hit its output-token cap, so
+    the content is truncated even when the partial JSON still happens to parse.
+    """
+    try:
+        return response.choices[0].finish_reason
+    except (AttributeError, IndexError, TypeError):
+        return None
 
 
 def _extract_usage(response: Any, *, model: str) -> AudioUsage:

--- a/src/kagura_memory/ingest/_browser.py
+++ b/src/kagura_memory/ingest/_browser.py
@@ -192,8 +192,10 @@ class BrowserFetcher:
         self._resolve_cache = {}
 
         context = await self._browser.new_context()
-        page = await context.new_page()
         try:
+            # new_page() is inside the try so a failure here still closes the
+            # freshly-created context (otherwise it would leak a browser context).
+            page = await context.new_page()
             await page.route("**/*", self._route_handler)
             try:
                 response = await page.goto(

--- a/src/kagura_memory/ingest/_safety.py
+++ b/src/kagura_memory/ingest/_safety.py
@@ -15,6 +15,7 @@ exact IP validated here — see :meth:`Fetcher._stream_request` (#188).
 from __future__ import annotations
 
 import ipaddress
+import os
 from pathlib import Path
 
 _BLOCKED_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
@@ -64,8 +65,29 @@ def is_blocked_ip(ip_str: str) -> bool:
     return any(ip in net for net in _BLOCKED_NETWORKS)
 
 
+def _blocked_prefixes() -> tuple[Path, ...]:
+    """Sensitive directory prefixes to default-deny for the running platform.
+
+    ``~/.ssh`` is always included (resolved against the current ``$HOME``). On
+    Windows the system directory (``%SystemRoot%``, typically ``C:\\Windows``)
+    and ``%ProgramData%`` are blocked; on POSIX the directories in
+    :data:`_DEFAULT_BLOCKED_PATH_PREFIXES` are used. The POSIX list is left out
+    on Windows because a drive-rooted path can never live under ``/etc`` et al.
+    """
+    prefixes: list[Path] = [Path.home() / ".ssh"]
+    if os.name == "nt":
+        system_root = os.environ.get("SystemRoot") or os.environ.get("windir") or r"C:\Windows"
+        prefixes.append(Path(system_root))
+        program_data = os.environ.get("ProgramData")
+        if program_data:
+            prefixes.append(Path(program_data))
+    else:
+        prefixes.extend(Path(p) for p in _DEFAULT_BLOCKED_PATH_PREFIXES)
+    return tuple(prefixes)
+
+
 def is_blocked_system_path(path: Path) -> bool:
-    """True iff the absolute path matches a default-deny prefix.
+    """True iff the absolute path is inside a sensitive system directory.
 
     Args:
         path: Filesystem path to test. Must already be resolved to an
@@ -74,14 +96,13 @@ def is_blocked_system_path(path: Path) -> bool:
             path on rejection.
 
     Returns:
-        ``True`` if the absolute path starts with a sensitive system
+        ``True`` if the absolute path is at or under a default-blocked system
         directory, ``False`` otherwise.
+
+    Matching uses :meth:`pathlib.PurePath.is_relative_to`, so a prefix only
+    matches on a path-segment boundary — ``/var/log`` blocks ``/var/log/x`` but
+    not ``/varlog`` — and comparison is case-insensitive on Windows.
     """
     if not path.is_absolute():
         return False
-    s = str(path)
-    if s.startswith(str(Path.home() / ".ssh")):
-        return True
-    return any(
-        s == prefix or s.startswith(prefix + "/") for prefix in _DEFAULT_BLOCKED_PATH_PREFIXES
-    )
+    return any(path.is_relative_to(prefix) for prefix in _blocked_prefixes())

--- a/src/kagura_memory/ingest/fetcher.py
+++ b/src/kagura_memory/ingest/fetcher.py
@@ -141,9 +141,18 @@ class Fetcher:
 
         # URL form takes precedence: anything starting with a scheme like
         # http://, https://, ftp://, file://, ... is parsed as a URL.
+        #
+        # Exception: a Windows drive-letter path ("C:\\Users\\f\\doc.pdf" or
+        # "C:/Users/f/doc.pdf") is mis-parsed by urlsplit as scheme="c" with no
+        # authority, which would otherwise be rejected as an unsupported scheme
+        # and break *all* absolute-path local-file ingestion on Windows. A real
+        # URL scheme we serve is multi-character; a single ASCII letter with no
+        # netloc is a drive letter, so route it to the local-file path instead.
         parsed = urlsplit(source)
-        if parsed.scheme:
-            if parsed.scheme.lower() not in _ALLOWED_SCHEMES:
+        scheme = parsed.scheme.lower()
+        is_windows_drive = len(scheme) == 1 and scheme.isalpha() and not parsed.netloc
+        if scheme and not is_windows_drive:
+            if scheme not in _ALLOWED_SCHEMES:
                 raise KaguraFetchError(
                     f"unsupported scheme {parsed.scheme!r}; only http(s) is allowed",
                     url=source,

--- a/tests/test__http.py
+++ b/tests/test__http.py
@@ -228,3 +228,17 @@ def test_reject_message_includes_label_and_url():
     """The error surfaces the caller-supplied label and the offending URL."""
     with pytest.raises(ValueError, match=r"MCP URL must use HTTPS.*localhost\.evil\.com"):
         validate_https_url("http://localhost.evil.com", label="MCP URL")
+
+
+def test_retry_after_seconds_parses_digits_else_none():
+    """_retry_after_seconds honors integer seconds, else None (incl. HTTP-date / absent)."""
+    from kagura_memory._http import _retry_after_seconds
+
+    class _Resp:
+        def __init__(self, headers):
+            self.headers = headers
+
+    assert _retry_after_seconds(_Resp({"Retry-After": "30"})) == 30
+    assert _retry_after_seconds(_Resp({"Retry-After": " 45 "})) == 45  # stripped
+    assert _retry_after_seconds(_Resp({"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})) is None
+    assert _retry_after_seconds(_Resp({})) is None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -430,6 +430,63 @@ async def test_call_ollama_success():
 
 
 @pytest.mark.asyncio
+async def test_call_ollama_stream_merges_ndjson():
+    """With ollama_stream=True, _call_ollama merges NDJSON chunks into one body."""
+    agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b", ollama_stream=True)
+
+    chunks = [
+        {"message": {"role": "assistant", "content": '{"should_'}, "done": False},
+        {"message": {"role": "assistant", "content": 'remember": true}'}, "done": False},
+        {
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "prompt_eval_count": 100,
+            "eval_count": 50,
+        },
+    ]
+    ndjson = "\n".join(json.dumps(c) for c in chunks)
+
+    mock_client = AsyncMock()
+    mock_resp = MagicMock()
+    mock_resp.text = ndjson
+    mock_resp.raise_for_status = MagicMock()
+    mock_client.post.return_value = mock_resp
+    agent._ollama_client = mock_client
+
+    data, resp = await agent._call_ollama([{"role": "user", "content": "test"}], 0.3)
+
+    # The split content reassembles into valid JSON.
+    assert data == {"should_remember": True}
+    assert resp["message"]["content"] == '{"should_remember": true}'
+    # Token counts from the final chunk survive the merge.
+    usage = agent._extract_usage(resp)
+    assert usage is not None
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 50
+    await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_litellm_usage_coerces_none_token_counts():
+    """A litellm usage object exposing None counts must not crash LLMUsage."""
+    agent = KaguraAgent(api_key="test", model="gpt-5.4-nano")
+
+    usage_obj = MagicMock()
+    usage_obj.prompt_tokens = None
+    usage_obj.completion_tokens = None
+    usage_obj.total_tokens = None
+    response = MagicMock()
+    response.usage = usage_obj
+
+    usage = agent._extract_usage(response)
+    assert usage is not None
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+    await agent.close()
+
+
+@pytest.mark.asyncio
 async def test_ollama_usage_extraction():
     """_extract_usage should handle Ollama response dict format."""
     agent = KaguraAgent(api_key="test", model="ollama/qwen3:30b")

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -466,6 +466,19 @@ async def test_call_ollama_stream_merges_ndjson():
     await agent.close()
 
 
+def test_merge_ollama_stream_skips_blank_lines_and_empty_content():
+    """_merge_ollama_stream ignores blank lines and empty-content chunks."""
+    raw = (
+        "\n"
+        "   \n"  # blank / whitespace-only lines are skipped
+        '{"message": {"content": ""}, "done": false}\n'  # empty content not appended
+        '{"message": {"content": "x"}, "done": true, "eval_count": 1}\n'
+    )
+    merged = KaguraAgent._merge_ollama_stream(raw)
+    assert merged["message"]["content"] == "x"
+    assert merged.get("eval_count") == 1
+
+
 @pytest.mark.asyncio
 async def test_litellm_usage_coerces_none_token_counts():
     """A litellm usage object exposing None counts must not crash LLMUsage."""

--- a/tests/test_auth_credentials.py
+++ b/tests/test_auth_credentials.py
@@ -32,11 +32,14 @@ from kagura_memory.auth.credentials import (
 )
 from kagura_memory.auth.device_flow import TokenResponse
 
-# The cross-process refresh-dedup tests rely on fcntl serializing two
-# independent open descriptions of the same lock file; gate them to POSIX (CI
-# runs Linux). The Windows msvcrt backend is unit-tested in test_filelock.py.
+# Gate POSIX-specific behaviour to non-Windows (CI runs Linux):
+#   - the cross-process refresh-dedup tests rely on fcntl serializing two
+#     independent open descriptions of the same lock file (the Windows msvcrt
+#     backend is unit-tested in test_filelock.py); and
+#   - the 0600/0700 file-mode tests assert POSIX permission bits, which
+#     os.chmod cannot set on Windows (NTFS uses ACLs).
 _POSIX_ONLY_CREDS = pytest.mark.skipif(
-    sys.platform == "win32", reason="cross-process dedup test uses POSIX fcntl"
+    sys.platform == "win32", reason="POSIX-only: fcntl serialization / chmod permission bits"
 )
 
 
@@ -181,6 +184,7 @@ def test_save_and_load_round_trip(tmp_path: Path):
     assert restored.get_profile().access_token == "atok-1"
 
 
+@_POSIX_ONLY_CREDS
 def test_save_enforces_file_mode_0600(tmp_path: Path):
     path = tmp_path / "creds.json"
     cf = CredentialsFile()
@@ -189,6 +193,7 @@ def test_save_enforces_file_mode_0600(tmp_path: Path):
     assert stat.S_IMODE(path.stat().st_mode) == CREDENTIALS_FILE_MODE
 
 
+@_POSIX_ONLY_CREDS
 def test_save_enforces_dir_mode_0700(tmp_path: Path):
     path = tmp_path / "subdir" / "creds.json"
     cf = CredentialsFile()
@@ -253,6 +258,7 @@ def test_delete_profile_no_op_when_missing(tmp_path: Path):
     assert "alice" in restored.profiles  # untouched
 
 
+@_POSIX_ONLY_CREDS
 def test_load_fixes_loose_file_perms(tmp_path: Path):
     """File written 0644 should be coerced back to 0600 on read."""
     path = tmp_path / "creds.json"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@ from kagura_memory import (
     KaguraError,
     KaguraNotFoundError,
     KaguraQuotaError,
+    KaguraRateLimitError,
     MemoryListResponse,
     MemoryStatsResponse,
     RollbackResult,
@@ -146,6 +147,29 @@ async def test_initialize_session_non_401_http_error_surfaces_class_name():
     msg = str(exc_info.value)
     assert msg != "HTTP 503: "
     assert msg.endswith("HTTPStatusError") or "HTTP 503: " in msg and len(msg.split(": ", 1)[1]) > 0
+
+
+@pytest.mark.asyncio
+async def test_http_429_raises_rate_limit_with_retry_after():
+    """A 429 surfaces as KaguraRateLimitError carrying the Retry-After seconds."""
+    client = KaguraClient(api_key="test", mcp_url="https://test.com/mcp")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_response.headers = {"Retry-After": "12"}
+    mock_response.json.return_value = {"detail": "slow down"}
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "429", request=MagicMock(), response=mock_response
+    )
+
+    with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_response
+        with pytest.raises(KaguraRateLimitError) as exc_info:
+            await client._initialize_session()
+
+    assert exc_info.value.retry_after == 12
+    assert "slow down" in str(exc_info.value)
+    await client.close()
 
     await client.close()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -876,6 +876,19 @@ async def test_forget_by_query():
 
 
 @pytest.mark.asyncio
+async def test_forget_requires_target():
+    """forget() with neither memory_id nor query raises rather than sending a no-op."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        with pytest.raises(ValueError, match="memory_id or query"):
+            await client.forget(context_id="ctx")
+        mock.assert_not_called()
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_explore_calls_tool():
     """explore() should assemble correct arguments."""
     client = _make_initialized_client()

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -66,15 +66,21 @@ def test_file_lock_creates_parent_dir(tmp_path: Path):
         assert target.parent.is_dir()
 
 
-def test_file_lock_noop_when_fcntl_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """On a platform without fcntl the CM degrades to a no-op (no lock file)."""
+def test_file_lock_noop_when_no_backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """With neither fcntl nor msvcrt the CM degrades to a no-op (no lock file).
+
+    Both backends are stubbed out (not just ``fcntl``) so this exercises the
+    no-op path on every platform — on Windows ``fcntl`` is already absent but
+    the real ``msvcrt`` backend would otherwise take over and create a lock
+    file, masking the no-op branch.
+    """
     import builtins
 
     real_import = builtins.__import__
 
     def fake_import(name: str, *args: object, **kwargs: object):
-        if name == "fcntl":
-            raise ImportError("simulated no fcntl (Windows)")
+        if name in ("fcntl", "msvcrt"):
+            raise ImportError(f"simulated missing {name}")
         return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(builtins, "__import__", fake_import)

--- a/tests/test_ingest_audio.py
+++ b/tests/test_ingest_audio.py
@@ -485,6 +485,11 @@ def test_extract_content_handles_bad_response() -> None:
     assert _audio._extract_content(object()) == ""  # no .choices → AttributeError path
 
 
+def test_extract_finish_reason_handles_bad_response() -> None:
+    # No .choices → AttributeError path → None (treated as not length-truncated).
+    assert _audio._extract_finish_reason(object()) is None
+
+
 def test_extract_usage_handles_non_int_tokens() -> None:
     class _BadUsage:
         prompt_tokens = "oops"  # int() raises ValueError → defaults to zeros

--- a/tests/test_ingest_audio.py
+++ b/tests/test_ingest_audio.py
@@ -39,8 +39,9 @@ class _Message:
 
 
 class _Choice:
-    def __init__(self, content: str) -> None:
+    def __init__(self, content: str, finish_reason: str | None = None) -> None:
         self.message = _Message(content)
+        self.finish_reason = finish_reason
 
 
 class _Usage:
@@ -50,8 +51,15 @@ class _Usage:
 
 
 class _Response:
-    def __init__(self, content: str, *, prompt: int = 1000, completion: int = 200) -> None:
-        self.choices = [_Choice(content)]
+    def __init__(
+        self,
+        content: str,
+        *,
+        prompt: int = 1000,
+        completion: int = 200,
+        finish_reason: str | None = None,
+    ) -> None:
+        self.choices = [_Choice(content, finish_reason)]
         self.usage = _Usage(prompt, completion)
 
 
@@ -318,6 +326,20 @@ async def test_truncated_json_raises() -> None:
     with patch.object(_audio, "_load_litellm", return_value=mod):
         with pytest.raises(KaguraIngestError, match="truncated|could not parse"):
             await transcribe_audio(b"x", mime="audio/mpeg", source_uri="a.mp3")
+
+
+@pytest.mark.asyncio
+async def test_truncation_by_finish_reason_fails_fast() -> None:
+    # Valid, parseable JSON but the model hit its output-token cap
+    # (finish_reason="length"): the transcript is silently incomplete. Detect it
+    # and fail fast — an identical retry would just truncate again and re-bill.
+    truncated = _Response(_GOOD_JSON, finish_reason="length")
+    mod = _mock_litellm([truncated, truncated])
+    with patch.object(_audio, "_load_litellm", return_value=mod):
+        with pytest.raises(KaguraIngestError, match="truncated"):
+            await transcribe_audio(b"x", mime="audio/mpeg", source_uri="a.mp3")
+    # No retry on deterministic truncation: exactly one provider call.
+    assert mod.acompletion.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_fetcher.py
+++ b/tests/test_ingest_fetcher.py
@@ -335,7 +335,10 @@ async def test_local_file_path(tmp_path: Any) -> None:
         assert result.body.startswith(b"%PDF-")
         assert result.source_type == "file"
         assert result.source_uri.startswith("file://")
-        assert str(pdf) in result.source_uri
+        # Compare against the canonical file URI rather than a raw-string
+        # substring: on Windows ``str(pdf)`` uses backslashes while ``as_uri()``
+        # uses forward slashes, so a substring check is not portable.
+        assert result.source_uri == pdf.resolve().as_uri()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ingest_safety.py
+++ b/tests/test_ingest_safety.py
@@ -2,11 +2,24 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
 
-from kagura_memory.ingest._safety import is_blocked_ip, is_blocked_system_path
+from kagura_memory.ingest._safety import (
+    _blocked_prefixes,
+    is_blocked_ip,
+    is_blocked_system_path,
+)
+
+_POSIX_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX system paths (/etc, /proc, ...) are not absolute on Windows",
+)
+_WINDOWS_ONLY = pytest.mark.skipif(
+    sys.platform != "win32", reason="Windows-specific system-path blocking"
+)
 
 
 @pytest.mark.parametrize(
@@ -40,11 +53,13 @@ def test_is_blocked_ip_treats_malformed_as_blocked() -> None:
     assert is_blocked_ip("999.999.999.999") is True
 
 
+@_POSIX_ONLY
 def test_is_blocked_system_path_blocks_etc() -> None:
     assert is_blocked_system_path(Path("/etc/passwd")) is True
     assert is_blocked_system_path(Path("/etc")) is True
 
 
+@_POSIX_ONLY
 def test_is_blocked_system_path_blocks_proc() -> None:
     assert is_blocked_system_path(Path("/proc/1/maps")) is True
 
@@ -65,8 +80,32 @@ def test_is_blocked_system_path_returns_false_for_relative_path() -> None:
     assert is_blocked_system_path(Path("relative/path.txt")) is False
 
 
+@_POSIX_ONLY
 def test_is_blocked_system_path_distinguishes_prefix_match_from_exact() -> None:
     """'/varlog' MUST NOT match the '/var/log' prefix — requires separator."""
     assert is_blocked_system_path(Path("/varlog")) is False
     assert is_blocked_system_path(Path("/var/log")) is True
     assert is_blocked_system_path(Path("/var/log/anything.log")) is True
+
+
+def test_blocked_prefixes_includes_ssh_dir() -> None:
+    """~/.ssh is always blocked, regardless of platform."""
+    assert (Path.home() / ".ssh") in _blocked_prefixes()
+
+
+@_WINDOWS_ONLY
+def test_is_blocked_system_path_blocks_windows_system_root() -> None:
+    """The Windows directory (and its children) are blocked, case-insensitively."""
+    import os
+
+    system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+    assert is_blocked_system_path(system_root) is True
+    assert is_blocked_system_path(system_root / "System32" / "config" / "SAM") is True
+    # Case-insensitive match (NTFS is case-insensitive).
+    assert is_blocked_system_path(Path(str(system_root).lower())) is True
+
+
+@_WINDOWS_ONLY
+def test_is_blocked_system_path_allows_windows_user_path() -> None:
+    """A normal user document path is not blocked on Windows."""
+    assert is_blocked_system_path(Path(r"C:\Users\someone\docs\report.pdf")) is False

--- a/tests/test_ingest_safety.py
+++ b/tests/test_ingest_safety.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import sys
+import types
 from pathlib import Path
 
 import pytest
 
+from kagura_memory.ingest import _safety
 from kagura_memory.ingest._safety import (
     _blocked_prefixes,
     is_blocked_ip,
@@ -91,6 +93,29 @@ def test_is_blocked_system_path_distinguishes_prefix_match_from_exact() -> None:
 def test_blocked_prefixes_includes_ssh_dir() -> None:
     """~/.ssh is always blocked, regardless of platform."""
     assert (Path.home() / ".ssh") in _blocked_prefixes()
+
+
+def test_blocked_prefixes_windows_branch(monkeypatch) -> None:
+    """Cover the Windows prefix branch on any host (CI runs Linux).
+
+    Inject a fake ``os`` into the module rather than patching the real
+    ``os.name`` — the latter corrupts pytest's own platform checks.
+    """
+    fake_os = types.SimpleNamespace(
+        name="nt",
+        environ={"SystemRoot": r"C:\Windows", "ProgramData": r"C:\ProgramData"},
+    )
+    monkeypatch.setattr(_safety, "os", fake_os)
+    joined = " ".join(str(p) for p in _blocked_prefixes())
+    assert "Windows" in joined
+    assert "ProgramData" in joined
+
+
+def test_blocked_prefixes_posix_branch(monkeypatch) -> None:
+    """Cover the POSIX prefix branch on any host (dev runs Windows)."""
+    monkeypatch.setattr(_safety, "os", types.SimpleNamespace(name="posix", environ={}))
+    joined = " ".join(str(p) for p in _blocked_prefixes())
+    assert "etc" in joined and "proc" in joined  # POSIX system dirs present
 
 
 @_WINDOWS_ONLY

--- a/tests/test_setup_claude.py
+++ b/tests/test_setup_claude.py
@@ -99,11 +99,12 @@ class TestSelectOrCreateContext:
             )
             assert result == "ctx-abc"
 
-    @patch("kagura_memory.setup_claude.asyncio")
     @patch("kagura_memory.setup_claude._create_context")
-    def test_interactive_create_new(self, mock_create: AsyncMock, mock_asyncio: MagicMock) -> None:
+    def test_interactive_create_new(self, mock_create: AsyncMock) -> None:
         """Interactive: no contexts, user creates a new one."""
-        mock_asyncio.run.return_value = {"context_id": "ctx-new", "name": "test"}
+        # Let the real asyncio.run await the AsyncMock coroutine (mocking
+        # asyncio wholesale would leave the coroutine un-awaited).
+        mock_create.return_value = {"context_id": "ctx-new", "name": "test"}
         with patch("kagura_memory.setup_claude.click") as mock_click:
             mock_click.prompt.side_effect = ["my-project", "A summary"]
             mock_click.echo = MagicMock()
@@ -118,13 +119,12 @@ class TestSelectOrCreateContext:
             )
             assert result == "ctx-new"
 
-    @patch("kagura_memory.setup_claude.asyncio")
     @patch("kagura_memory.setup_claude._create_context")
-    def test_interactive_create_new_from_list(
-        self, mock_create: AsyncMock, mock_asyncio: MagicMock
-    ) -> None:
+    def test_interactive_create_new_from_list(self, mock_create: AsyncMock) -> None:
         """Interactive: contexts exist, user chooses 'create new'."""
-        mock_asyncio.run.return_value = {"context_id": "ctx-brand-new", "name": "new-proj"}
+        # Let the real asyncio.run await the AsyncMock coroutine (mocking
+        # asyncio wholesale would leave the coroutine un-awaited).
+        mock_create.return_value = {"context_id": "ctx-brand-new", "name": "new-proj"}
         with patch("kagura_memory.setup_claude.click") as mock_click:
             mock_click.prompt.side_effect = [2, "new-proj", ""]
             mock_click.echo = MagicMock()


### PR DESCRIPTION
## Summary

Full-codebase review pass (the initial `/goal`). 10 atomic commits: a real cross-platform bug, several robustness fixes, an error-handling refactor, and documentation accuracy fixes. **Most importantly, this fixes the 16 Windows-only test failures** that the other open PRs (#205, #206) note as pre-existing — so this should land first to green the baseline on Windows.

## Bug fixes
- **fix(ingest): Windows drive-letter paths** — `urlsplit("C:\...")` parsed the drive as scheme `"c"`, so `Fetcher.fetch()` rejected every absolute Windows path → **all local-file ingestion was broken on Windows**. Route single-letter no-authority schemes to the local-file path. Also makes 3 platform-fragile tests portable (URI compare, filelock no-op stubs both backends, 0600/0700 gated to POSIX).
- **fix(agent)**: Ollama streaming (`stream:true` was parsed with `resp.json()` → crash), cache-miss returning a live cache reference, deep-recall seeding from the wrong (cumulative) result, `_extract_usage` None coercion, broad-except retry logging.
- **fix(ingest)**: audio transcript truncation now fails fast on `finish_reason=="length"` (was silently accepted + double-billed); browser context leak on `new_page()` failure.
- **fix(client)**: `forget()` now requires `memory_id` or `query` (was an ambiguous no-op).

## Refactor / quality
- **refactor(ingest): cross-platform system-path denylist** — `is_blocked_system_path` now uses `PurePath.is_relative_to` (segment-aware, case-insensitive on Windows) + a platform-aware prefix set (%SystemRoot%/%ProgramData% on Windows). Closes the Windows gap the fetcher fix exposed; also fixes a latent `~/.ssh` prefix bug.
- **refactor(client): unify HTTP error mapping, add 429** — one `raise_for_kagura_status` helper; `KaguraRateLimitError` (claimed in the docstring) is now actually raised; activates `extract_detail` so 422s show the failing field.
- **test(setup)**: stop leaking an un-awaited coroutine (suite is warning-free).

## Docs
- Corrected ingest capability claims (formats/audio supported; image OCR not yet wired), SDK↔server compat table → 0.31.x, `kagura auth list`, credentials-lock + `delete_edge` default docstrings (the latter verified against the memory-cloud server).

## Verification
`ruff`, `ruff format --check`, `pyright src/` green; `pytest` green on this branch (1122 passed) — including the 16 that fail on `main` under Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
