### PR TITLE
docs(readme): fill logo flower center white to match brand mark

### DIFF
--- a/assets/kagura-logo-dark.svg
+++ b/assets/kagura-logo-dark.svg
@@ -14,6 +14,7 @@
     <circle cx="66" cy="147" r="38" fill="url(#kg-gofun)"/>
     <circle cx="45" cy="82" r="38" fill="url(#kg-kodai)"/>
     <g stroke="#fffffb" stroke-width="9" stroke-linecap="round" fill="#fffffb">
+      <polygon points="100,82 117,94.4 110.6,114.6 89.4,114.6 83,94.4" stroke="none"/>
       <line x1="100" y1="58" x2="100" y2="82"/>
       <line x1="139.8" y1="87" x2="117" y2="94.4"/>
       <line x1="124.6" y1="134" x2="110.6" y2="114.6"/>

--- a/assets/kagura-logo.svg
+++ b/assets/kagura-logo.svg
@@ -14,6 +14,7 @@
     <circle cx="66" cy="147" r="38" fill="url(#kg-gofun)"/>
     <circle cx="45" cy="82" r="38" fill="url(#kg-kodai)"/>
     <g stroke="#fffffb" stroke-width="9" stroke-linecap="round" fill="#fffffb">
+      <polygon points="100,82 117,94.4 110.6,114.6 89.4,114.6 83,94.4" stroke="none"/>
       <line x1="100" y1="58" x2="100" y2="82"/>
       <line x1="139.8" y1="87" x2="117" y2="94.4"/>
       <line x1="124.6" y1="134" x2="110.6" y2="114.6"/>


### PR DESCRIPTION
## Summary

The README header logo rendered the flower's center as overlapping colored petals with only thin white spokes — the official brand mark (`KaguraAI_logo*.png`) has a **solid white-filled core**. This adds a white center polygon to both SVG variants (light + dark) so the stems, dots, and core form the white star, matching the official logo.

## Changes

- `assets/kagura-logo.svg` — add white center polygon
- `assets/kagura-logo-dark.svg` — add white center polygon

Petal colors and positions already matched the official mark (green top, purple upper-left, orange upper-right, cream lower-left, amber lower-right); the only missing element was the white center fill.

## Verification

Rendered both variants locally (light on white, dark on `#0d1117`) — the center is now white-filled and matches the official PNG. Pure asset change; no code, tests, or README text affected.

> Note: the README references these SVGs from `main` via raw.githubusercontent, so the logo updates on the README only after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)