### PR TITLE
docs(readme): match official brand mark (transparent flower center)

### DIFF
--- a/assets/kagura-logo-dark.svg
+++ b/assets/kagura-logo-dark.svg
@@ -6,26 +6,28 @@
     <linearGradient id="kg-ukon" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#fdc659"/><stop offset="1" stop-color="#faa916"/></linearGradient>
     <linearGradient id="kg-gofun" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f2f1cf"/><stop offset="1" stop-color="#dcdf9a"/></linearGradient>
     <linearGradient id="kg-kodai" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#9c79ae"/><stop offset="1" stop-color="#70477c"/></linearGradient>
+    <mask id="kg-petals" maskUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+      <rect x="-20" y="-20" width="240" height="240" fill="#fff"/>
+      <g fill="#000" stroke="#000" stroke-width="8" stroke-linecap="round">
+        <line x1="100" y1="71" x2="100" y2="52.3"/>
+        <line x1="127.58" y1="91.04" x2="145.36" y2="85.26"/>
+        <line x1="117.05" y1="123.46" x2="128.04" y2="138.59"/>
+        <line x1="82.95" y1="123.46" x2="71.96" y2="138.59"/>
+        <line x1="72.42" y1="91.04" x2="54.64" y2="85.26"/>
+        <circle cx="100" cy="52.3" r="7"/>
+        <circle cx="145.36" cy="85.26" r="7"/>
+        <circle cx="128.04" cy="138.59" r="7"/>
+        <circle cx="71.96" cy="138.59" r="7"/>
+        <circle cx="54.64" cy="85.26" r="7"/>
+      </g>
+    </mask>
   </defs>
-  <g transform="translate(12 10) scale(0.5)">
-    <circle cx="100" cy="42" r="38" fill="url(#kg-tokiwa)"/>
-    <circle cx="155" cy="82" r="38" fill="url(#kg-shu)"/>
-    <circle cx="134" cy="147" r="38" fill="url(#kg-ukon)"/>
-    <circle cx="66" cy="147" r="38" fill="url(#kg-gofun)"/>
-    <circle cx="45" cy="82" r="38" fill="url(#kg-kodai)"/>
-    <g stroke="#fffffb" stroke-width="9" stroke-linecap="round" fill="#fffffb">
-      <polygon points="100,82 117,94.4 110.6,114.6 89.4,114.6 83,94.4" stroke="none"/>
-      <line x1="100" y1="58" x2="100" y2="82"/>
-      <line x1="139.8" y1="87" x2="117" y2="94.4"/>
-      <line x1="124.6" y1="134" x2="110.6" y2="114.6"/>
-      <line x1="75.4" y1="134" x2="89.4" y2="114.6"/>
-      <line x1="60.2" y1="87" x2="83" y2="94.4"/>
-      <circle cx="100" cy="58" r="8" stroke="none"/>
-      <circle cx="139.8" cy="87" r="8" stroke="none"/>
-      <circle cx="124.6" cy="134" r="8" stroke="none"/>
-      <circle cx="75.4" cy="134" r="8" stroke="none"/>
-      <circle cx="60.2" cy="87" r="8" stroke="none"/>
-    </g>
+  <g transform="translate(12 10) scale(0.5)" mask="url(#kg-petals)">
+    <circle cx="100" cy="35" r="38" fill="url(#kg-tokiwa)"/>
+    <circle cx="161.82" cy="79.91" r="38" fill="url(#kg-shu)"/>
+    <circle cx="138.21" cy="152.59" r="38" fill="url(#kg-ukon)"/>
+    <circle cx="61.79" cy="152.59" r="38" fill="url(#kg-gofun)"/>
+    <circle cx="38.18" cy="79.91" r="38" fill="url(#kg-kodai)"/>
   </g>
   <text x="132" y="78" font-family="'Noto Sans JP', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.5"><tspan fill="#f0f6fc">Kagura</tspan><tspan fill="#faa916"> AI</tspan></text>
 </svg>

--- a/assets/kagura-logo.svg
+++ b/assets/kagura-logo.svg
@@ -6,26 +6,28 @@
     <linearGradient id="kg-ukon" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#fdc659"/><stop offset="1" stop-color="#faa916"/></linearGradient>
     <linearGradient id="kg-gofun" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f2f1cf"/><stop offset="1" stop-color="#dcdf9a"/></linearGradient>
     <linearGradient id="kg-kodai" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#9c79ae"/><stop offset="1" stop-color="#70477c"/></linearGradient>
