### PR TITLE
feat(plugin): package kagura CLI as in-repo Claude Code skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "kagura-memory",
+  "description": "Thin Claude Code skills over the Kagura Memory CLI (doctor / auth / setup / ingest / resource / files).",
+  "owner": {
+    "name": "Kagura AI, Inc.",
+    "url": "https://github.com/kagura-ai"
+  },
+  "plugins": [
+    {
+      "name": "kagura-memory",
+      "source": "./",
+      "version": "0.31.0",
+      "category": "ai"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "kagura-memory",
+  "version": "0.31.0",
+  "description": "Thin Claude Code skills over the Kagura Memory CLI: doctor, auth, setup, document ingestion, resource tokens, and R2 file uploads.",
+  "author": {
+    "name": "Kagura AI, Inc.",
+    "url": "https://github.com/kagura-ai"
+  },
+  "homepage": "https://github.com/kagura-ai/kagura-memory-python-sdk",
+  "repository": "https://github.com/kagura-ai/kagura-memory-python-sdk",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "mcp",
+    "kagura",
+    "claude-code",
+    "ingestion",
+    "rag",
+    "ai-agent",
+    "developer-tools"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -475,6 +475,16 @@ Or use the CLI directly:
 kagura process -m "今日の学び：FastAPIのDIはDepends()を使う"
 ```
 
+### Claude Code plugin (CLI-as-skills)
+
+This repo also ships a thin **Claude Code plugin** under
+[`.claude-plugin/`](.claude-plugin/plugin.json) + [`skills/`](skills/) that wraps
+the high-value CLI commands as skills (`doctor`, `auth`, `setup`, `ingest`,
+`resource`, `files`) — each shells out to the installed `kagura` CLI and returns
+clear guidance when it is not installed/authenticated. Registration in the
+`kagura-plugins` marketplace (so it installs via
+`/plugin install kagura-memory@kagura-plugins`) is tracked as a follow-up.
+
 ## API Coverage
 
 | Operation | SDK Client | Protocol | Auth |

--- a/skills/auth/SKILL.md
+++ b/skills/auth/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: auth
+description: Manage Kagura Memory authentication — log in (OAuth device flow), check status, refresh tokens, and list or switch profiles. Use when the user wants to sign in to Kagura, see which account/workspace is active, or manage multiple profiles.
+---
+
+# kagura auth — authentication
+
+Drive the Kagura Memory CLI's auth commands. Thin wrapper around the installed
+`kagura` CLI — no secrets are handled here.
+
+## Preflight
+
+`kagura --version`; if missing, tell the user to `uv tool install kagura-memory`
+(or `pip install kagura-memory`) and stop.
+
+## Run (choose by intent)
+
+```bash
+kagura auth status                 # who am I — profile, workspace, scope, expiry
+kagura auth login                  # OAuth device flow (add --no-browser on SSH/headless)
+kagura auth list                   # all stored profiles; default marked with *
+kagura auth use <name>             # set the default profile deliberately
+kagura auth refresh                # rotate the access token
+kagura auth logout                 # revoke + delete a profile
+```
+
+## Consume the result
+
+- Relay the CLI output verbatim where it matters (status table, login URL/code).
+- On "not authenticated", run `kagura auth login`.
+- **Multi-profile safety:** if several profiles exist, surface which profile and
+  workspace are active so the user does not operate on the wrong account; use
+  `kagura auth use <name>` or `--profile <name>` to pick one.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: doctor
+description: Diagnose the local Kagura Memory CLI setup (install, auth, MCP wiring). Use before other kagura skills, or whenever a kagura command reports a blocked or misconfigured environment.
+---
+
+# kagura doctor — environment diagnosis
+
+Run the Kagura Memory CLI's self-check and report what must be fixed. This skill
+is a thin wrapper — it shells out to the already-installed `kagura` CLI and never
+reimplements the checks.
+
+## Preflight
+
+Confirm the CLI is installed: `kagura --version`. If it reports "command not
+found", tell the user to install it — `uv tool install kagura-memory` (or
+`pip install kagura-memory`) — and stop. This skill is instructions only; it
+cannot install the package itself.
+
+## Run
+
+```bash
+kagura doctor
+```
+
+## Consume the result
+
+- **Exit 0** → the environment is healthy; relay the summary.
+- **Non-zero** → relay exactly what `doctor` reports is wrong and its suggested
+  fix. The common ones are "not authenticated" → run the `auth` skill
+  (`kagura auth login`) and "Claude Code not wired" → run the `setup` skill
+  (`kagura setup claude`). Do not guess beyond what `doctor` prints.

--- a/skills/files/SKILL.md
+++ b/skills/files/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: files
+description: Upload, list, delete, and get download URLs for files in Kagura Memory's R2 storage (sha256 integrity-bound). Use when the user wants to attach or manage raw files in their workspace.
+---
+
+# kagura files — R2 file storage
+
+Drive the `kagura files` command group (presigned-PUT uploads with sha256
+binding). Thin wrapper around the installed `kagura` CLI.
+
+## Preflight
+
+- `kagura --version`; if missing → `uv tool install kagura-memory` (or
+  `pip install kagura-memory`), then stop.
+- Requires authentication. Run `kagura auth status`; if not authed, run the
+  `auth` skill first.
+
+## Run (choose by intent)
+
+```bash
+kagura files upload ./data.bin          # upload (sha256-bound presigned PUT)
+kagura files list                       # list stored files
+kagura files download-url <file_id>     # short-lived GET URL
+kagura files delete <file_id>           # delete a file
+```
+
+## Consume the result
+
+- Relay the returned file id and download URL. **Download URLs are short-lived**
+  — do not cache them; re-run `download-url` when one expires.

--- a/skills/ingest/SKILL.md
+++ b/skills/ingest/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ingest
+description: Ingest a document or URL into Kagura Memory — extract text, chunk it, and store an overview plus per-section memories. Use when the user wants to add a PDF, Office/HTML/EPUB file, audio/video, or a web page to their memory graph.
+---
+
+# kagura ingest — document ingestion
+
+Drive `kagura ingest` to turn a file or URL into a structured set of memories.
+Thin wrapper around the installed `kagura` CLI.
+
+## Preflight
+
+- `kagura --version`; if missing → `uv tool install kagura-memory` (or
+  `pip install kagura-memory`), then stop.
+- Heavy parsers are opt-in extras (e.g. `pip install 'kagura-memory[ingest-pdf]'`
+  or `[ingest-all]`); a missing parser surfaces a clear "install ..." error from
+  the CLI — relay that hint rather than guessing.
+- Requires authentication and a target context. Run `kagura auth status`; if not
+  authed, run the `auth` skill first.
+
+## Run
+
+```bash
+kagura ingest ./report.pdf                  # local file
+kagura ingest https://example.com/page      # URL
+kagura ingest ./report.pdf --dry-run        # preview cost/sections; no LLM or backend write
+kagura ingest ./report.pdf --json           # machine-readable result for scripting
+```
+
+## Consume the result
+
+- Relay the overview + per-section counts and any per-section error records.
+- On a missing-extra error, surface the exact `pip install` command the CLI
+  prints. Use `--dry-run` first when the user wants a cost/size estimate.

--- a/skills/resource/SKILL.md
+++ b/skills/resource/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: resource
+description: Manage Kagura resource tokens and push external data (Slack/CI/CRM events) into a context. Use for resource token create/list/update/revoke, resource setup/import, and impact/schema stats.
+---
+
+# kagura resource — resource tokens & external ingestion
+
+Drive the `kagura resource` command group. Thin wrapper around the installed
+`kagura` CLI.
+
+## Preflight
+
+- `kagura --version`; if missing → `uv tool install kagura-memory` (or
+  `pip install kagura-memory`), then stop.
+- Requires authentication. Run `kagura auth status`; if not authed, run the
+  `auth` skill first.
+
+## Run (choose by intent)
+
+```bash
+kagura resource setup ...                       # provision a resource binding
+kagura resource import <file>                   # bulk-import events
+kagura resource stats                           # resource impact / usage
+kagura resource schema                          # inferred event schema
+kagura resource tokens list|create|update|revoke
+```
+
+## Consume the result
+
+- Relay the CLI output. **Resource tokens are secrets:** when one is created it
+  is shown once and not stored — surface it to the user and remind them to save
+  it now. Prefer `revoke` over leaving stale tokens active.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: setup
+description: Wire Claude Code to Kagura Memory Cloud by writing the MCP config. Use during onboarding to connect this machine's Claude Code to a Kagura workspace.
+---
+
+# kagura setup claude — onboarding
+
+Connect Claude Code to Kagura Memory via the refresh-aware `kagura-mcp` stdio
+proxy. Thin wrapper around the installed `kagura` CLI.
+
+## Preflight
+
+- `kagura --version`; if missing → `uv tool install kagura-memory` (or
+  `pip install kagura-memory`), then stop.
+- Requires authentication. Run `kagura auth status`; if not logged in, run the
+  `auth` skill first (`kagura auth login`), or pass `--profile <name>` for an
+  existing profile.
+
+## Run
+
+```bash
+kagura setup claude                  # wire the refresh-aware kagura-mcp proxy
+kagura setup claude --profile <name> # bind to a named OAuth profile
+```
+
+## Consume the result
+
+- Relay which `.mcp.json` was written. A "kagura-mcp not on PATH" message is a
+  warning, not a failure.
+- Suggest `kagura doctor` (the `doctor` skill) to confirm the wiring end-to-end.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,79 @@
+"""Validate the in-repo Claude Code plugin scaffold (#191).
+
+Asserts the plugin manifest + marketplace entry are valid JSON with the required
+keys, their versions are internally consistent, and each shell-out skill exists
+with frontmatter whose ``name`` matches its directory. Frontmatter is parsed
+without a YAML dependency (kagura-memory's dev deps don't include PyYAML).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+SKILLS = ["doctor", "auth", "setup", "ingest", "resource", "files"]
+_SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_plugin_json_valid_and_required_keys() -> None:
+    assert PLUGIN_JSON.is_file(), f"missing {PLUGIN_JSON}"
+    data = _load(PLUGIN_JSON)
+    for key in ("name", "version", "description", "author", "license"):
+        assert key in data, f"plugin.json missing '{key}'"
+    assert data["name"] == "kagura-memory"
+    assert data["license"] == "MIT"
+    assert _SEMVER.match(data["version"]), data["version"]
+
+
+def test_marketplace_json_valid_and_entry() -> None:
+    assert MARKETPLACE_JSON.is_file(), f"missing {MARKETPLACE_JSON}"
+    data = _load(MARKETPLACE_JSON)
+    for key in ("name", "description", "owner", "plugins"):
+        assert key in data, f"marketplace.json missing '{key}'"
+    assert data["name"] == "kagura-memory"
+    assert isinstance(data["plugins"], list) and len(data["plugins"]) == 1
+    entry = data["plugins"][0]
+    assert entry["name"] == "kagura-memory"
+    assert entry["source"] == "./"
+
+
+def test_plugin_and_marketplace_versions_synced() -> None:
+    # Internal consistency between the two manifests. Keeping these in sync with
+    # kagura_memory.__version__ at release time is a documented follow-up (the
+    # version lives only in __init__.py per .claude/rules/versioning.md, so
+    # coupling here would require wiring /release — see the PR).
+    assert _load(PLUGIN_JSON)["version"] == _load(MARKETPLACE_JSON)["plugins"][0]["version"]
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Parse simple ``key: value`` SKILL.md frontmatter without PyYAML."""
+    assert text.startswith("---\n"), "SKILL.md must open with YAML frontmatter"
+    _, fm, _body = text.split("---\n", 2)
+    out: dict[str, str] = {}
+    for line in fm.splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            out[key.strip()] = value.strip()
+    return out
+
+
+@pytest.mark.parametrize("name", SKILLS)
+def test_skill_md_exists_with_matching_frontmatter(name: str) -> None:
+    path = REPO_ROOT / "skills" / name / "SKILL.md"
+    assert path.is_file(), f"missing {path}"
+    text = path.read_text(encoding="utf-8")
+    front = _frontmatter(text)
+    assert front.get("name") == name, f"{name}/SKILL.md frontmatter name must equal its dir"
+    assert front.get("description"), f"{name}/SKILL.md needs a description"
+    body = text.split("---\n", 2)[2]
+    assert body.strip(), f"{name}/SKILL.md needs a body"


### PR DESCRIPTION
## Summary

Closes #191 (in-repo half).

Adds a thin **Claude Code plugin** that wraps the high-value `kagura` CLI commands as skills, mirroring the `kagura-planner` precedent (reference-don't-vendor — the plugin lives beside the CLI it wraps, so versions stay together):

- **`.claude-plugin/plugin.json`** + **`marketplace.json`** — plugin manifest + single-plugin marketplace entry.
- **`skills/{doctor,auth,setup,ingest,resource,files}/SKILL.md`** — each is a thin shell-out to `kagura <cmd>` with: a preflight install hint when the CLI is missing (`uv tool install kagura-memory`), an auth hint when not logged in, and "consume the result" guidance. No logic is reimplemented.
- **`tests/test_plugin.py`** — asserts both manifests are valid JSON with required keys, their versions are internally consistent, and each `SKILL.md` exists with frontmatter whose `name` matches its directory. Parses frontmatter without a PyYAML dependency (not in dev deps).
- **README** — short "Claude Code plugin" subsection.

## Scope / follow-ups

- **Out of scope (cross-repo):** registering this plugin in the `kagura-plugins` marketplace (`marketplace.json` in that separate repo) so it installs via `/plugin install kagura-memory@kagura-plugins`. That repo isn't part of this one; tracked as a follow-up.
- **Version sync:** the test enforces *internal* manifest consistency only. Coupling the manifest version to `kagura_memory.__version__` would break the current single-source-of-truth release flow (`.claude/rules/versioning.md` keeps the version only in `__init__.py`); wiring `/release` to bump the manifests is a separate follow-up.
- Packaging is unaffected: the wheel still targets `src/kagura_memory`; `.claude-plugin/` and `skills/` are repo-level only.

## Tests

`uv run pytest tests/test_plugin.py` (9 passed); full suite **1161 passed / 38 skipped**; `ruff`, `ruff format --check`, `pyright src/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
