### PR TITLE
chore(plugin): sync manifest version to __version__, enforce in CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "kagura-cli",
       "source": "./",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "category": "ai"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-cli",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Thin Claude Code skills over the Kagura Memory CLI (kagura): doctor, auth, setup, document ingestion, resource tokens, and R2 file uploads.",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -41,6 +41,15 @@ Edit `__version__` in `src/kagura_memory/__init__.py` to the new version.
 
 Check if `MIN_SERVER_VERSION` in `src/kagura_memory/client.py` needs updating for this release (e.g., if new methods require a newer server version). Update if necessary.
 
+### 4c. Sync the plugin manifest versions
+
+The in-repo Claude Code plugin (`kagura-cli`) ships from this repo and is released together with the package, so its version must match `__version__`. Set both to the new version:
+
+- `.claude-plugin/plugin.json` → `"version"`
+- `.claude-plugin/marketplace.json` → `plugins[0].version`
+
+`tests/test_plugin.py::test_plugin_and_marketplace_versions_synced` enforces this — if you skip it, `/quality` (and CI) will fail.
+
 ### 5. Update lock file
 
 ```bash
@@ -56,7 +65,7 @@ uv build
 ### 7. Commit and tag
 
 ```bash
-git add src/kagura_memory/__init__.py uv.lock
+git add src/kagura_memory/__init__.py uv.lock .claude-plugin/plugin.json .claude-plugin/marketplace.json
 git commit -m "chore(release): vX.Y.Z"
 git tag vX.Y.Z
 ```

--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -37,10 +37,11 @@ While `MAJOR` is `0`, breaking changes bump MINOR instead.
 
 Use `/release patch|minor|major` to:
 1. Bump `__version__` in `__init__.py`
-2. `uv lock`
-3. Commit: `chore(release): vX.Y.Z`
-4. Tag: `vX.Y.Z`
-5. Push commit + tag → CI publishes to PyPI
+2. Sync the plugin manifests (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) to the same version — they ship from this repo and `tests/test_plugin.py` fails CI if they drift from `__version__`
+3. `uv lock`
+4. Commit: `chore(release): vX.Y.Z`
+5. Tag: `vX.Y.Z`
+6. Push commit + tag → CI publishes to PyPI
 
 ### Test release
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -47,12 +47,26 @@ def test_marketplace_json_valid_and_entry() -> None:
     assert entry["source"] == "./"
 
 
+def _pkg_version() -> str:
+    """Read ``kagura_memory.__version__`` by parsing the source (no import → no deps)."""
+    init = (REPO_ROOT / "src" / "kagura_memory" / "__init__.py").read_text(encoding="utf-8")
+    match = re.search(r'^__version__ = "([^"]+)"', init, re.MULTILINE)
+    assert match, "could not find __version__ in __init__.py"
+    return match.group(1)
+
+
 def test_plugin_and_marketplace_versions_synced() -> None:
-    # Internal consistency between the two manifests. Keeping these in sync with
-    # kagura_memory.__version__ at release time is a documented follow-up (the
-    # version lives only in __init__.py per .claude/rules/versioning.md, so
-    # coupling here would require wiring /release — see the PR).
-    assert _load(PLUGIN_JSON)["version"] == _load(MARKETPLACE_JSON)["plugins"][0]["version"]
+    # The plugin ships from this repo and is released alongside the package, so its
+    # manifests must track kagura_memory.__version__ (the single source of truth —
+    # .claude/rules/versioning.md). /release bumps all three together; asserting it
+    # here turns any future drift into a CI failure instead of a silent skew.
+    pkg = _pkg_version()
+    plugin_ver = _load(PLUGIN_JSON)["version"]
+    market_ver = _load(MARKETPLACE_JSON)["plugins"][0]["version"]
+    assert plugin_ver == market_ver, f"plugin.json {plugin_ver} != marketplace {market_ver}"
+    assert plugin_ver == pkg, (
+        f"plugin manifests {plugin_ver} != __version__ {pkg} (run /release or sync)"
+    )
 
 
 def _frontmatter(text: str) -> dict[str, str]:


### PR DESCRIPTION
## What

The `kagura-cli` plugin manifests were stuck at `0.31.0` while the package advanced to `0.32.0`. `test_plugin.py` only checked the two manifests matched **each other**, not `__version__`, so they drifted silently every release.

## Changes

- Bump `.claude-plugin/plugin.json` + `marketplace.json` to `0.32.0`.
- `test_plugin.py`: assert both manifests equal `kagura_memory.__version__` (parsed from source, no import → no deps), so any future drift **fails CI** instead of skewing silently.
- Wire `/release` (new step 4c, git-add) + `versioning.md` to bump the manifests alongside `__version__`.

## Verification

- `uv run pytest` → 1168 passed, 38 skipped; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)