### PR TITLE
fix(plugin): rename Claude Code plugin to kagura-cli (avoid name collision)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "kagura-memory",
+  "name": "kagura-cli",
   "description": "Thin Claude Code skills over the Kagura Memory CLI (doctor / auth / setup / ingest / resource / files).",
   "owner": {
     "name": "Kagura AI, Inc.",
@@ -8,7 +8,7 @@
   },
   "plugins": [
     {
-      "name": "kagura-memory",
+      "name": "kagura-cli",
       "source": "./",
       "version": "0.31.0",
       "category": "ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "kagura-memory",
+  "name": "kagura-cli",
   "version": "0.31.0",
-  "description": "Thin Claude Code skills over the Kagura Memory CLI: doctor, auth, setup, document ingestion, resource tokens, and R2 file uploads.",
+  "description": "Thin Claude Code skills over the Kagura Memory CLI (kagura): doctor, auth, setup, document ingestion, resource tokens, and R2 file uploads.",
   "author": {
     "name": "Kagura AI, Inc.",
     "url": "https://github.com/kagura-ai"

--- a/README.md
+++ b/README.md
@@ -481,9 +481,11 @@ This repo also ships a thin **Claude Code plugin** under
 [`.claude-plugin/`](.claude-plugin/plugin.json) + [`skills/`](skills/) that wraps
 the high-value CLI commands as skills (`doctor`, `auth`, `setup`, `ingest`,
 `resource`, `files`) — each shells out to the installed `kagura` CLI and returns
-clear guidance when it is not installed/authenticated. Registration in the
-`kagura-plugins` marketplace (so it installs via
-`/plugin install kagura-memory@kagura-plugins`) is tracked as a follow-up.
+clear guidance when it is not installed/authenticated. The plugin is named
+**`kagura-cli`** (distinct from the `kagura-memory` SDK package and the existing
+`kagura-memory` MCP plugin). Registration in the `kagura-plugins` marketplace (so
+it installs via `/plugin install kagura-cli@kagura-plugins`) is tracked as a
+follow-up.
 
 ## API Coverage
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -30,7 +30,7 @@ def test_plugin_json_valid_and_required_keys() -> None:
     data = _load(PLUGIN_JSON)
     for key in ("name", "version", "description", "author", "license"):
         assert key in data, f"plugin.json missing '{key}'"
-    assert data["name"] == "kagura-memory"
+    assert data["name"] == "kagura-cli"
     assert data["license"] == "MIT"
     assert _SEMVER.match(data["version"]), data["version"]
 
@@ -40,10 +40,10 @@ def test_marketplace_json_valid_and_entry() -> None:
     data = _load(MARKETPLACE_JSON)
     for key in ("name", "description", "owner", "plugins"):
         assert key in data, f"marketplace.json missing '{key}'"
-    assert data["name"] == "kagura-memory"
+    assert data["name"] == "kagura-cli"
     assert isinstance(data["plugins"], list) and len(data["plugins"]) == 1
     entry = data["plugins"][0]
-    assert entry["name"] == "kagura-memory"
+    assert entry["name"] == "kagura-cli"
     assert entry["source"] == "./"
 
 


### PR DESCRIPTION
## Summary

Follow-up to #191 / PR #209. The scaffold named the plugin **`kagura-memory`**, which collides:

1. A **`kagura-memory` plugin already exists** in the marketplace (skills `kagura-memory:recall` / `remember` / `guide` / `session-start` / …). A second plugin of the same name clashes on the plugin name *and* the `kagura-memory:*` skill namespace.
2. It duplicates the **`kagura-memory` SDK / PyPI package** name — confusing (`pip install kagura-memory` vs the plugin).

Issue #191's acceptance criteria already specified `/plugin install **kagura-cli**@kagura-plugins`, so this restores the intended name.

## Change
Rename the plugin to **`kagura-cli`** in `.claude-plugin/plugin.json` + `marketplace.json` (and the `tests/test_plugin.py` assertions + the README install hint). Skills now namespace as `kagura-cli:doctor`, `kagura-cli:auth`, … — distinct from the existing `kagura-memory` MCP plugin. No skill files or behavior change.

`uv run pytest tests/test_plugin.py` (9 passed); `ruff` / `pyright` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