+    <mask id="kg-petals" maskUnits="userSpaceOnUse" x="-20" y="-20" width="240" height="240">
+      <rect x="-20" y="-20" width="240" height="240" fill="#fff"/>
+      <g fill="#000" stroke="#000" stroke-width="8" stroke-linecap="round">
+        <line x1="100" y1="71" x2="100" y2="52.3"/>
+        <line x1="127.58" y1="91.04" x2="145.36" y2="85.26"/>
+        <line x1="117.05" y1="123.46" x2="128.04" y2="138.59"/>
+        <line x1="82.95" y1="123.46" x2="71.96" y2="138.59"/>
+        <line x1="72.42" y1="91.04" x2="54.64" y2="85.26"/>
+        <circle cx="100" cy="52.3" r="7"/>
+        <circle cx="145.36" cy="85.26" r="7"/>
+        <circle cx="128.04" cy="138.59" r="7"/>
+        <circle cx="71.96" cy="138.59" r="7"/>
+        <circle cx="54.64" cy="85.26" r="7"/>
+      </g>
+    </mask>
   </defs>
-  <g transform="translate(12 10) scale(0.5)">
-    <circle cx="100" cy="42" r="38" fill="url(#kg-tokiwa)"/>
-    <circle cx="155" cy="82" r="38" fill="url(#kg-shu)"/>
-    <circle cx="134" cy="147" r="38" fill="url(#kg-ukon)"/>
-    <circle cx="66" cy="147" r="38" fill="url(#kg-gofun)"/>
-    <circle cx="45" cy="82" r="38" fill="url(#kg-kodai)"/>
-    <g stroke="#fffffb" stroke-width="9" stroke-linecap="round" fill="#fffffb">
-      <polygon points="100,82 117,94.4 110.6,114.6 89.4,114.6 83,94.4" stroke="none"/>
-      <line x1="100" y1="58" x2="100" y2="82"/>
-      <line x1="139.8" y1="87" x2="117" y2="94.4"/>
-      <line x1="124.6" y1="134" x2="110.6" y2="114.6"/>
-      <line x1="75.4" y1="134" x2="89.4" y2="114.6"/>
-      <line x1="60.2" y1="87" x2="83" y2="94.4"/>
-      <circle cx="100" cy="58" r="8" stroke="none"/>
-      <circle cx="139.8" cy="87" r="8" stroke="none"/>
-      <circle cx="124.6" cy="134" r="8" stroke="none"/>
-      <circle cx="75.4" cy="134" r="8" stroke="none"/>
-      <circle cx="60.2" cy="87" r="8" stroke="none"/>
-    </g>
+  <g transform="translate(12 10) scale(0.5)" mask="url(#kg-petals)">
+    <circle cx="100" cy="35" r="38" fill="url(#kg-tokiwa)"/>
+    <circle cx="161.82" cy="79.91" r="38" fill="url(#kg-shu)"/>
+    <circle cx="138.21" cy="152.59" r="38" fill="url(#kg-ukon)"/>
+    <circle cx="61.79" cy="152.59" r="38" fill="url(#kg-gofun)"/>
+    <circle cx="38.18" cy="79.91" r="38" fill="url(#kg-kodai)"/>
   </g>
   <text x="132" y="78" font-family="'Noto Sans JP', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.5"><tspan fill="#1f2328">Kagura</tspan><tspan fill="#faa916"> AI</tspan></text>
 </svg>


### PR DESCRIPTION
## Summary

Follow-up to #214. That PR added a small *solid-white pentagon* to the logo center, but the official brand mark (the transparent `KaguraAI_logo*.png` files) is built differently — so this rebuilds the mark to match it exactly.

The official mark:
- **Five tangent petals in a ring** (green top, purple upper-left, orange upper-right, cream lower-left, amber lower-right) — *not* heavily overlapping like the old SVG.
- A **transparent five-point-star center** (the petals' negative space).
- A **transparent lollipop** (stem + dot) cut from each petal, pointing inward.

## Changes

- `assets/kagura-logo.svg` and `assets/kagura-logo-dark.svg`: rebuild the flower mark via an SVG `<mask>` so the center and cutouts are genuine transparency. Geometry measured from `KaguraAI_logo5.png` (petal r=38, ring R=65 ≈ r/sin36°, dot r=7, stem width 8). Text + dark-mode text handling unchanged.

## Behavior

- **Light backgrounds**: pixel-faithful to the official artwork — center and cutouts appear white.
- **Dark backgrounds**: the transparent center/cutouts show the page through them (center star + dots go dark). This is the intended "exact transparent match" behavior.

## Verification

Rendered both variants in **Chromium** (light + dark, loaded as `<img>` exactly as GitHub embeds them) — mark matches the official PNG and text layout is correct. Note: ImageMagick cannot render SVG masks, so browser verification was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)