### PR TITLE
feat(secrets): zero-knowledge secret client + `kagura secret` CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "kagura-cli",
-  "description": "Thin Claude Code skills over the Kagura Memory CLI (doctor / auth / setup / ingest / resource / files).",
+  "description": "Thin Claude Code skills over the Kagura Memory CLI (doctor / auth / setup / ingest / resource / files / secret).",
   "owner": {
     "name": "Kagura AI, Inc.",
     "url": "https://github.com/kagura-ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kagura-cli",
   "version": "0.32.1",
-  "description": "Thin Claude Code skills over the Kagura Memory CLI (kagura): doctor, auth, setup, document ingestion, resource tokens, and R2 file uploads.",
+  "description": "Thin Claude Code skills over the Kagura Memory CLI (kagura): doctor, auth, setup, document ingestion, resource tokens, R2 file uploads, and zero-knowledge secrets.",
   "author": {
     "name": "Kagura AI, Inc.",
     "url": "https://github.com/kagura-ai"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,14 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Install dependencies (with ingest extras)
+      - name: Install dependencies (with ingest + secret extras)
         # Issue #80's ingest module pulls pymupdf + pillow via optional
         # extras. The unit tests for that module import PIL at module
-        # level, so we install the full extras here. Core SDK consumers
-        # are unaffected — extras are opt-in via `pip install
-        # kagura-memory[ingest-pdf]`.
-        run: uv sync --dev --extra ingest-all --python ${{ matrix.python-version }}
+        # level, so we install the full extras here. The `secret` extra
+        # (Issue #216: pyrage + keyring) is likewise imported at module
+        # level by tests/test_secrets_*.py. Core SDK consumers are
+        # unaffected — extras are opt-in via `pip install kagura-memory[...]`.
+        run: uv sync --dev --extra ingest-all --extra secret --python ${{ matrix.python-version }}
 
       - name: Test with coverage
         run: uv run pytest tests/ -v -m "not integration and not eval and not browser and not youtube and not audio" --cov=src/kagura_memory --cov-report=xml --cov-report=term

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-Python SDK for Kagura Memory Cloud. Four clients:
+Python SDK for Kagura Memory Cloud. Five clients:
 - `KaguraClient` — MCP client for memory and context operations
 - `KaguraAgent` — LLM-powered session analysis with hooks/skills API
 - `ResourceClient` — REST client for resource token management and data ingestion
 - `FilesClient` — REST + presigned PUT client for file uploads with sha256 integrity binding (server v0.15.1+)
+- `SecretClient` — REST client for the zero-knowledge secret store (age recipient encryption, local decrypt; `[secret]` extra, server v0.39.0+)
 
 ## Development Workflow
 
@@ -32,9 +33,10 @@ uv run pyright src/              # Type check
 - Resource ingestion: `setup_resource`, `ingest_event`, `ingest_events`
 - Resource stats/schema: `get_resource_impact`, `get_resource_schema`
 - **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+)
+- **Zero-knowledge secrets**: `SecretClient` + `kagura secret` — age recipient encryption, local decrypt; private key in OS keychain via `pyrage`/`keyring` (`[secret]` extra, server v0.39.0+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs
-- CLI: `kagura doctor`, `kagura auth login/refresh/status/list`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura context search-config`, `kagura sleep history/report/rollback`
+- CLI: `kagura doctor`, `kagura auth login/refresh/status/list`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura secret keygen/put/get/grant/rotate/exec`, `kagura context search-config`, `kagura sleep history/report/rollback`
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This SDK connects your Python code to [Kagura Memory Cloud](https://github.com/k
 | **`KaguraClient`** | MCP (JSON-RPC) | Direct memory ops — remember, recall, explore, reference, forget |
 | **`ResourceClient`** | REST API | External data ingestion — push data from Slack, CI/CD, CRM into Kagura |
 | **`FilesClient`** | REST + presigned PUT | File uploads with sha256 integrity binding (R2) |
+| **`SecretClient`** | REST + age crypto | Zero-knowledge secrets — age recipient encryption, **local decryption** (the server only ever stores armored ciphertext) |
 | **`FileIngestor`** | CLI + SDK | Document ingestion — PDF/Office/HTML/EPUB, audio & YouTube transcripts → memory graph + R2 archive |
 
 ## 60-second demo
@@ -310,10 +311,34 @@ Re-uploading bytes whose sha256 already exists in the workspace returns the **ex
 
 Runnable: [`examples/files_upload.py`](examples/files_upload.py).
 
+### SecretClient — Zero-Knowledge Secrets
+
+Client side of the secret store (memory-cloud v0.39.0+, requires the `[secret]` extra: `pip install 'kagura-memory[secret]'`). Secrets are encrypted to recipients' `age`/X25519 public keys and decrypted **locally** — memory-cloud only ever stores armored ciphertext, never plaintext. All crypto is delegated to the audited [`pyrage`](https://pypi.org/project/pyrage/) binding; the age private key is held in your OS keychain (`keyring`) and never transmitted.
+
+```python
+from kagura_memory.secrets.client import SecretClient
+
+async with SecretClient.from_mcp_url(api_key="kagura_...", mcp_url="https://memory.kagura-ai.com/mcp") as client:
+    # Register your public key (lands in `pending` until an owner approves it).
+    me = await client.register_pubkey("age1...", label="laptop")
+
+    # Encrypt-and-store in one call. recipients_snapshot / grant_pubkey_ids are
+    # derived 1:1 from the recipient set, so the server's grant-consistency
+    # invariant holds by construction.
+    actives = [p for p in await client.list_pubkeys() if p.status == "active"]
+    await client.put_secret_for_recipients("db-prod", b"hunter2", actives)
+
+    # Fetch ciphertext (decrypt locally with your own key — not shown here).
+    sv = await client.fetch_secret("db-prod")
+```
+
+Most workflows use the CLI instead — see [`kagura secret`](#zero-knowledge-secrets-kagura-secret) below, which handles keychain custody and the get/put/grant/rotate flows with built-in misuse guards.
+
 ## SDK ↔ memory-cloud Compatibility
 
 | SDK | Min memory-cloud | Notes |
 |---|---|---|
+| 0.33.0+ | 0.17.1 (0.39.0 for `kagura secret`) | **Zero-knowledge secret store.** `SecretClient` / `kagura secret` need memory-cloud **0.39.0+** (the `/api/v1/config/secrets` endpoints). `MIN_SERVER_VERSION` is **not** bumped — the rest of the SDK still works on 0.17.1+; only the secret surface requires 0.39.0. Requires the `[secret]` extra. |
 | 0.27.0 – 0.31.x | 0.17.1 | **Agent memory substrate.** `load_pinned` + `delivery_mode` pin-on-write, `recall_upcoming`, `feedback`, `set_state`/`get_state`, and the `trust_tier` recall filter each need a memory-cloud carrying the matching [#885](https://github.com/kagura-ai/memory-cloud/issues/885) agent-substrate APIs (≈ v0.23.0+); against an older server those specific tools return an MCP "tool not found". `MIN_SERVER_VERSION` stays **0.17.1** — the rest of the SDK still works on 0.17.1+. **v0.29.0 also changed error handling (breaking): MCP tool methods now raise `KaguraNotFoundError`/`KaguraError` instead of returning `{"status":"error"}` dicts** (see the KaguraClient error-handling note above). |
 | 0.15.0 – 0.20.x | 0.15.1 | `FilesClient` + R2 checksum binding. `list_tags()` additionally needs **0.15.4** — `MIN_SERVER_VERSION` is intentionally not bumped, only that one method requires the newer server. |
 | 0.14.x | 0.15.1 | `FilesClient` + R2 checksum binding (`x-amz-checksum-sha256` on PUT) |
@@ -423,6 +448,23 @@ kagura files delete <file-id>
 kagura config show
 ```
 
+### Zero-knowledge secrets (`kagura secret`)
+
+Requires the `[secret]` extra (`pip install 'kagura-memory[secret]'`) and memory-cloud 0.39.0+. Your `age` private key lives in the OS keychain; memory-cloud only ever stores armored ciphertext.
+
+```bash
+kagura secret keygen --label laptop          # generate keypair → keychain, register public key (pending)
+kagura secret approve <pubkey-id>            # owner: approve a pending key (verify its fingerprint out-of-band)
+kagura secret put db-prod < secret.txt       # value from stdin/--from-file — never from argv
+kagura secret get db-prod | psql             # refuses to print to a TTY; pipe it, or use -o FILE (0600) / --reveal
+kagura secret exec --as DATABASE_URL=db-prod -- ./server   # inject into a child env, no disk/scrollback
+kagura secret grant db-prod --to <pubkey-id> # re-encrypt to the expanded recipient set
+kagura secret revoke db-prod --to <pubkey-id># revoke a grant (then `rotate` — revoke ≠ invalidation)
+kagura secret rotate db-prod                 # encrypt a NEW value to the remaining recipients
+kagura secret list                           # secret metadata (never the values)
+kagura secret audit-verify                   # verify the tamper-evident audit chain
+```
+
 ### Document ingestion (`kagura ingest`)
 
 See the [60-second demo](#60-second-demo) above for the happy path. The full option surface:
@@ -490,7 +532,7 @@ kagura process -m "今日の学び：FastAPIのDIはDepends()を使う"
 This repo also ships a thin **Claude Code plugin** under
 [`.claude-plugin/`](.claude-plugin/plugin.json) + [`skills/`](skills/) that wraps
 the high-value CLI commands as skills (`doctor`, `auth`, `setup`, `ingest`,
-`resource`, `files`) — each shells out to the installed `kagura` CLI and returns
+`resource`, `files`, `secret`) — each shells out to the installed `kagura` CLI and returns
 clear guidance when it is not installed/authenticated. The plugin is named
 **`kagura-cli`** (distinct from the `kagura-memory` SDK package and the existing
 `kagura-memory` MCP plugin). Registration in the `kagura-plugins` marketplace (so
@@ -519,6 +561,8 @@ follow-up.
 | Resource Impact (stats) | `ResourceClient` | REST API | API Key |
 | Resource Schema | `ResourceClient` | REST API | API Key |
 | File upload / download-url / delete / list | `FilesClient` | REST + presigned PUT | API Key |
+| Secret pubkey registry (register/list/me/approve/revoke) | `SecretClient` | REST API | API Key / OAuth |
+| Secret put / fetch / list / revoke-grant / audit-verify | `SecretClient` | REST API (age, local decrypt) | API Key / OAuth |
 | Account erasure (GDPR Art.17 / APPI) | — | Web UI only | Session |
 
 Context deletion is a **soft delete** available via `KaguraClient.delete_context()` and `kagura context delete` (the CLI prompts for confirmation). Account erasure (GDPR Art.17 / APPI) is intentionally Web UI only — it is irreversible and requires session authentication and confirmation. `kagura sleep rollback` runs over the MCP API Key but is itself destructive (reverses edge creation, merges, importance updates, promotions, and archives) and the CLI requires `--yes` to skip the interactive confirmation. The server commits per-action without a Saga, so a 5xx response after partial success means SOME actions may have been reversed before the error surfaced — re-run `kagura sleep report` to inspect the post-failure state.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,15 @@ ingest-all = [
     "kagura-memory[ingest-youtube]",
     "kagura-memory[ingest-browser]",
 ]
+# Zero-knowledge secret client (Issue #216) — `kagura secret` CLI.
+# `pyrage` provides the audited Rust `age`/X25519 crypto (no home-grown
+# crypto); armoring is a pure-Python transport wrapper in secrets/crypto.py.
+# `keyring` holds the age private key in the OS keychain (repo-dotfile keys
+# are disallowed). Opt-in so the base install stays crypto-dependency-free.
+secret = [
+    "pyrage>=1.1",
+    "keyring>=24.0",
+]
 
 [project.scripts]
 kagura = "kagura_memory.cli:main"

--- a/skills/secret/SKILL.md
+++ b/skills/secret/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: secret
+description: Store and retrieve zero-knowledge secrets with the `kagura secret` CLI — age recipient encryption, local decrypt (memory-cloud never sees plaintext). Use for keygen/enroll, put/get, grant/revoke/rotate, exec-with-injected-env, and audit verification.
+---
+
+# kagura secret — zero-knowledge secret store
+
+Drive the `kagura secret` command group: secrets are encrypted to recipients'
+`age`/X25519 public keys and decrypted **locally**, so memory-cloud only ever
+stores armored ciphertext. Thin wrapper around the installed `kagura` CLI.
+
+## Preflight
+
+- `kagura --version`; if missing → `uv tool install 'kagura-memory[secret]'`
+  (or `pip install 'kagura-memory[secret]'`), then stop. The **`[secret]` extra
+  is required** — it pulls in `pyrage` (age crypto) and `keyring` (key custody).
+- Requires memory-cloud **0.39.0+** and authentication. Run `kagura auth status`;
+  if not authed, run the `auth` skill first.
+- First use on a machine: `kagura secret keygen` creates an age keypair, stores
+  the **private key in the OS keychain**, and registers the public key (it lands
+  `pending` until a workspace owner approves it).
+
+## Run (choose by intent)
+
+```bash
+kagura secret keygen --label laptop          # enroll: keypair → keychain, register pubkey
+kagura secret approve <pubkey-id>            # owner: approve a pending key (verify fingerprint OOB)
+kagura secret put db-prod < secret.txt       # store; value from stdin/--from-file (never argv)
+kagura secret get db-prod | your-tool        # fetch + local decrypt (see guardrails below)
+kagura secret exec --as DATABASE_URL=db-prod -- ./server   # inject into a child env, no disk/scrollback
+kagura secret grant db-prod --to <pubkey-id> # re-encrypt to the expanded recipient set
+kagura secret revoke db-prod --to <pubkey-id># revoke a grant — then rotate
+kagura secret rotate db-prod                 # encrypt a NEW value to the remaining recipients
+kagura secret list                           # secret metadata (never the values)
+kagura secret audit-verify                   # verify the tamper-evident audit chain
+```
+
+## Consume the result
+
+- **Never read a secret value aloud or paste it back.** `get` refuses to print to
+  a terminal by design — keep it piped or write to a file (`-o FILE`, mode 0600).
+  Do **not** pass `--reveal` on the user's behalf.
+- **Never put a value on the command line** (`ps`/shell-history leak): always pipe
+  it to `put`/`rotate` via stdin or `--from-file`.
+- **Private keys never leave the keychain.** `keygen` prints only the public key +
+  fingerprint — relay those, never any `AGE-SECRET-KEY...` material.
+- **revoke ≠ cryptographic invalidation.** A revoked recipient may still hold a
+  fetched copy — after `revoke`, run `kagura secret rotate` *and* regenerate the
+  upstream provider credential to actually contain a leak.
+- On `keygen`/`approve`, surface the **fingerprint** so the user can verify it
+  out-of-band (TOFU) before trusting the key.

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -152,22 +152,38 @@ def main():
 main.add_command(_auth_group, name="auth")
 
 
-# Register the `kagura secret` sub-group (zero-knowledge secret store, #216).
-# Its crypto deps (pyrage/keyring) ship in the optional ``[secret]`` extra, so
-# the import can fail on a base install — fall back to a stub that points the
-# operator at the extra instead of breaking the whole CLI.
-try:
-    from .secrets.cli import secret as _secret_group
+def _register_secret_command(
+    main_group: click.Group, *, import_secret: Callable[[], click.Command] | None = None
+) -> None:
+    """Register the `kagura secret` sub-group (zero-knowledge secret store, #216).
 
-    main.add_command(_secret_group, name="secret")
-except ModuleNotFoundError as _e:
-    # Only fall back when the optional [secret] deps (pyrage/keyring) are
-    # actually missing — re-raise any other import failure (e.g. a real bug in
-    # secrets.cli) so it isn't silently masked by the "install the extra" stub.
-    if (_e.name or "").split(".")[0] not in {"pyrage", "keyring"}:
-        raise
+    Its crypto deps (pyrage/keyring) ship in the optional ``[secret]`` extra, so
+    the import can fail on a base install — fall back to a stub that points the
+    operator at the extra instead of breaking the whole CLI. Any *other* import
+    failure (e.g. a real bug in ``secrets.cli``) is re-raised so it isn't masked.
 
-    @main.command(name="secret", context_settings={"ignore_unknown_options": True})
+    ``import_secret`` is an injection seam for tests; production uses the real
+    package import.
+    """
+
+    def _default_import() -> click.Command:
+        from .secrets.cli import secret as secret_group
+
+        return secret_group
+
+    importer = import_secret or _default_import
+    try:
+        secret_group: click.Command | None = importer()
+    except ModuleNotFoundError as e:
+        if (e.name or "").split(".")[0] not in {"pyrage", "keyring"}:
+            raise
+        secret_group = None
+
+    if secret_group is not None:
+        main_group.add_command(secret_group, name="secret")
+        return
+
+    @main_group.command(name="secret", context_settings={"ignore_unknown_options": True})
     @click.argument("_args", nargs=-1, type=click.UNPROCESSED)
     def _secret_stub(_args: tuple[str, ...]) -> None:
         """Zero-knowledge secret store (requires the [secret] extra)."""
@@ -175,6 +191,9 @@ except ModuleNotFoundError as _e:
             "the `kagura secret` commands require optional crypto dependencies. "
             "Install them with:  pip install 'kagura-memory[secret]'"
         )
+
+
+_register_secret_command(main)
 
 
 @main.command()

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -160,7 +160,12 @@ try:
     from .secrets.cli import secret as _secret_group
 
     main.add_command(_secret_group, name="secret")
-except ImportError:
+except ModuleNotFoundError as _e:
+    # Only fall back when the optional [secret] deps (pyrage/keyring) are
+    # actually missing — re-raise any other import failure (e.g. a real bug in
+    # secrets.cli) so it isn't silently masked by the "install the extra" stub.
+    if (_e.name or "").split(".")[0] not in {"pyrage", "keyring"}:
+        raise
 
     @main.command(name="secret", context_settings={"ignore_unknown_options": True})
     @click.argument("_args", nargs=-1, type=click.UNPROCESSED)

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -152,6 +152,26 @@ def main():
 main.add_command(_auth_group, name="auth")
 
 
+# Register the `kagura secret` sub-group (zero-knowledge secret store, #216).
+# Its crypto deps (pyrage/keyring) ship in the optional ``[secret]`` extra, so
+# the import can fail on a base install — fall back to a stub that points the
+# operator at the extra instead of breaking the whole CLI.
+try:
+    from .secrets.cli import secret as _secret_group
+
+    main.add_command(_secret_group, name="secret")
+except ImportError:
+
+    @main.command(name="secret", context_settings={"ignore_unknown_options": True})
+    @click.argument("_args", nargs=-1, type=click.UNPROCESSED)
+    def _secret_stub(_args: tuple[str, ...]) -> None:
+        """Zero-knowledge secret store (requires the [secret] extra)."""
+        raise click.ClickException(
+            "the `kagura secret` commands require optional crypto dependencies. "
+            "Install them with:  pip install 'kagura-memory[secret]'"
+        )
+
+
 @main.command()
 @click.option("--message", "-m", help="Single message to process")
 @click.option("--file", "-f", type=click.File("r"), help="Session JSON file")

--- a/src/kagura_memory/exceptions.py
+++ b/src/kagura_memory/exceptions.py
@@ -110,3 +110,26 @@ class KaguraIngestError(KaguraError):
     effort) and do NOT raise this exception — only fatal orchestration failures
     do (e.g. extractor cannot decode the file, no Provider configured).
     """
+
+
+class KaguraSecretError(KaguraError):
+    """Base error for the zero-knowledge secret client (Issue #216)."""
+
+
+class KaguraCryptoError(KaguraSecretError):
+    """age encryption/decryption or armor (de)framing failed.
+
+    Raised by :mod:`kagura_memory.secrets.crypto` for malformed recipients,
+    decrypt failures (wrong identity / corrupt ciphertext), non-armored input,
+    or a ciphertext that exceeds the server's size cap. The underlying
+    ``pyrage`` error (if any) is preserved via ``__cause__``.
+    """
+
+
+class KaguraKeyCustodyError(KaguraSecretError):
+    """The age private key could not be stored or retrieved securely.
+
+    Raised by :mod:`kagura_memory.secrets.keymanager` when no acceptable
+    custody backend is available (fail-closed) or the keychain rejects a
+    read/write. Repo-dotfile private keys are disallowed by design.
+    """

--- a/src/kagura_memory/secrets/__init__.py
+++ b/src/kagura_memory/secrets/__init__.py
@@ -1,0 +1,11 @@
+"""Zero-knowledge secret client for Kagura Memory Cloud (Issue #216).
+
+Client side of the secret store (server: memory-cloud#1128, v0.39.0):
+``age``/X25519 recipient encryption with **local decryption** — the private
+key never leaves the client and memory-cloud only ever sees armored ciphertext.
+
+Submodules:
+
+- :mod:`~kagura_memory.secrets.crypto` — age wrap/unwrap, armor codec,
+  fingerprint (wraps the audited ``pyrage`` binding).
+"""

--- a/src/kagura_memory/secrets/cli.py
+++ b/src/kagura_memory/secrets/cli.py
@@ -1,0 +1,531 @@
+"""``kagura secret`` CLI — zero-knowledge secret store (Issue #216).
+
+Composes the three library layers (crypto / keymanager / client). Security-
+critical DX guards live here:
+
+- ``get`` refuses to print a secret to a TTY unless ``--reveal``/``-o`` is given.
+- ``put`` reads the value from stdin/``--from-file`` only — never from argv.
+- ``keygen`` never prints the private key; only the public recipient + fingerprint.
+- ``revoke`` warns that revoke is not cryptographic invalidation → rotate.
+- ``exec`` injects secrets into the child's environment via process replacement
+  and never mutates the parent ``os.environ``.
+
+Module-level helpers (``_get_secret_client``, ``_make_key_manager``,
+``_stdout_isatty``, ``_exec_child``) are deliberately overridable so the CLI is
+unit-testable without a network, a keychain, or an actual ``exec``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import sys
+import tempfile
+from collections.abc import Awaitable, Iterator
+from pathlib import Path
+from typing import TypeVar
+
+import click
+
+from .._auth import _resolve_auth
+from ..config import load_config
+from ..exceptions import KaguraAuthError, KaguraSecretError, _exc_message
+from . import crypto
+from .client import SecretClient
+from .keymanager import KeyManager
+from .models import (
+    AuditVerifyResponse,
+    PubkeyResponse,
+    SecretMetaResponse,
+    SecretPutResponse,
+)
+
+T = TypeVar("T")
+
+
+# --------------------------------------------------------------------------
+# Testable seams + IO helpers
+# --------------------------------------------------------------------------
+
+
+def _get_secret_client() -> SecretClient:
+    """Construct a SecretClient via the canonical SDK auth chain."""
+    config = load_config()
+    try:
+        resolved = _resolve_auth(api_key=None, mcp_url=None, profile=None, config=config)
+    except KaguraAuthError as e:
+        raise click.ClickException(_exc_message(e)) from e
+    return SecretClient._from_resolved_auth(resolved)
+
+
+def _make_key_manager(profile: str = "default") -> KeyManager:
+    """Construct a KeyManager (OS-keychain custody)."""
+    return KeyManager(profile=profile)
+
+
+def _stdout_isatty() -> bool:
+    return sys.stdout.isatty()
+
+
+def _stdin_isatty() -> bool:
+    return sys.stdin.isatty()
+
+
+def _disable_core_dumps() -> None:
+    """Best-effort: prevent plaintext from landing in a core dump on crash.
+
+    POSIX-only; a silent no-op on Windows (no ``resource`` module / core dumps)
+    or where the limit cannot be set.
+    """
+    if sys.platform == "win32":
+        return
+    try:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+    except (ValueError, OSError):
+        pass
+
+
+def _read_secret_value(from_file: str | None) -> bytes:
+    """Read a secret value from ``--from-file``, piped stdin, or a no-echo prompt.
+
+    A single trailing newline (``\\n`` or ``\\r\\n``) from piped input is stripped
+    so ``echo secret | kagura secret put ...`` stores ``secret``, not ``secret\\n``.
+    The value is never taken from argv (it would leak via ``ps``/shell history).
+    """
+    if from_file is not None:
+        return Path(from_file).read_bytes()
+    if _stdin_isatty():
+        import getpass
+
+        return getpass.getpass("Secret value (input hidden): ").encode("utf-8")
+    data = click.get_binary_stream("stdin").read()
+    if data.endswith(b"\r\n"):
+        return data[:-2]
+    if data.endswith(b"\n"):
+        return data[:-1]
+    return data
+
+
+def _write_secret_file(path: Path, data: bytes) -> None:
+    """Atomically write ``data`` to ``path`` with mode 0600.
+
+    Mirrors the temp+fsync+chmod+replace sequence of
+    :func:`kagura_memory.auth.credentials._atomic_write_json` (kept as a separate
+    helper here because that one is dict→JSON and concurrency-locked for the
+    credentials hot path; this one writes raw secret bytes).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, path)
+        # fsync the parent dir so the rename is durable on crash/power-loss
+        # (parity with _atomic_write_json). Best-effort: unsupported on Windows
+        # and some filesystems, where the atomic rename above already happened.
+        try:
+            dir_fd = os.open(str(path.parent), os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _exec_child(argv: list[str], env: dict[str, str]) -> None:
+    """Replace this process with ``argv`` carrying ``env``.
+
+    On POSIX, ``execvpe`` replaces the address space so the decrypted plaintext
+    in this process dies atomically. On Windows (no real exec), run as a child
+    and propagate its exit code.
+    """
+    if not argv:
+        raise click.ClickException("no command given to `kagura secret exec`")
+    if os.name == "posix":
+        os.execvpe(argv[0], argv, env)
+    else:
+        import subprocess
+
+        completed = subprocess.run(argv, env=env)  # noqa: S603
+        raise SystemExit(completed.returncode)
+
+
+@contextlib.contextmanager
+def _click_errors() -> Iterator[None]:
+    """Map SDK/runtime errors to a clean ClickException.
+
+    ClickException renders as ``Error: <message>`` with no traceback, so wrapping
+    fallible SDK calls (crypto, keychain custody) prevents a raw Python traceback
+    — whose exception ``repr`` could include sensitive bytes — from reaching the
+    terminal. Use it around any synchronous SDK work done outside :func:`_run`.
+    """
+    try:
+        yield
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(_exc_message(e)) from e
+
+
+def _run(coro: Awaitable[T]) -> T:
+    """Run an async operation, mapping SDK errors to ClickException."""
+    with _click_errors():
+        return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+async def _resolve_put_recipients(
+    client: SecretClient, km: KeyManager, to_ids: tuple[str, ...]
+) -> list[PubkeyResponse]:
+    """Resolve ``--to`` ids to active recipients, defaulting to the caller's own key."""
+    pubkeys = await client.list_pubkeys()
+    active = {p.id: p for p in pubkeys if p.status == "active"}
+    if to_ids:
+        recipients = []
+        for tid in to_ids:
+            p = active.get(tid)
+            if p is None:
+                raise click.ClickException(f"pubkey {tid} is not an active recipient")
+            recipients.append(p)
+        return recipients
+    my_fp = km.fingerprint()
+    for p in active.values():
+        if p.fingerprint == my_fp:
+            return [p]
+    raise click.ClickException(
+        "no active recipient found for your key. Run `kagura secret keygen` and have an "
+        "owner approve it, or pass --to <pubkey-id>."
+    )
+
+
+# --------------------------------------------------------------------------
+# Command group
+# --------------------------------------------------------------------------
+
+
+@click.group()
+def secret() -> None:
+    """Zero-knowledge secret store — age recipient encryption, local decrypt."""
+
+
+@secret.command()
+@click.option("--profile", default="default", help="Key profile (default: default).")
+@click.option("--label", default=None, help="Human-readable label for this pubkey.")
+@click.option(
+    "--no-register", is_flag=True, help="Generate + custody only; skip server registration."
+)
+def keygen(profile: str, label: str | None, no_register: bool) -> None:
+    """Generate an age keypair, custody the private key, and register the public key.
+
+    Idempotent: if a key already exists for this profile it is reused (not
+    regenerated), so a run whose server registration previously failed can be
+    safely retried.
+    """
+    km = _make_key_manager(profile)
+    # Custody calls can fail-closed (no keychain) — map to a clean error, not a
+    # traceback, so a headless host sees the actionable "install a keyring" hint.
+    with _click_errors():
+        if km.has_key():
+            recipient, fp = km.get_recipient(), km.fingerprint()
+            existed = True
+        else:
+            recipient, fp = km.enroll()
+            existed = False
+    if existed:
+        click.echo(f"A key already exists for profile '{profile}'; reusing it.")
+    else:
+        click.echo(f"✓ age keypair generated and stored in your OS keychain (profile '{profile}').")
+    click.echo(f"  Public key:  {recipient}")
+    click.echo(f"  Fingerprint: {fp}")
+    if no_register:
+        click.echo("  (--no-register: did not register with the server.)")
+        return
+
+    async def _register() -> PubkeyResponse:
+        async with _get_secret_client() as c:
+            return await c.register_pubkey(recipient, label=label)
+
+    resp = _run(_register())
+    click.echo(f"  Registered with the server (status: {resp.status}).")
+    click.echo(f"  An owner approves it with:  kagura secret approve {resp.id}")
+    click.echo("  Share the fingerprint out-of-band so the owner can verify it (TOFU).")
+
+
+@secret.command()
+@click.argument("pubkey_id")
+def approve(pubkey_id: str) -> None:
+    """Approve a pending pubkey (owner only)."""
+
+    async def _approve() -> PubkeyResponse:
+        async with _get_secret_client() as c:
+            return await c.approve_pubkey(pubkey_id)
+
+    resp = _run(_approve())
+    click.echo(f"✓ Approved pubkey {resp.id} (status: {resp.status}).")
+    click.echo(f"  Fingerprint: {resp.fingerprint}")
+    click.echo("  Verify this fingerprint matches what the member reported out-of-band (TOFU).")
+
+
+@secret.command()
+@click.option("--mine", is_flag=True, help="Only your own pubkeys.")
+def pubkeys(mine: bool) -> None:
+    """List recipient pubkeys."""
+
+    async def _list() -> list[PubkeyResponse]:
+        async with _get_secret_client() as c:
+            return await (c.list_my_pubkeys() if mine else c.list_pubkeys())
+
+    items = _run(_list())
+    if not items:
+        click.echo("(no pubkeys)")
+        return
+    for p in items:
+        label = f"  {p.label}" if p.label else ""
+        click.echo(f"{p.status:8} {p.fingerprint[:16]}…  {p.id}{label}")
+
+
+@secret.command()
+@click.argument("name")
+@click.option(
+    "--to", "to_ids", multiple=True, help="Recipient pubkey id (repeatable). Default: yourself."
+)
+@click.option(
+    "--from-file",
+    "from_file",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Read the value from a file instead of stdin.",
+)
+@click.option("--profile", default="default", help="Your key profile (default: default).")
+def put(name: str, to_ids: tuple[str, ...], from_file: str | None, profile: str) -> None:
+    """Store a secret. The value is read from stdin or --from-file (never from argv)."""
+    value = _read_secret_value(from_file)
+    km = _make_key_manager(profile)
+
+    async def _put() -> tuple[SecretPutResponse, list[PubkeyResponse]]:
+        async with _get_secret_client() as c:
+            recipients = await _resolve_put_recipients(c, km, to_ids)
+            resp = await c.put_secret_for_recipients(name, value, recipients)
+            return resp, recipients
+
+    resp, recipients = _run(_put())
+    click.echo(
+        f"✓ Stored '{resp.name}' v{resp.version_number} for {len(recipients)} recipient(s).",
+        err=True,
+    )
+
+
+@secret.command()
+@click.argument("name")
+@click.option(
+    "-o",
+    "--output",
+    "output",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="Write to FILE (mode 0600) instead of stdout.",
+)
+@click.option(
+    "--reveal", is_flag=True, help="Allow printing to a terminal (overrides the TTY guard)."
+)
+@click.option(
+    "--version", "version_number", type=int, default=None, help="Pin a version (default: latest)."
+)
+@click.option("--profile", default="default", help="Your key profile (default: default).")
+def get(
+    name: str, output: str | None, reveal: bool, version_number: int | None, profile: str
+) -> None:
+    """Fetch a secret and decrypt it locally with your key."""
+    if output is None and not reveal and _stdout_isatty():
+        raise click.ClickException(
+            "refusing to print a secret to a terminal.\n"
+            f"  Pipe it:    kagura secret get {name} | your-tool\n"
+            f"  To a file:  kagura secret get {name} -o FILE   (written 0600)\n"
+            f"  Force show: kagura secret get {name} --reveal"
+        )
+    _disable_core_dumps()
+    km = _make_key_manager(profile)
+
+    # Decrypt inside the _run scope so a custody/decrypt failure (no key
+    # enrolled, not a recipient, corrupt ciphertext) surfaces as a clean error.
+    async def _fetch() -> bytes:
+        async with _get_secret_client() as c:
+            sv = await c.fetch_secret(name, version_number=version_number)
+        return crypto.decrypt(sv.ciphertext, km.get_identity())
+
+    plaintext = _run(_fetch())
+    if output is not None:
+        _write_secret_file(Path(output), plaintext)
+        click.echo(f"✓ wrote '{name}' to {output} (mode 0600).", err=True)
+    else:
+        click.echo(plaintext, nl=False)
+
+
+@secret.command(name="list")
+def list_() -> None:
+    """List secret metadata (never the values)."""
+
+    async def _list() -> list[SecretMetaResponse]:
+        async with _get_secret_client() as c:
+            return await c.list_secrets()
+
+    items = _run(_list())
+    if not items:
+        click.echo("(no secrets)")
+        return
+    for s in items:
+        flag = "  ⚠ rotation needed" if s.rotation_needed else ""
+        click.echo(f"{s.name}  v{s.current_version}  grants={s.grant_count}  {s.status}{flag}")
+
+
+@secret.command()
+@click.argument("name")
+@click.option("--to", "to_id", required=True, help="Pubkey id to grant.")
+@click.option("--profile", default="default", help="Your key profile (default: default).")
+def grant(name: str, to_id: str, profile: str) -> None:
+    """Grant a recipient access (re-encrypts the secret to the expanded set).
+
+    You must be a current recipient — only a recipient can decrypt the value to
+    re-encrypt it for the new set.
+    """
+    km = _make_key_manager(profile)
+
+    async def _grant() -> tuple[SecretPutResponse, list[PubkeyResponse]]:
+        async with _get_secret_client() as c:
+            # The fetch and the pubkey listing are independent — run concurrently.
+            sv, pubkeys_ = await asyncio.gather(c.fetch_secret(name), c.list_pubkeys())
+            plaintext = crypto.decrypt(sv.ciphertext, km.get_identity())
+            active = [p for p in pubkeys_ if p.status == "active"]
+            snapshot = set(sv.recipients_snapshot)
+            by_id = {p.id: p for p in active if p.fingerprint in snapshot}
+            new = next((p for p in active if p.id == to_id), None)
+            if new is None:
+                raise click.ClickException(f"pubkey {to_id} is not an active recipient")
+            by_id[new.id] = new
+            recipients = list(by_id.values())
+            resp = await c.put_secret_for_recipients(name, plaintext, recipients)
+            return resp, recipients
+
+    resp, recipients = _run(_grant())
+    click.echo(
+        f"✓ granted {to_id} on '{name}'; re-encrypted to {len(recipients)} recipient(s) "
+        f"(v{resp.version_number})."
+    )
+
+
+@secret.command()
+@click.argument("name")
+@click.option("--to", "to_id", required=True, help="Recipient pubkey id to revoke.")
+def revoke(name: str, to_id: str) -> None:
+    """Revoke one recipient's grant. Does NOT invalidate already-fetched copies."""
+
+    async def _revoke() -> SecretMetaResponse:
+        async with _get_secret_client() as c:
+            return await c.revoke_grant(name, to_id)
+
+    _run(_revoke())
+    click.echo(f"✓ revoked {to_id} on '{name}'.")
+    click.echo("  ⚠ revoke does NOT invalidate copies already fetched by that recipient.")
+    click.echo(f"     To contain a leak, rotate now:  kagura secret rotate {name}")
+    click.echo("     (rotate re-encrypts a new value to the remaining recipients; also")
+    click.echo("      regenerate the upstream provider credential.)")
+
+
+@secret.command()
+@click.argument("name")
+@click.option(
+    "--from-file",
+    "from_file",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False),
+    help="Read the new value from a file instead of stdin.",
+)
+@click.option("--profile", default="default", help="Your key profile (default: default).")
+def rotate(name: str, from_file: str | None, profile: str) -> None:
+    """Rotate a secret: encrypt a NEW value to the remaining recipients."""
+    new_value = _read_secret_value(from_file)
+
+    async def _rotate() -> tuple[SecretPutResponse, list[PubkeyResponse]]:
+        async with _get_secret_client() as c:
+            sv, pubkeys_ = await asyncio.gather(c.fetch_secret(name), c.list_pubkeys())
+            snapshot = set(sv.recipients_snapshot)
+            recipients = [p for p in pubkeys_ if p.status == "active" and p.fingerprint in snapshot]
+            if not recipients:
+                raise click.ClickException(f"no active recipients remain for '{name}'")
+            resp = await c.put_secret_for_recipients(name, new_value, recipients)
+            return resp, recipients
+
+    resp, recipients = _run(_rotate())
+    click.echo(f"✓ rotated '{name}' to v{resp.version_number} for {len(recipients)} recipient(s).")
+    click.echo("  Remember to regenerate the upstream provider credential (the real token).")
+
+
+@secret.command(name="audit-verify")
+def audit_verify() -> None:
+    """Verify the tamper-evident audit chain (owner/admin)."""
+
+    async def _verify() -> AuditVerifyResponse:
+        async with _get_secret_client() as c:
+            return await c.verify_audit()
+
+    r = _run(_verify())
+    if r.valid:
+        click.echo(f"✓ audit chain valid ({r.entries} entries, head {r.head}).")
+    else:
+        raise click.ClickException(f"audit chain BROKEN at entry {r.broken_at}: {r.reason}")
+
+
+@secret.command(
+    name="exec",
+    context_settings={"ignore_unknown_options": True, "allow_interspersed_args": False},
+)
+@click.option(
+    "--as", "as_specs", multiple=True, required=True, help="ENV_NAME=secret_name (repeatable)."
+)
+@click.option("--profile", default="default", help="Your key profile (default: default).")
+@click.argument("command", nargs=-1, type=click.UNPROCESSED, required=True)
+def exec_(as_specs: tuple[str, ...], profile: str, command: tuple[str, ...]) -> None:
+    """Run COMMAND with secrets injected into its environment (no disk, no scrollback).
+
+    Example:  kagura secret exec --as DATABASE_URL=db-prod -- ./server
+    """
+    _disable_core_dumps()
+    km = _make_key_manager(profile)
+    specs: list[tuple[str, str]] = []
+    for spec in as_specs:
+        env_name, sep, secret_name = spec.partition("=")
+        if not sep or not env_name or not secret_name:
+            raise click.ClickException(f"--as expects ENV_NAME=secret_name (got {spec!r})")
+        specs.append((env_name, secret_name))
+
+    async def _build_child_env() -> dict[str, str]:
+        # Read the identity once (not once per secret) and fetch concurrently.
+        identity = km.get_identity()
+        async with _get_secret_client() as c:
+            fetched = await asyncio.gather(*(c.fetch_secret(n) for _, n in specs))
+        # Build on a COPY — never mutate os.environ (python.md). The decode runs
+        # INSIDE this _run-wrapped coroutine and raises a value-free error on
+        # non-UTF-8 bytes, so the plaintext never reaches a traceback.
+        env = dict(os.environ)
+        for (env_name, secret_name), sv in zip(specs, fetched, strict=True):
+            try:
+                env[env_name] = crypto.decrypt(sv.ciphertext, identity).decode("utf-8")
+            except UnicodeDecodeError:
+                raise KaguraSecretError(
+                    f"secret {secret_name!r} is not valid UTF-8 and cannot be used as an "
+                    "environment variable"
+                ) from None  # `from None`: do not chain the exc (its repr holds the bytes)
+        return env
+
+    child_env = _run(_build_child_env())
+    _exec_child(list(command), child_env)

--- a/src/kagura_memory/secrets/cli.py
+++ b/src/kagura_memory/secrets/cli.py
@@ -85,6 +85,8 @@ def _disable_core_dumps() -> None:
 
         resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
     except (ValueError, OSError):
+        # Best-effort hardening: if the limit can't be set (sandboxed/already
+        # lowered), proceed anyway rather than blocking the command.
         pass
 
 
@@ -137,6 +139,8 @@ def _write_secret_file(path: Path, data: bytes) -> None:
             finally:
                 os.close(dir_fd)
         except OSError:
+            # Directory fsync is unsupported on Windows / some filesystems; the
+            # atomic rename above already landed, so skip the durability extra.
             pass
     except BaseException:
         tmp_path.unlink(missing_ok=True)
@@ -309,7 +313,8 @@ def pubkeys(mine: bool) -> None:
 @click.option("--profile", default="default", help="Your key profile (default: default).")
 def put(name: str, to_ids: tuple[str, ...], from_file: str | None, profile: str) -> None:
     """Store a secret. The value is read from stdin or --from-file (never from argv)."""
-    value = _read_secret_value(from_file)
+    with _click_errors():  # a --from-file read error must not surface as a traceback
+        value = _read_secret_value(from_file)
     km = _make_key_manager(profile)
 
     async def _put() -> tuple[SecretPutResponse, list[PubkeyResponse]]:
@@ -453,7 +458,8 @@ def revoke(name: str, to_id: str) -> None:
 @click.option("--profile", default="default", help="Your key profile (default: default).")
 def rotate(name: str, from_file: str | None, profile: str) -> None:
     """Rotate a secret: encrypt a NEW value to the remaining recipients."""
-    new_value = _read_secret_value(from_file)
+    with _click_errors():  # a --from-file read error must not surface as a traceback
+        new_value = _read_secret_value(from_file)
 
     async def _rotate() -> tuple[SecretPutResponse, list[PubkeyResponse]]:
         async with _get_secret_client() as c:

--- a/src/kagura_memory/secrets/client.py
+++ b/src/kagura_memory/secrets/client.py
@@ -1,0 +1,313 @@
+"""REST client for the Kagura zero-knowledge secret store (Issue #216).
+
+Talks to ``/api/v1/config/secrets`` on memory-cloud (v0.39.0). This client is a
+pure wire layer — it sends/receives **only armored ciphertext** and public
+metadata; it never holds the age private key (that is
+:class:`~kagura_memory.secrets.keymanager.KeyManager`'s job) and never sees
+plaintext. Construction mirrors :class:`~kagura_memory.resource_client.ResourceClient`
+and :class:`~kagura_memory.files_client.FilesClient` so the three REST clients
+share one shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import httpx
+
+from .._auth import _AuthSource, _OAuthAuth, _resolve_auth, _StaticAuth
+from .._http import SDK_VERSION, base_url_from_mcp, extract_detail, validate_https_url
+from ..auth.credentials import KaguraOAuth
+from ..exceptions import (
+    KaguraAuthError,
+    KaguraConnectionError,
+    KaguraNotFoundError,
+    KaguraSecretError,
+    _exc_message,
+)
+from . import crypto
+from .models import (
+    AuditVerifyResponse,
+    PubkeyResponse,
+    SecretMetaResponse,
+    SecretPutResponse,
+    SecretValueResponse,
+)
+
+_BASE = "/api/v1/config/secrets"
+
+
+class SecretClient:
+    """REST client for the secret store's pubkey-registry and secret endpoints.
+
+    All methods may raise:
+        KaguraAuthError: Authentication failed (401).
+        KaguraNotFoundError: Resource not found (404).
+        KaguraConnectionError: Other HTTP/network errors (incl. the 400 the
+            server returns when a put's grant set is inconsistent).
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str = "https://memory.kagura-ai.com",
+        timeout: float = 30.0,
+        *,
+        _oauth: KaguraOAuth | None = None,
+        _auth_source: _AuthSource | None = None,
+    ) -> None:
+        """Initialize with a static API key, or via :meth:`from_mcp_url` for OAuth.
+
+        Args:
+            api_key: Kagura API key (Bearer). Required unless ``_oauth`` is given.
+            base_url: REST API base URL (without path).
+            timeout: Request timeout in seconds.
+            _oauth: Private. ``from_mcp_url`` supplies a ``KaguraOAuth`` handler.
+            _auth_source: Private. Provenance tag from ``_resolve_auth``.
+
+        Raises:
+            ValueError: If neither ``api_key`` nor ``_oauth`` is provided.
+        """
+        if api_key is None and _oauth is None:
+            raise ValueError(
+                "SecretClient requires api_key, or use SecretClient.from_mcp_url(...) "
+                "to resolve credentials from environment, OAuth profile, or .kagura.json."
+            )
+
+        stripped_url = base_url.rstrip("/")
+        validate_https_url(stripped_url, label="Base URL")
+        self.base_url = stripped_url
+        self._oauth = _oauth
+        self._auth_source = _auth_source
+        if _oauth is not None:
+            self._client = httpx.AsyncClient(
+                timeout=timeout,
+                headers={"User-Agent": f"kagura-memory-sdk/{SDK_VERSION}"},
+                auth=_oauth,
+            )
+        else:
+            # ``api_key`` is baked into the header, not stored as an attribute
+            # (python.md: "Never store API keys as instance attributes").
+            self._client = httpx.AsyncClient(
+                timeout=timeout,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "User-Agent": f"kagura-memory-sdk/{SDK_VERSION}",
+                },
+            )
+
+    @classmethod
+    def from_mcp_url(
+        cls,
+        api_key: str | None = None,
+        mcp_url: str | None = None,
+        timeout: float = 30.0,
+        *,
+        profile: str | None = None,
+    ) -> SecretClient:
+        """Create a client by resolving credentials from the SDK auth chain.
+
+        Same precedence as the other REST clients: explicit ``api_key`` >
+        ``KAGURA_API_KEY`` > OAuth profile > ``.kagura.json``. The REST
+        ``base_url`` is derived from the resolved ``mcp_url``.
+        """
+        resolved = _resolve_auth(api_key=api_key, mcp_url=mcp_url, profile=profile)
+        return cls._from_resolved_auth(resolved, timeout=timeout)
+
+    @classmethod
+    def _from_resolved_auth(
+        cls,
+        resolved: _StaticAuth | _OAuthAuth,
+        *,
+        timeout: float = 30.0,
+    ) -> SecretClient:
+        """Construct from a pre-resolved auth — internal CLI helper."""
+        base_url = base_url_from_mcp(resolved.mcp_url.rstrip("/"))
+        if isinstance(resolved, _StaticAuth):
+            return cls(
+                api_key=resolved.api_key,
+                base_url=base_url,
+                timeout=timeout,
+                _auth_source=resolved.source,
+            )
+        return cls(
+            base_url=base_url,
+            timeout=timeout,
+            _oauth=resolved.oauth,
+            _auth_source="oauth",
+        )
+
+    async def _request(
+        self,
+        method: Literal["GET", "POST", "PATCH", "DELETE"],
+        path: str,
+        *,
+        json: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Make an HTTP request with standard Kagura error mapping."""
+        url = f"{self.base_url}{path}"
+        try:
+            response = await self._client.request(method, url, json=json, params=params)
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 401:
+                hint = (
+                    "Re-run `kagura auth login` or inspect ~/.kagura/credentials.json."
+                    if self._oauth is not None
+                    else "Check your API key."
+                )
+                raise KaguraAuthError(f"Authentication failed. {hint}") from e
+            if status == 404:
+                raise KaguraNotFoundError(extract_detail(e.response) or "Not found") from e
+            detail = extract_detail(e.response)
+            msg = f"HTTP {status}: {detail}" if detail else f"HTTP {status}"
+            raise KaguraConnectionError(msg) from e
+        except httpx.RequestError as e:
+            raise KaguraConnectionError(f"Connection failed: {_exc_message(e)}") from e
+
+    # -- pubkey registry -----------------------------------------------------
+
+    async def register_pubkey(self, pubkey: str, label: str | None = None) -> PubkeyResponse:
+        """Register a public age recipient (lands in ``pending`` until approved)."""
+        body: dict[str, Any] = {"pubkey": pubkey}
+        if label is not None:
+            body["label"] = label
+        response = await self._request("POST", f"{_BASE}/pubkeys", json=body)
+        return PubkeyResponse.model_validate(response.json())
+
+    async def list_pubkeys(self) -> list[PubkeyResponse]:
+        """List all pubkeys in the workspace (owner/admin view)."""
+        response = await self._request("GET", f"{_BASE}/pubkeys")
+        return [PubkeyResponse.model_validate(p) for p in response.json()]
+
+    async def list_my_pubkeys(self) -> list[PubkeyResponse]:
+        """List the caller's own pubkeys."""
+        response = await self._request("GET", f"{_BASE}/pubkeys/me")
+        return [PubkeyResponse.model_validate(p) for p in response.json()]
+
+    async def approve_pubkey(self, pubkey_id: str) -> PubkeyResponse:
+        """Approve a pending pubkey (owner only; TOFU attestation)."""
+        response = await self._request("POST", f"{_BASE}/pubkeys/{pubkey_id}/approve")
+        return PubkeyResponse.model_validate(response.json())
+
+    async def revoke_pubkey(self, pubkey_id: str) -> PubkeyResponse:
+        """Revoke a pubkey (owner only)."""
+        response = await self._request("POST", f"{_BASE}/pubkeys/{pubkey_id}/revoke")
+        return PubkeyResponse.model_validate(response.json())
+
+    # -- secrets -------------------------------------------------------------
+
+    async def put_secret(
+        self,
+        name: str,
+        ciphertext: str,
+        recipients_snapshot: list[str],
+        grant_pubkey_ids: list[str],
+    ) -> SecretPutResponse:
+        """Store a new ciphertext version (low-level).
+
+        The server enforces ``set(recipients_snapshot) ==
+        {fingerprint(pk) for pk in grant_pubkey_ids}`` and returns 400 on
+        mismatch. Prefer :meth:`put_secret_for_recipients`, which builds both
+        lists consistently from a recipient set.
+        """
+        body = {
+            "name": name,
+            "ciphertext": ciphertext,
+            "recipients_snapshot": recipients_snapshot,
+            "grant_pubkey_ids": grant_pubkey_ids,
+        }
+        response = await self._request("POST", _BASE, json=body)
+        return SecretPutResponse.model_validate(response.json())
+
+    async def list_secrets(self) -> list[SecretMetaResponse]:
+        """List secret metadata (never includes values)."""
+        response = await self._request("GET", _BASE)
+        return [SecretMetaResponse.model_validate(s) for s in response.json()]
+
+    async def fetch_secret(
+        self, name: str, version_number: int | None = None
+    ) -> SecretValueResponse:
+        """Fetch a secret's armored ciphertext (name carried in body for '/' names)."""
+        body: dict[str, Any] = {"name": name}
+        if version_number is not None:
+            body["version_number"] = version_number
+        response = await self._request("POST", f"{_BASE}/fetch", json=body)
+        return SecretValueResponse.model_validate(response.json())
+
+    async def revoke_grant(self, name: str, recipient_pubkey_id: str) -> SecretMetaResponse:
+        """Revoke one recipient's grant on a secret (flags ``rotation_needed``).
+
+        Note: revoke does NOT invalidate copies already fetched — follow with
+        :meth:`put_secret_for_recipients` (re-encrypt to the remaining
+        recipients) and rotate the upstream credential to truly contain a leak.
+        """
+        body = {"name": name, "recipient_pubkey_id": recipient_pubkey_id}
+        response = await self._request("POST", f"{_BASE}/revoke-grant", json=body)
+        return SecretMetaResponse.model_validate(response.json())
+
+    async def verify_audit(self) -> AuditVerifyResponse:
+        """Verify the tamper-evident audit chain (owner/admin)."""
+        response = await self._request("GET", f"{_BASE}/audit/verify")
+        return AuditVerifyResponse.model_validate(response.json())
+
+    # -- high-level orchestration -------------------------------------------
+
+    async def put_secret_for_recipients(
+        self,
+        name: str,
+        plaintext: bytes,
+        recipients: list[PubkeyResponse],
+    ) -> SecretPutResponse:
+        """Encrypt ``plaintext`` to ``recipients`` and store it in one call.
+
+        Enforces the server's grant-consistency invariant client-side (fail
+        fast, before the network): every recipient must be ``active`` and carry
+        a fingerprint matching its pubkey. ``recipients_snapshot`` and
+        ``grant_pubkey_ids`` are derived 1:1 from ``recipients`` so the sets
+        match by construction.
+
+        Raises:
+            KaguraSecretError: empty recipients, a non-active recipient, or a
+                pubkey whose advertised fingerprint != ``sha256(pubkey)``.
+        """
+        if not recipients:
+            raise KaguraSecretError("at least one recipient is required to put a secret")
+        for r in recipients:
+            if r.status != "active":
+                raise KaguraSecretError(
+                    f"recipient {r.pubkey} is not active (status={r.status!r}); "
+                    "grants require an owner-approved (active) pubkey"
+                )
+            if crypto.fingerprint(r.pubkey) != r.fingerprint:
+                raise KaguraSecretError(
+                    f"pubkey/fingerprint mismatch for recipient {r.id} — refusing to "
+                    "encrypt to a pubkey whose advertised fingerprint is inconsistent"
+                )
+        ciphertext = crypto.encrypt(plaintext, [r.pubkey for r in recipients])
+        return await self.put_secret(
+            name=name,
+            ciphertext=ciphertext,
+            recipients_snapshot=[r.fingerprint for r in recipients],
+            grant_pubkey_ids=[r.id for r in recipients],
+        )
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> SecretClient:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: Any,
+    ) -> None:
+        await self.close()

--- a/src/kagura_memory/secrets/crypto.py
+++ b/src/kagura_memory/secrets/crypto.py
@@ -1,0 +1,162 @@
+"""age (X25519) crypto primitives for the zero-knowledge secret client.
+
+All cryptography is delegated to the audited ``pyrage`` binding (Rust ``age``);
+the only thing this module implements itself is the RFC 7468 PEM *armor* codec
+(base64 + ``-----BEGIN AGE ENCRYPTED FILE-----`` framing), because ``pyrage``
+emits binary age files but the server contract (sdk#216 / memory-cloud#1128)
+stores **armored** ciphertext. Armoring is a transport encoding, not crypto.
+
+Contract invariants enforced here:
+
+- ``fingerprint(pubkey) == sha256_hex(pubkey)`` over the ``age1`` string.
+- recipients match :data:`RECIPIENT_RE` (``^age1[0-9a-z]{20,110}$``, plain X25519).
+- armored ciphertext is ``<=`` :data:`MAX_CIPHERTEXT_BYTES` (262144).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import re
+import textwrap
+from typing import Any
+
+import pyrage as _pyrage
+
+from ..exceptions import KaguraCryptoError
+
+# pyrage (the Rust `age` binding) ships incomplete type stubs that don't declare
+# its submodules (``x25519``) or error classes, so static checkers choke on
+# otherwise-correct attribute access. Treat the module as ``Any`` — runtime
+# behavior is unchanged; only type visibility is relaxed.
+pyrage: Any = _pyrage
+
+#: Plain X25519 age recipient (no plugin recipients in MVP). Anchored with
+#: ``\Z`` (not ``$``) so a trailing newline does NOT match — ``$`` matches just
+#: before a final ``\n``, which would let ``age1...\n`` slip past the validator.
+RECIPIENT_RE = re.compile(r"^age1[0-9a-z]{20,110}\Z")
+
+#: Server cap on stored ciphertext (256 KiB). ``blob_ref`` (R2) is future work.
+MAX_CIPHERTEXT_BYTES = 262144
+
+_ARMOR_BEGIN = "-----BEGIN AGE ENCRYPTED FILE-----"
+_ARMOR_END = "-----END AGE ENCRYPTED FILE-----"
+
+
+def generate_keypair() -> tuple[str, str]:
+    """Generate a fresh X25519 age keypair.
+
+    Returns:
+        ``(identity, recipient)`` where ``identity`` is the
+        ``AGE-SECRET-KEY-1...`` private key string (to be placed in custody by
+        :class:`~kagura_memory.secrets.keymanager.KeyManager`) and ``recipient``
+        is the public ``age1...`` string (registered with the server).
+    """
+    identity = pyrage.x25519.Identity.generate()
+    return str(identity), str(identity.to_public())
+
+
+def recipient_from_identity(identity: str) -> str:
+    """Derive the public ``age1`` recipient from an ``AGE-SECRET-KEY-1`` identity.
+
+    Raises:
+        KaguraCryptoError: if ``identity`` is not a valid age identity string.
+    """
+    try:
+        return str(pyrage.x25519.Identity.from_str(identity).to_public())
+    except pyrage.IdentityError as e:
+        raise KaguraCryptoError(f"invalid age identity: {e}") from e
+
+
+def fingerprint(pubkey: str) -> str:
+    """Return the server fingerprint: ``sha256`` hex of the recipient string.
+
+    Mirrors ``hashlib.sha256(pubkey.encode("utf-8")).hexdigest()`` exactly so a
+    locally computed value can be checked against ``PubkeyResponse.fingerprint``.
+    """
+    return hashlib.sha256(pubkey.encode("utf-8")).hexdigest()
+
+
+def armor_encode(binary: bytes) -> str:
+    """Wrap a binary age file in RFC 7468 PEM armor (64-column base64)."""
+    body = "\n".join(textwrap.wrap(base64.standard_b64encode(binary).decode("ascii"), 64))
+    return f"{_ARMOR_BEGIN}\n{body}\n{_ARMOR_END}\n"
+
+
+def armor_decode(armored: str) -> bytes:
+    """Reverse :func:`armor_encode`. Tolerant of CRLF and surrounding blanks.
+
+    Raises:
+        KaguraCryptoError: if the input is not a well-formed armored age file.
+    """
+    lines = [ln.strip() for ln in armored.strip().splitlines()]
+    if len(lines) < 2 or lines[0] != _ARMOR_BEGIN or lines[-1] != _ARMOR_END:
+        raise KaguraCryptoError("not an armored age file (missing PEM header/footer)")
+    try:
+        # b64decode (not standard_b64decode) so we can pass validate=True —
+        # non-base64 chars are then rejected, not silently discarded.
+        return base64.b64decode("".join(lines[1:-1]), validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise KaguraCryptoError(f"corrupt armored age body: {e}") from e
+
+
+def encrypt(plaintext: bytes, recipients: list[str]) -> str:
+    """Encrypt ``plaintext`` to one or more age recipients; return armored age.
+
+    Args:
+        plaintext: raw secret bytes.
+        recipients: public ``age1...`` strings (e.g. granted recipients).
+
+    Raises:
+        KaguraCryptoError: empty/malformed recipients, an ``age`` failure, or an
+            armored result exceeding :data:`MAX_CIPHERTEXT_BYTES`.
+    """
+    if not recipients:
+        raise KaguraCryptoError("at least one recipient is required to encrypt")
+    parsed = []
+    for r in recipients:
+        if not RECIPIENT_RE.match(r):
+            raise KaguraCryptoError(f"malformed age recipient: {r!r}")
+        try:
+            parsed.append(pyrage.x25519.Recipient.from_str(r))
+        except pyrage.RecipientError as e:
+            raise KaguraCryptoError(f"invalid age recipient {r!r}: {e}") from e
+
+    try:
+        binary = pyrage.encrypt(plaintext, parsed)
+    except pyrage.EncryptError as e:
+        raise KaguraCryptoError(f"age encryption failed: {e}") from e
+
+    armored = armor_encode(binary)
+    size = len(armored.encode("ascii"))
+    if size > MAX_CIPHERTEXT_BYTES:
+        raise KaguraCryptoError(
+            f"ciphertext is {size} bytes, exceeds the {MAX_CIPHERTEXT_BYTES}-byte cap"
+        )
+    return armored
+
+
+def decrypt(armored: str, identity: str) -> bytes:
+    """Decrypt an armored age ciphertext with an ``AGE-SECRET-KEY-1`` identity.
+
+    Raises:
+        KaguraCryptoError: input over the size cap, malformed armor, a bad
+            identity string, or a decrypt failure (wrong identity / corrupt
+            ciphertext).
+    """
+    # Inbound cap (symmetric with encrypt) so an oversized blob is rejected
+    # before it is fully base64-decoded into memory.
+    if len(armored) > MAX_CIPHERTEXT_BYTES:
+        raise KaguraCryptoError(
+            f"ciphertext is {len(armored)} bytes, exceeds the {MAX_CIPHERTEXT_BYTES}-byte cap"
+        )
+    binary = armor_decode(armored)
+    try:
+        ident = pyrage.x25519.Identity.from_str(identity)
+    except pyrage.IdentityError as e:
+        raise KaguraCryptoError(f"invalid age identity: {e}") from e
+    try:
+        return pyrage.decrypt(binary, [ident])
+    except pyrage.DecryptError as e:
+        raise KaguraCryptoError(f"age decryption failed: {e}") from e

--- a/src/kagura_memory/secrets/crypto.py
+++ b/src/kagura_memory/secrets/crypto.py
@@ -22,7 +22,7 @@ import re
 import textwrap
 from typing import Any
 
-import pyrage as _pyrage
+import pyrage as _pyrage  # type: ignore[import-not-found]
 
 from ..exceptions import KaguraCryptoError
 

--- a/src/kagura_memory/secrets/keymanager.py
+++ b/src/kagura_memory/secrets/keymanager.py
@@ -41,8 +41,8 @@ class KeyringStore:
     SERVICE = "kagura-secret"
 
     def get(self, name: str) -> str | None:
-        import keyring
-        import keyring.errors
+        import keyring  # type: ignore[import-not-found]
+        import keyring.errors  # type: ignore[import-not-found]
 
         try:
             return keyring.get_password(self.SERVICE, name)
@@ -52,9 +52,9 @@ class KeyringStore:
             raise KaguraKeyCustodyError(f"failed to read key from keychain: {e}") from e
 
     def set(self, name: str, value: str) -> None:
-        import keyring
-        import keyring.backends.fail
-        import keyring.errors
+        import keyring  # type: ignore[import-not-found]
+        import keyring.backends.fail  # type: ignore[import-not-found]
+        import keyring.errors  # type: ignore[import-not-found]
 
         if isinstance(keyring.get_keyring(), keyring.backends.fail.Keyring):
             raise KaguraKeyCustodyError(
@@ -68,8 +68,8 @@ class KeyringStore:
             raise KaguraKeyCustodyError(f"failed to store key in keychain: {e}") from e
 
     def delete(self, name: str) -> None:
-        import keyring
-        import keyring.errors
+        import keyring  # type: ignore[import-not-found]
+        import keyring.errors  # type: ignore[import-not-found]
 
         try:
             keyring.delete_password(self.SERVICE, name)

--- a/src/kagura_memory/secrets/keymanager.py
+++ b/src/kagura_memory/secrets/keymanager.py
@@ -108,7 +108,7 @@ class KeyManager:
         if self.has_key():
             raise KaguraKeyCustodyError(
                 f"a key already exists for profile {self._profile!r}; refusing to "
-                "overwrite. Use `kagura secret rotate` to roll, or delete first."
+                "overwrite it. Delete it first, or enroll under a different --profile."
             )
         identity, recipient = crypto.generate_keypair()
         self._store.set(self._key_name, identity)

--- a/src/kagura_memory/secrets/keymanager.py
+++ b/src/kagura_memory/secrets/keymanager.py
@@ -1,0 +1,141 @@
+"""age private-key custody (Issue #216).
+
+The age private key (``AGE-SECRET-KEY-1...``) is the root of trust for the
+zero-knowledge secret store: whoever holds it can decrypt every ciphertext ever
+shared with the matching recipient. It therefore lives in the **OS keychain**
+(``keyring``), never in a repo dotfile, and the SDK is **fail-closed** — if no
+secure keychain backend is available, enrollment refuses rather than silently
+falling back to a plaintext file on disk.
+
+Custody is abstracted behind the :class:`KeyStore` protocol so callers (and
+tests) can inject an alternative backend; the default is :class:`KeyringStore`.
+
+Note: a passphrase-encrypted file tier (``age -p`` / scrypt) for hosts without
+a keychain is a deliberate follow-on; the MVP is keychain-or-refuse.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..exceptions import KaguraKeyCustodyError
+from . import crypto
+
+
+class KeyStore(Protocol):
+    """Minimal secret-at-rest backend: get / set / delete a named string."""
+
+    def get(self, name: str) -> str | None: ...
+    def set(self, name: str, value: str) -> None: ...
+    def delete(self, name: str) -> None: ...
+
+
+class KeyringStore:
+    """:class:`KeyStore` backed by the OS keychain via ``keyring``.
+
+    Refuses to write when the active backend is the no-op ``fail`` keyring
+    (e.g. a headless Linux host with no Secret Service) — storing the private
+    key only to have ``keyring`` drop it would defeat custody.
+    """
+
+    SERVICE = "kagura-secret"
+
+    def get(self, name: str) -> str | None:
+        import keyring
+        import keyring.errors
+
+        try:
+            return keyring.get_password(self.SERVICE, name)
+        except keyring.errors.KeyringError as e:
+            # A locked / uninitialized keychain must surface as a custody error,
+            # not a bare keyring exception — same contract as set().
+            raise KaguraKeyCustodyError(f"failed to read key from keychain: {e}") from e
+
+    def set(self, name: str, value: str) -> None:
+        import keyring
+        import keyring.backends.fail
+        import keyring.errors
+
+        if isinstance(keyring.get_keyring(), keyring.backends.fail.Keyring):
+            raise KaguraKeyCustodyError(
+                "no OS keychain backend available; refusing to store the age "
+                "private key insecurely. Install a keyring backend (e.g. "
+                "Secret Service / libsecret on Linux) and retry."
+            )
+        try:
+            keyring.set_password(self.SERVICE, name, value)
+        except keyring.errors.KeyringError as e:
+            raise KaguraKeyCustodyError(f"failed to store key in keychain: {e}") from e
+
+    def delete(self, name: str) -> None:
+        import keyring
+        import keyring.errors
+
+        try:
+            keyring.delete_password(self.SERVICE, name)
+        except keyring.errors.PasswordDeleteError:
+            # Idempotent delete — absent key is success.
+            pass
+
+
+class KeyManager:
+    """Generate and custody the per-profile age keypair.
+
+    The private key never leaves the keychain; callers only ever receive the
+    public recipient and its fingerprint (for server registration and
+    out-of-band TOFU verification).
+    """
+
+    def __init__(self, *, profile: str = "default", store: KeyStore | None = None) -> None:
+        self._profile = profile
+        self._store: KeyStore = store if store is not None else KeyringStore()
+
+    @property
+    def _key_name(self) -> str:
+        return f"identity:{self._profile}"
+
+    def has_key(self) -> bool:
+        """True when a private key is already in custody for this profile."""
+        return self._store.get(self._key_name) is not None
+
+    def enroll(self) -> tuple[str, str]:
+        """Generate a keypair, store the private key, return ``(recipient, fingerprint)``.
+
+        Raises:
+            KaguraKeyCustodyError: if a key already exists for this profile
+                (refuses to overwrite) or no secure keychain is available.
+        """
+        if self.has_key():
+            raise KaguraKeyCustodyError(
+                f"a key already exists for profile {self._profile!r}; refusing to "
+                "overwrite. Use `kagura secret rotate` to roll, or delete first."
+            )
+        identity, recipient = crypto.generate_keypair()
+        self._store.set(self._key_name, identity)
+        return recipient, crypto.fingerprint(recipient)
+
+    def get_identity(self) -> str:
+        """Return the custodied private key.
+
+        Raises:
+            KaguraKeyCustodyError: if no key is enrolled for this profile.
+        """
+        identity = self._store.get(self._key_name)
+        if identity is None:
+            raise KaguraKeyCustodyError(
+                f"no age key in custody for profile {self._profile!r}; "
+                "run `kagura secret keygen` first."
+            )
+        return identity
+
+    def get_recipient(self) -> str:
+        """Return the public ``age1`` recipient derived from the custodied key."""
+        return crypto.recipient_from_identity(self.get_identity())
+
+    def fingerprint(self) -> str:
+        """Return the sha256 fingerprint of this profile's public recipient."""
+        return crypto.fingerprint(self.get_recipient())
+
+    def delete(self) -> None:
+        """Remove this profile's private key from custody (idempotent)."""
+        self._store.delete(self._key_name)

--- a/src/kagura_memory/secrets/models.py
+++ b/src/kagura_memory/secrets/models.py
@@ -1,0 +1,69 @@
+"""Pydantic models for the secret-store REST contract (memory-cloud v0.39.0).
+
+Field names mirror the server's OpenAPI schema for ``/api/v1/config/secrets``.
+These are pure data models (no crypto), so importing them does not require the
+``[secret]`` extra. ``status`` fields are kept as plain strings rather than
+enums so a future server-side status value does not break deserialization.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class PubkeyResponse(BaseModel):
+    """Recipient pubkey metadata (the pubkey is public; no private material)."""
+
+    id: str
+    identity_id: str
+    pubkey: str
+    fingerprint: str
+    label: str | None = None
+    status: str  # "pending" | "active" | "revoked"
+    created_at: str
+    attested_at: str | None = None
+    revoked_at: str | None = None
+
+
+class SecretPutResponse(BaseModel):
+    """Result of a put (store a new ciphertext version)."""
+
+    name: str
+    version_number: int
+    status: str
+    rotation_needed: bool
+
+
+class SecretMetaResponse(BaseModel):
+    """Secret metadata — never includes the value."""
+
+    name: str
+    status: str
+    rotation_needed: bool
+    current_version: int | None = None
+    grant_count: int
+    created_at: str
+    updated_at: str
+
+
+class SecretValueResponse(BaseModel):
+    """Opaque ciphertext returned to a granted caller. The server cannot read it."""
+
+    name: str
+    version_number: int
+    alg: str
+    ciphertext: str
+    blob_ref: str | None = None
+    recipients_snapshot: list[str]
+    rotation_needed: bool
+    created_at: str
+
+
+class AuditVerifyResponse(BaseModel):
+    """Tamper-evidence check over the secret-store audit chain."""
+
+    valid: bool
+    entries: int | None = None
+    head: str | None = None
+    broken_at: int | None = None
+    reason: str | None = None

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -17,7 +17,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PLUGIN_JSON = REPO_ROOT / ".claude-plugin" / "plugin.json"
 MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
-SKILLS = ["doctor", "auth", "setup", "ingest", "resource", "files"]
+SKILLS = ["doctor", "auth", "setup", "ingest", "resource", "files", "secret"]
 _SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
 
 

--- a/tests/test_secrets_cli.py
+++ b/tests/test_secrets_cli.py
@@ -1,0 +1,539 @@
+"""Tests for the `kagura secret` CLI subgroup.
+
+Focus: the security-critical DX guards (get's TTY refusal, put-from-stdin,
+keygen never printing the private key, revoke's rotate warning, exec's env
+injection without mutating os.environ) plus a representative happy path per
+command. Network and keychain are replaced via the module's testable seams
+(`_get_secret_client`, `_make_key_manager`, `_stdout_isatty`, `_exec_child`).
+"""
+
+import os
+import uuid
+
+import pytest
+from click.testing import CliRunner
+
+from kagura_memory.exceptions import KaguraCryptoError, KaguraKeyCustodyError
+from kagura_memory.secrets import cli as secret_cli
+from kagura_memory.secrets import crypto
+from kagura_memory.secrets.cli import secret
+from kagura_memory.secrets.keymanager import KeyManager
+from kagura_memory.secrets.models import (
+    AuditVerifyResponse,
+    PubkeyResponse,
+    SecretMetaResponse,
+    SecretPutResponse,
+    SecretValueResponse,
+)
+
+
+class _FakeStore:
+    def __init__(self):
+        self.data: dict[str, str] = {}
+
+    def get(self, name):
+        return self.data.get(name)
+
+    def set(self, name, value):
+        self.data[name] = value
+
+    def delete(self, name):
+        self.data.pop(name, None)
+
+
+class _UnavailableStore(_FakeStore):
+    """Simulates a host with no usable keychain (fail-closed)."""
+
+    def set(self, name, value):
+        raise KaguraKeyCustodyError("no secure keychain available")
+
+
+class FakeSecretClient:
+    """Async-context-manager stand-in for SecretClient."""
+
+    def __init__(self):
+        self.pubkeys: list[PubkeyResponse] = []
+        self.value: SecretValueResponse | None = None
+        self.audit = AuditVerifyResponse(valid=True, entries=3, head="abc")
+        self.secrets: list[SecretMetaResponse] = []
+        self.calls: dict = {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def register_pubkey(self, pubkey, label=None):
+        self.calls["register"] = (pubkey, label)
+        return PubkeyResponse(
+            id=str(uuid.uuid4()),
+            identity_id=str(uuid.uuid4()),
+            pubkey=pubkey,
+            fingerprint=crypto.fingerprint(pubkey),
+            label=label,
+            status="pending",
+            created_at="t",
+        )
+
+    async def approve_pubkey(self, pubkey_id):
+        self.calls["approve"] = pubkey_id
+        pub = self.pubkeys[0].pubkey if self.pubkeys else "age1x"
+        return PubkeyResponse(
+            id=pubkey_id,
+            identity_id="i",
+            pubkey=pub,
+            fingerprint=crypto.fingerprint(pub),
+            label=None,
+            status="active",
+            created_at="t",
+        )
+
+    async def list_pubkeys(self):
+        return self.pubkeys
+
+    async def list_my_pubkeys(self):
+        return self.pubkeys
+
+    async def fetch_secret(self, name, version_number=None):
+        self.calls["fetch"] = (name, version_number)
+        return self.value
+
+    async def put_secret_for_recipients(self, name, plaintext, recipients):
+        self.calls["put"] = (name, plaintext, recipients)
+        return SecretPutResponse(
+            name=name, version_number=1, status="active", rotation_needed=False
+        )
+
+    async def revoke_grant(self, name, recipient_pubkey_id):
+        self.calls["revoke"] = (name, recipient_pubkey_id)
+        return SecretMetaResponse(
+            name=name,
+            status="active",
+            rotation_needed=True,
+            current_version=2,
+            grant_count=1,
+            created_at="t",
+            updated_at="t",
+        )
+
+    async def verify_audit(self):
+        return self.audit
+
+    async def list_secrets(self):
+        return self.secrets
+
+
+@pytest.fixture
+def km():
+    """A real KeyManager with an in-memory store, enrolled."""
+    manager = KeyManager(profile="default", store=_FakeStore())
+    manager.enroll()
+    return manager
+
+
+@pytest.fixture
+def wired(monkeypatch, km):
+    """Wire the CLI seams to a FakeSecretClient + the enrolled km."""
+    fake = FakeSecretClient()
+    monkeypatch.setattr(secret_cli, "_get_secret_client", lambda: fake)
+    monkeypatch.setattr(secret_cli, "_make_key_manager", lambda profile="default": km)
+    return fake, km
+
+
+def _active_pubkey(recipient: str) -> PubkeyResponse:
+    return PubkeyResponse(
+        id=str(uuid.uuid4()),
+        identity_id="i",
+        pubkey=recipient,
+        fingerprint=crypto.fingerprint(recipient),
+        label="laptop",
+        status="active",
+        created_at="t",
+    )
+
+
+# --- keygen -----------------------------------------------------------------
+
+
+def test_keygen_never_prints_private_key(monkeypatch):
+    fake = FakeSecretClient()
+    monkeypatch.setattr(secret_cli, "_get_secret_client", lambda: fake)
+    monkeypatch.setattr(
+        secret_cli,
+        "_make_key_manager",
+        lambda profile="default": KeyManager(profile=profile, store=_FakeStore()),
+    )
+    result = CliRunner().invoke(secret, ["keygen", "--label", "laptop"])
+    assert result.exit_code == 0, result.output
+    assert "AGE-SECRET-KEY" not in result.output  # private key never leaks
+    assert "age1" in result.output  # public recipient shown
+    assert "Fingerprint" in result.output
+    assert fake.calls["register"][1] == "laptop"  # registered with label
+
+
+def test_keygen_no_register_skips_server(monkeypatch):
+    fake = FakeSecretClient()
+    monkeypatch.setattr(secret_cli, "_get_secret_client", lambda: fake)
+    monkeypatch.setattr(
+        secret_cli,
+        "_make_key_manager",
+        lambda profile="default": KeyManager(profile=profile, store=_FakeStore()),
+    )
+    result = CliRunner().invoke(secret, ["keygen", "--no-register"])
+    assert result.exit_code == 0, result.output
+    assert "AGE-SECRET-KEY" not in result.output
+    assert "register" not in fake.calls  # never hit the server
+
+
+def test_keygen_is_idempotent_reuses_existing_key(monkeypatch):
+    """If a key is already custodied, keygen reuses it and re-registers (recoverable)."""
+    fake = FakeSecretClient()
+    km = KeyManager(profile="default", store=_FakeStore())
+    recipient, _ = km.enroll()
+    monkeypatch.setattr(secret_cli, "_get_secret_client", lambda: fake)
+    monkeypatch.setattr(secret_cli, "_make_key_manager", lambda profile="default": km)
+    result = CliRunner().invoke(secret, ["keygen"])
+    assert result.exit_code == 0, result.output
+    assert fake.calls["register"][0] == recipient  # re-registered the SAME key
+    assert km.get_recipient() == recipient  # key unchanged (not regenerated)
+
+
+# --- get: the centerpiece DX guard -----------------------------------------
+
+
+def test_get_refuses_to_print_to_tty(monkeypatch, wired):
+    monkeypatch.setattr(secret_cli, "_stdout_isatty", lambda: True)
+    result = CliRunner().invoke(secret, ["get", "db"])
+    assert result.exit_code != 0
+    assert "refusing" in result.output.lower()
+
+
+def test_get_pipes_plaintext_without_trailing_newline(monkeypatch, wired):
+    fake, km = wired
+    monkeypatch.setattr(secret_cli, "_stdout_isatty", lambda: False)
+    armored = crypto.encrypt(b"hunter2", [km.get_recipient()])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["get", "db"])
+    assert result.exit_code == 0, result.output
+    assert result.output == "hunter2"  # exact, no trailing newline
+
+
+def test_get_reveal_bypasses_tty_guard(monkeypatch, wired):
+    fake, km = wired
+    monkeypatch.setattr(secret_cli, "_stdout_isatty", lambda: True)
+    armored = crypto.encrypt(b"shown", [km.get_recipient()])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["get", "db", "--reveal"])
+    assert result.exit_code == 0, result.output
+    assert "shown" in result.output
+
+
+def test_get_writes_file_0600(monkeypatch, wired, tmp_path):
+    fake, km = wired
+    monkeypatch.setattr(secret_cli, "_stdout_isatty", lambda: True)  # would refuse, but -o given
+    armored = crypto.encrypt(b"filesecret", [km.get_recipient()])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    out = tmp_path / "secret.key"
+    result = CliRunner().invoke(secret, ["get", "db", "-o", str(out)])
+    assert result.exit_code == 0, result.output
+    assert out.read_bytes() == b"filesecret"
+
+
+def test_get_pins_version(monkeypatch, wired):
+    fake, km = wired
+    monkeypatch.setattr(secret_cli, "_stdout_isatty", lambda: False)
+    armored = crypto.encrypt(b"v5data", [km.get_recipient()])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=5,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["get", "db", "--version", "5"])
+    assert result.exit_code == 0, result.output
+    assert fake.calls["fetch"] == ("db", 5)
+
+
+# --- put --------------------------------------------------------------------
+
+
+def test_put_reads_stdin_and_encrypts(monkeypatch, wired):
+    fake, km = wired
+    fake.pubkeys = [_active_pubkey(km.get_recipient())]
+    result = CliRunner().invoke(secret, ["put", "db"], input="hunter2\n")
+    assert result.exit_code == 0, result.output
+    name, plaintext, recipients = fake.calls["put"]
+    assert name == "db"
+    assert plaintext == b"hunter2"  # one trailing newline stripped
+    assert len(recipients) == 1
+
+
+def test_put_has_no_value_option():
+    """A secret value must never be passable via argv."""
+    result = CliRunner().invoke(secret, ["put", "db", "--value", "leak"])
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()
+
+
+def test_put_with_explicit_to(wired):
+    fake, km = wired
+    _, r2 = crypto.generate_keypair()
+    pk2 = _active_pubkey(r2)
+    fake.pubkeys = [_active_pubkey(km.get_recipient()), pk2]
+    result = CliRunner().invoke(secret, ["put", "db", "--to", pk2.id], input="v\n")
+    assert result.exit_code == 0, result.output
+    _, _, recipients = fake.calls["put"]
+    assert [r.id for r in recipients] == [pk2.id]
+
+
+def test_put_rejects_unknown_recipient(wired):
+    fake, km = wired
+    fake.pubkeys = [_active_pubkey(km.get_recipient())]
+    result = CliRunner().invoke(secret, ["put", "db", "--to", "nope"], input="v\n")
+    assert result.exit_code != 0
+    assert "not an active recipient" in result.output.lower()
+
+
+# --- revoke: the rotate warning ---------------------------------------------
+
+
+def test_revoke_warns_revoke_is_not_invalidation(wired):
+    fake, _ = wired
+    pk_id = str(uuid.uuid4())
+    result = CliRunner().invoke(secret, ["revoke", "db", "--to", pk_id])
+    assert result.exit_code == 0, result.output
+    assert fake.calls["revoke"] == ("db", pk_id)
+    low = result.output.lower()
+    assert "rotate" in low
+    assert "not" in low and "invalidate" in low
+
+
+# --- exec: env injection without mutating os.environ ------------------------
+
+
+def test_exec_injects_env_and_does_not_touch_os_environ(monkeypatch, wired):
+    fake, km = wired
+    armored = crypto.encrypt(b"db-pass", [km.get_recipient()])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    captured = {}
+
+    def fake_exec(argv, env):
+        captured["argv"] = argv
+        captured["env"] = env
+
+    monkeypatch.setattr(secret_cli, "_exec_child", fake_exec)
+    assert "DBPASS" not in os.environ
+    result = CliRunner().invoke(secret, ["exec", "--as", "DBPASS=db", "--", "myserver", "--flag"])
+    assert result.exit_code == 0, result.output
+    assert captured["argv"] == ["myserver", "--flag"]
+    assert captured["env"]["DBPASS"] == "db-pass"
+    assert "DBPASS" not in os.environ  # parent env untouched
+
+
+# --- approve / list / pubkeys / audit-verify --------------------------------
+
+
+def test_pubkeys_lists_active(wired):
+    fake, km = wired
+    fake.pubkeys = [_active_pubkey(km.get_recipient())]
+    result = CliRunner().invoke(secret, ["pubkeys"])
+    assert result.exit_code == 0, result.output
+    assert "active" in result.output
+
+
+def test_exec_rejects_malformed_as_spec(wired):
+    result = CliRunner().invoke(secret, ["exec", "--as", "BROKEN", "--", "cmd"])
+    assert result.exit_code != 0
+    assert "ENV_NAME=secret_name" in result.output
+
+
+def test_approve_shows_fingerprint_and_tofu_note(wired):
+    fake, _ = wired
+    fake.pubkeys = [_active_pubkey("age1qqqqqqqqqqqqqqqqqqqqqqqqqqqq")]
+    pk_id = str(uuid.uuid4())
+    result = CliRunner().invoke(secret, ["approve", pk_id])
+    assert result.exit_code == 0, result.output
+    assert fake.calls["approve"] == pk_id
+    assert "fingerprint" in result.output.lower()
+    assert "verify" in result.output.lower()  # TOFU prompt
+
+
+def test_audit_verify_reports_valid(wired):
+    result = CliRunner().invoke(secret, ["audit-verify"])
+    assert result.exit_code == 0, result.output
+    assert "valid" in result.output.lower()
+
+
+def test_audit_verify_fails_on_broken_chain(monkeypatch, wired):
+    fake, _ = wired
+    fake.audit = AuditVerifyResponse(valid=False, broken_at=7, reason="hash mismatch")
+    result = CliRunner().invoke(secret, ["audit-verify"])
+    assert result.exit_code != 0
+    assert "broken" in result.output.lower() or "7" in result.output
+
+
+def test_list_secrets(wired):
+    fake, _ = wired
+    fake.secrets = [
+        SecretMetaResponse(
+            name="db",
+            status="active",
+            rotation_needed=True,
+            current_version=2,
+            grant_count=3,
+            created_at="t",
+            updated_at="t",
+        )
+    ]
+    result = CliRunner().invoke(secret, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "db" in result.output
+
+
+# --- rotate -----------------------------------------------------------------
+
+
+def test_grant_adds_recipient_and_reencrypts(wired):
+    fake, km = wired
+    r1 = km.get_recipient()
+    _, r2 = crypto.generate_keypair()
+    pk1 = _active_pubkey(r1)
+    pk2 = _active_pubkey(r2)
+    fake.pubkeys = [pk1, pk2]
+    old = crypto.encrypt(b"old-value", [r1])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=old,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["grant", "db", "--to", pk2.id])
+    assert result.exit_code == 0, result.output
+    _, plaintext, recipients = fake.calls["put"]
+    assert plaintext == b"old-value"  # decrypted with own key, then re-encrypted
+    assert {r.id for r in recipients} == {pk1.id, pk2.id}
+
+
+def test_rotate_reencrypts_to_remaining_recipients(monkeypatch, wired):
+    fake, km = wired
+    recipient = km.get_recipient()
+    fake.pubkeys = [_active_pubkey(recipient)]
+    old = crypto.encrypt(b"old", [recipient])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=old,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=True,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["rotate", "db"], input="newsecret\n")
+    assert result.exit_code == 0, result.output
+    name, plaintext, recipients = fake.calls["put"]
+    assert plaintext == b"newsecret"
+    assert len(recipients) == 1
+
+
+# --- error mapping: SDK errors must surface as clean ClickExceptions --------
+
+
+def test_exec_non_utf8_secret_is_clean_error_no_leak(monkeypatch, wired):
+    """A non-UTF-8 secret must NOT leak via a raw UnicodeDecodeError traceback."""
+    fake, km = wired
+    armored = crypto.encrypt(b"\xff\xfe\x00binary", [km.get_recipient()])
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    monkeypatch.setattr(secret_cli, "_exec_child", lambda argv, env: None)
+    result = CliRunner().invoke(secret, ["exec", "--as", "TOKEN=db", "--", "cmd"])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, UnicodeDecodeError)  # mapped, not raw
+    assert "utf-8" in result.output.lower()  # value-free explanation
+
+
+def test_get_undecryptable_is_clean_error(monkeypatch, wired):
+    fake, km = wired
+    monkeypatch.setattr(secret_cli, "_stdout_isatty", lambda: False)
+    _, other = crypto.generate_keypair()
+    armored = crypto.encrypt(b"x", [other])  # NOT encrypted to km's key
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=armored,
+        blob_ref=None,
+        recipients_snapshot=[crypto.fingerprint(other)],
+        rotation_needed=False,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["get", "db"])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, KaguraCryptoError)  # mapped to ClickException
+
+
+def test_keygen_no_keychain_is_clean_error(monkeypatch):
+    fake = FakeSecretClient()
+    monkeypatch.setattr(secret_cli, "_get_secret_client", lambda: fake)
+    monkeypatch.setattr(
+        secret_cli,
+        "_make_key_manager",
+        lambda profile="default": KeyManager(profile=profile, store=_UnavailableStore()),
+    )
+    result = CliRunner().invoke(secret, ["keygen"])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, KaguraKeyCustodyError)  # mapped, no traceback
+    assert "keychain" in result.output.lower()

--- a/tests/test_secrets_cli.py
+++ b/tests/test_secrets_cli.py
@@ -8,8 +8,10 @@ command. Network and keychain are replaced via the module's testable seams
 """
 
 import os
+import subprocess
 import uuid
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -537,3 +539,91 @@ def test_keygen_no_keychain_is_clean_error(monkeypatch):
     assert result.exit_code != 0
     assert not isinstance(result.exception, KaguraKeyCustodyError)  # mapped, no traceback
     assert "keychain" in result.output.lower()
+
+
+def test_put_value_read_error_is_clean_error(monkeypatch, wired):
+    def boom(_from_file):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(secret_cli, "_read_secret_value", boom)
+    result = CliRunner().invoke(secret, ["put", "db"])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, OSError)  # mapped to ClickException, no traceback
+
+
+def test_rotate_value_read_error_is_clean_error(monkeypatch, wired):
+    def boom(_from_file):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(secret_cli, "_read_secret_value", boom)
+    result = CliRunner().invoke(secret, ["rotate", "db"])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, OSError)
+
+
+# --- coverage: helpers, exec_child branches, empty-list paths ----------------
+
+
+def test_exec_child_requires_a_command():
+    with pytest.raises(click.ClickException):
+        secret_cli._exec_child([], {"A": "b"})
+
+
+def test_exec_child_posix_replaces_process(monkeypatch):
+    monkeypatch.setattr(os, "name", "posix")
+    captured = {}
+    monkeypatch.setattr(
+        os, "execvpe", lambda file, argv, env: captured.update(file=file, argv=argv, env=env)
+    )
+    secret_cli._exec_child(["echo", "hi"], {"A": "b"})
+    assert captured == {"file": "echo", "argv": ["echo", "hi"], "env": {"A": "b"}}
+
+
+def test_exec_child_windows_runs_subprocess(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+
+    class _Completed:
+        returncode = 3
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Completed())
+    with pytest.raises(SystemExit) as exc:
+        secret_cli._exec_child(["cmd"], {"A": "b"})
+    assert exc.value.code == 3
+
+
+def test_read_secret_value_from_file_is_verbatim(tmp_path):
+    f = tmp_path / "s.txt"
+    f.write_bytes(b"file-value\n")  # trailing newline preserved for file input
+    assert secret_cli._read_secret_value(str(f)) == b"file-value\n"
+
+
+def test_read_secret_value_prompts_on_tty(monkeypatch):
+    import getpass
+
+    monkeypatch.setattr(secret_cli, "_stdin_isatty", lambda: True)
+    monkeypatch.setattr(getpass, "getpass", lambda prompt="": "typed-secret")
+    assert secret_cli._read_secret_value(None) == b"typed-secret"
+
+
+def test_pubkeys_empty(wired):
+    fake, _ = wired
+    fake.pubkeys = []
+    result = CliRunner().invoke(secret, ["pubkeys"])
+    assert result.exit_code == 0, result.output
+    assert "no pubkeys" in result.output.lower()
+
+
+def test_pubkeys_mine(wired):
+    fake, km = wired
+    fake.pubkeys = [_active_pubkey(km.get_recipient())]
+    result = CliRunner().invoke(secret, ["pubkeys", "--mine"])
+    assert result.exit_code == 0, result.output
+    assert "active" in result.output
+
+
+def test_list_empty(wired):
+    fake, _ = wired
+    fake.secrets = []
+    result = CliRunner().invoke(secret, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "no secrets" in result.output.lower()

--- a/tests/test_secrets_cli.py
+++ b/tests/test_secrets_cli.py
@@ -770,3 +770,37 @@ def test_rotate_no_active_recipients(wired):
     result = CliRunner().invoke(secret, ["rotate", "db"], input="newval\n")
     assert result.exit_code != 0
     assert "no active recipients" in result.output.lower()
+
+
+# --- main CLI: secret-group registration / [secret]-extra fallback ----------
+
+
+def test_register_secret_command_adds_group_when_importable():
+    from kagura_memory import cli as main_cli
+
+    grp = click.Group()
+    main_cli._register_secret_command(grp, import_secret=lambda: click.Command("secret"))
+    assert "secret" in grp.commands
+
+
+def test_register_secret_command_stub_when_extra_missing():
+    from kagura_memory import cli as main_cli
+
+    def missing() -> click.Command:
+        raise ModuleNotFoundError("No module named 'pyrage'", name="pyrage")
+
+    grp = click.Group()
+    main_cli._register_secret_command(grp, import_secret=missing)
+    result = CliRunner().invoke(grp, ["secret", "whatever"])
+    assert result.exit_code != 0
+    assert "[secret]" in result.output
+
+
+def test_register_secret_command_reraises_unrelated_import_error():
+    from kagura_memory import cli as main_cli
+
+    def boom() -> click.Command:
+        raise ModuleNotFoundError("No module named 'numpy'", name="numpy")
+
+    with pytest.raises(ModuleNotFoundError):
+        main_cli._register_secret_command(click.Group(), import_secret=boom)

--- a/tests/test_secrets_cli.py
+++ b/tests/test_secrets_cli.py
@@ -7,15 +7,21 @@ command. Network and keychain are replaced via the module's testable seams
 (`_get_secret_client`, `_make_key_manager`, `_stdout_isatty`, `_exec_child`).
 """
 
+import io
 import os
 import subprocess
+import sys
 import uuid
 
 import click
 import pytest
 from click.testing import CliRunner
 
-from kagura_memory.exceptions import KaguraCryptoError, KaguraKeyCustodyError
+from kagura_memory.exceptions import (
+    KaguraAuthError,
+    KaguraCryptoError,
+    KaguraKeyCustodyError,
+)
 from kagura_memory.secrets import cli as secret_cli
 from kagura_memory.secrets import crypto
 from kagura_memory.secrets.cli import secret
@@ -627,3 +633,140 @@ def test_list_empty(wired):
     result = CliRunner().invoke(secret, ["list"])
     assert result.exit_code == 0, result.output
     assert "no secrets" in result.output.lower()
+
+
+# --- coverage: module seams, platform branches, error paths -----------------
+
+
+def test_make_key_manager_returns_keymanager():
+    assert isinstance(secret_cli._make_key_manager("p"), KeyManager)
+
+
+def test_stdout_isatty_returns_bool():
+    assert isinstance(secret_cli._stdout_isatty(), bool)
+
+
+def test_get_secret_client_builds_from_resolved_auth(monkeypatch):
+    from kagura_memory._auth import _StaticAuth
+
+    monkeypatch.setattr(secret_cli, "load_config", lambda: {})
+    monkeypatch.setattr(
+        secret_cli,
+        "_resolve_auth",
+        lambda **_kw: _StaticAuth(
+            api_key="k", mcp_url="https://memory.kagura-ai.com/mcp", source="env"
+        ),
+    )
+    client = secret_cli._get_secret_client()
+    assert client.base_url == "https://memory.kagura-ai.com"
+
+
+def test_get_secret_client_maps_auth_error(monkeypatch):
+    def boom(**_kw):
+        raise KaguraAuthError("no credentials")
+
+    monkeypatch.setattr(secret_cli, "load_config", lambda: {})
+    monkeypatch.setattr(secret_cli, "_resolve_auth", boom)
+    with pytest.raises(click.ClickException):
+        secret_cli._get_secret_client()
+
+
+def test_disable_core_dumps_noop_on_win32(monkeypatch):
+    monkeypatch.setattr(secret_cli.sys, "platform", "win32")
+    secret_cli._disable_core_dumps()  # returns early, no error
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="resource module is POSIX-only")
+def test_disable_core_dumps_swallows_setrlimit_error(monkeypatch):
+    import resource
+
+    monkeypatch.setattr(secret_cli.sys, "platform", "linux")
+
+    def boom(*_a, **_k):
+        raise OSError("cannot lower limit")
+
+    monkeypatch.setattr(resource, "setrlimit", boom)
+    secret_cli._disable_core_dumps()  # swallowed, no error
+
+
+def test_read_secret_value_strips_crlf(monkeypatch):
+    monkeypatch.setattr(secret_cli, "_stdin_isatty", lambda: False)
+    monkeypatch.setattr(
+        secret_cli.click, "get_binary_stream", lambda _name: io.BytesIO(b"secret\r\n")
+    )
+    assert secret_cli._read_secret_value(None) == b"secret"
+
+
+def test_read_secret_value_no_trailing_newline(monkeypatch):
+    monkeypatch.setattr(secret_cli, "_stdin_isatty", lambda: False)
+    monkeypatch.setattr(secret_cli.click, "get_binary_stream", lambda _name: io.BytesIO(b"secret"))
+    assert secret_cli._read_secret_value(None) == b"secret"
+
+
+def test_write_secret_file_cleans_up_temp_on_failure(monkeypatch, tmp_path):
+    def boom(*_a, **_k):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        secret_cli._write_secret_file(tmp_path / "x", b"data")
+    assert not list(tmp_path.glob(".x.*"))  # temp file cleaned up
+
+
+def test_write_secret_file_survives_dir_fsync_failure(monkeypatch, tmp_path):
+    real_open = os.open
+
+    def fake_open(path, flags, *a, **k):
+        if flags == os.O_RDONLY:  # the parent-dir fsync open
+            raise OSError("no dir fsync")
+        return real_open(path, flags, *a, **k)
+
+    monkeypatch.setattr(os, "open", fake_open)
+    out = tmp_path / "x"
+    secret_cli._write_secret_file(out, b"data")
+    assert out.read_bytes() == b"data"
+
+
+def test_put_no_active_recipient_for_self(wired):
+    fake, _ = wired
+    fake.pubkeys = []  # caller's key is not registered/active
+    result = CliRunner().invoke(secret, ["put", "db"], input="v\n")
+    assert result.exit_code != 0
+    assert "no active recipient" in result.output.lower()
+
+
+def test_grant_unknown_recipient(wired):
+    fake, km = wired
+    r1 = km.get_recipient()
+    fake.pubkeys = [_active_pubkey(r1)]
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=crypto.encrypt(b"v", [r1]),
+        blob_ref=None,
+        recipients_snapshot=[km.fingerprint()],
+        rotation_needed=False,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["grant", "db", "--to", "missing-id"])
+    assert result.exit_code != 0
+    assert "not an active recipient" in result.output.lower()
+
+
+def test_rotate_no_active_recipients(wired):
+    fake, km = wired
+    fake.pubkeys = []  # nobody active
+    fake.value = SecretValueResponse(
+        name="db",
+        version_number=1,
+        alg="age",
+        ciphertext=crypto.encrypt(b"v", [km.get_recipient()]),
+        blob_ref=None,
+        recipients_snapshot=["stale-fp"],
+        rotation_needed=True,
+        created_at="t",
+    )
+    result = CliRunner().invoke(secret, ["rotate", "db"], input="newval\n")
+    assert result.exit_code != 0
+    assert "no active recipients" in result.output.lower()

--- a/tests/test_secrets_client.py
+++ b/tests/test_secrets_client.py
@@ -1,0 +1,381 @@
+"""Tests for kagura_memory.secrets.client.SecretClient (REST wire layer).
+
+Schema mirrors the live memory-cloud OpenAPI (v0.39.0) for
+``/api/v1/config/secrets``. HTTP is mocked at ``client._client.request``,
+following the ResourceClient test convention.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from kagura_memory.exceptions import (
+    KaguraAuthError,
+    KaguraNotFoundError,
+    KaguraSecretError,
+)
+from kagura_memory.secrets import crypto
+from kagura_memory.secrets.client import SecretClient
+from kagura_memory.secrets.models import (
+    PubkeyResponse,
+    SecretMetaResponse,
+    SecretPutResponse,
+    SecretValueResponse,
+)
+
+
+def _mock_response(status_code: int = 200, json_data=None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = {} if json_data is None else json_data
+    response.raise_for_status = MagicMock()
+    response.headers = {}
+    return response
+
+
+def _error_response(status_code: int, detail: str = "boom") -> MagicMock:
+    response = _mock_response(status_code, {"detail": detail})
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "error",
+        request=httpx.Request("POST", "https://test.com/x"),
+        response=response,
+    )
+    return response
+
+
+def _pubkey_json(pubkey: str, *, status: str = "active", pk_id: str | None = None) -> dict:
+    return {
+        "id": pk_id or str(uuid.uuid4()),
+        "identity_id": str(uuid.uuid4()),
+        "pubkey": pubkey,
+        "fingerprint": crypto.fingerprint(pubkey),
+        "label": "laptop",
+        "status": status,
+        "created_at": "2026-06-29T00:00:00Z",
+        "attested_at": None,
+        "revoked_at": None,
+    }
+
+
+def _client() -> SecretClient:
+    return SecretClient(api_key="test", base_url="https://test.com")
+
+
+# --- construction parity ----------------------------------------------------
+
+
+def test_rejects_http_url():
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        SecretClient(api_key="t", base_url="http://evil.com")
+
+
+def test_api_key_not_on_instance():
+    client = _client()
+    assert not hasattr(client, "api_key")
+
+
+def test_from_mcp_url_strips_mcp_suffix():
+    client = SecretClient.from_mcp_url(api_key="t", mcp_url="https://memory.kagura-ai.com/mcp")
+    assert client.base_url == "https://memory.kagura-ai.com"
+
+
+# --- pubkey endpoints -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_pubkey():
+    client = _client()
+    _, recipient = crypto.generate_keypair()
+    resp = _mock_response(201, _pubkey_json(recipient, status="pending"))
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.register_pubkey(recipient, label="laptop")
+    assert isinstance(result, PubkeyResponse)
+    assert result.pubkey == recipient
+    method, url = req.call_args[0][0], req.call_args[0][1]
+    assert method == "POST"
+    assert url.endswith("/api/v1/config/secrets/pubkeys")
+    assert req.call_args.kwargs["json"] == {"pubkey": recipient, "label": "laptop"}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_pubkeys_returns_list():
+    client = _client()
+    _, r1 = crypto.generate_keypair()
+    _, r2 = crypto.generate_keypair()
+    resp = _mock_response(200, [_pubkey_json(r1), _pubkey_json(r2, status="pending")])
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.list_pubkeys()
+    assert [p.pubkey for p in result] == [r1, r2]
+    assert req.call_args[0][1].endswith("/api/v1/config/secrets/pubkeys")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_my_pubkeys_hits_me_endpoint():
+    client = _client()
+    _, r1 = crypto.generate_keypair()
+    resp = _mock_response(200, [_pubkey_json(r1)])
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        await client.list_my_pubkeys()
+    assert req.call_args[0][1].endswith("/api/v1/config/secrets/pubkeys/me")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_approve_pubkey():
+    client = _client()
+    _, r1 = crypto.generate_keypair()
+    pk_id = str(uuid.uuid4())
+    resp = _mock_response(200, _pubkey_json(r1, pk_id=pk_id))
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.approve_pubkey(pk_id)
+    assert result.id == pk_id
+    method, url = req.call_args[0][0], req.call_args[0][1]
+    assert method == "POST"
+    assert url.endswith(f"/api/v1/config/secrets/pubkeys/{pk_id}/approve")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_revoke_pubkey():
+    client = _client()
+    _, r1 = crypto.generate_keypair()
+    pk_id = str(uuid.uuid4())
+    resp = _mock_response(200, _pubkey_json(r1, status="revoked", pk_id=pk_id))
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        await client.revoke_pubkey(pk_id)
+    assert req.call_args[0][1].endswith(f"/api/v1/config/secrets/pubkeys/{pk_id}/revoke")
+    await client.close()
+
+
+# --- secret endpoints -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_secret_sends_contract_body():
+    client = _client()
+    ids = [str(uuid.uuid4())]
+    resp = _mock_response(
+        201, {"name": "db", "version_number": 1, "status": "active", "rotation_needed": False}
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.put_secret(
+            name="db",
+            ciphertext="-----BEGIN AGE ENCRYPTED FILE-----\nx\n-----END AGE ENCRYPTED FILE-----\n",
+            recipients_snapshot=["fp1"],
+            grant_pubkey_ids=ids,
+        )
+    assert isinstance(result, SecretPutResponse)
+    assert result.version_number == 1
+    body = req.call_args.kwargs["json"]
+    assert body["name"] == "db"
+    assert body["recipients_snapshot"] == ["fp1"]
+    assert body["grant_pubkey_ids"] == ids
+    assert req.call_args[0][1].endswith("/api/v1/config/secrets")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_list_secrets_returns_list():
+    client = _client()
+    resp = _mock_response(
+        200,
+        [
+            {
+                "name": "db",
+                "status": "active",
+                "rotation_needed": False,
+                "current_version": 2,
+                "grant_count": 3,
+                "created_at": "2026-06-29T00:00:00Z",
+                "updated_at": "2026-06-29T00:00:00Z",
+            }
+        ],
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.list_secrets()
+    assert isinstance(result[0], SecretMetaResponse)
+    assert result[0].grant_count == 3
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_secret_carries_name_in_body():
+    client = _client()
+    resp = _mock_response(
+        200,
+        {
+            "name": "db",
+            "version_number": 1,
+            "alg": "age",
+            "ciphertext": "armored-ct",
+            "blob_ref": None,
+            "recipients_snapshot": ["fp1"],
+            "rotation_needed": False,
+            "created_at": "2026-06-29T00:00:00Z",
+        },
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.fetch_secret("db")
+    assert isinstance(result, SecretValueResponse)
+    assert result.alg == "age"
+    method, url = req.call_args[0][0], req.call_args[0][1]
+    assert method == "POST"
+    assert url.endswith("/api/v1/config/secrets/fetch")
+    assert req.call_args.kwargs["json"] == {"name": "db"}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_fetch_secret_pins_version():
+    client = _client()
+    resp = _mock_response(
+        200,
+        {
+            "name": "db",
+            "version_number": 5,
+            "alg": "age",
+            "ciphertext": "x",
+            "blob_ref": None,
+            "recipients_snapshot": [],
+            "rotation_needed": False,
+            "created_at": "2026-06-29T00:00:00Z",
+        },
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        await client.fetch_secret("db", version_number=5)
+    assert req.call_args.kwargs["json"] == {"name": "db", "version_number": 5}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_revoke_grant():
+    client = _client()
+    pk_id = str(uuid.uuid4())
+    resp = _mock_response(
+        200,
+        {
+            "name": "db",
+            "status": "active",
+            "rotation_needed": True,
+            "current_version": 2,
+            "grant_count": 2,
+            "created_at": "2026-06-29T00:00:00Z",
+            "updated_at": "2026-06-29T00:00:00Z",
+        },
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.revoke_grant("db", pk_id)
+    assert result.rotation_needed is True
+    assert req.call_args.kwargs["json"] == {"name": "db", "recipient_pubkey_id": pk_id}
+    assert req.call_args[0][1].endswith("/api/v1/config/secrets/revoke-grant")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_verify_audit():
+    client = _client()
+    resp = _mock_response(
+        200, {"valid": True, "entries": 10, "head": "abc", "broken_at": None, "reason": None}
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.verify_audit()
+    assert result.valid is True
+    assert result.entries == 10
+    assert req.call_args[0][1].endswith("/api/v1/config/secrets/audit/verify")
+    await client.close()
+
+
+# --- high-level orchestration (HARD invariant #2: set-equality) -------------
+
+
+@pytest.mark.asyncio
+async def test_put_secret_for_recipients_roundtrips_and_matches_sets():
+    client = _client()
+    id1, r1 = crypto.generate_keypair()
+    id2, r2 = crypto.generate_keypair()
+    pk1 = PubkeyResponse.model_validate(_pubkey_json(r1))
+    pk2 = PubkeyResponse.model_validate(_pubkey_json(r2))
+    resp = _mock_response(
+        201, {"name": "db", "version_number": 1, "status": "active", "rotation_needed": False}
+    )
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        await client.put_secret_for_recipients("db", b"hunter2", [pk1, pk2])
+        body = req.call_args.kwargs["json"]
+
+    # set-equality: snapshot fingerprints == fingerprints of granted pubkeys
+    assert set(body["recipients_snapshot"]) == {pk1.fingerprint, pk2.fingerprint}
+    assert set(body["grant_pubkey_ids"]) == {pk1.id, pk2.id}
+    # the ciphertext actually decrypts for each recipient
+    assert crypto.decrypt(body["ciphertext"], id1) == b"hunter2"
+    assert crypto.decrypt(body["ciphertext"], id2) == b"hunter2"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_put_secret_for_recipients_rejects_non_active():
+    client = _client()
+    _, r1 = crypto.generate_keypair()
+    pending = PubkeyResponse.model_validate(_pubkey_json(r1, status="pending"))
+    with pytest.raises(KaguraSecretError, match="active"):
+        await client.put_secret_for_recipients("db", b"x", [pending])
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_put_secret_for_recipients_rejects_empty():
+    client = _client()
+    with pytest.raises(KaguraSecretError):
+        await client.put_secret_for_recipients("db", b"x", [])
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_put_secret_for_recipients_detects_fingerprint_mismatch():
+    """A pubkey whose advertised fingerprint != sha256(pubkey) is rejected."""
+    client = _client()
+    _, r1 = crypto.generate_keypair()
+    bad = _pubkey_json(r1)
+    bad["fingerprint"] = "0" * 64  # tampered / inconsistent listing
+    pk = PubkeyResponse.model_validate(bad)
+    with pytest.raises(KaguraSecretError, match="fingerprint"):
+        await client.put_secret_for_recipients("db", b"x", [pk])
+    await client.close()
+
+
+# --- error mapping ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_unknown_secret_raises_not_found():
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(404, "secret not found")
+        with pytest.raises(KaguraNotFoundError):
+            await client.fetch_secret("nope")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_401_raises_auth_error():
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(401)
+        with pytest.raises(KaguraAuthError):
+            await client.list_secrets()
+    await client.close()

--- a/tests/test_secrets_client.py
+++ b/tests/test_secrets_client.py
@@ -11,8 +11,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from kagura_memory._auth import _OAuthAuth
 from kagura_memory.exceptions import (
     KaguraAuthError,
+    KaguraConnectionError,
     KaguraNotFoundError,
     KaguraSecretError,
 )
@@ -379,3 +381,55 @@ async def test_401_raises_auth_error():
         with pytest.raises(KaguraAuthError):
             await client.list_secrets()
     await client.close()
+
+
+@pytest.mark.asyncio
+async def test_generic_http_error_maps_to_connection_error():
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(500, "internal error")
+        with pytest.raises(KaguraConnectionError):
+            await client.list_secrets()
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_request_error_maps_to_connection_error():
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.side_effect = httpx.ConnectError("network down")
+        with pytest.raises(KaguraConnectionError):
+            await client.list_secrets()
+    await client.close()
+
+
+# --- construction edges -----------------------------------------------------
+
+
+def test_requires_credentials():
+    with pytest.raises(ValueError, match="requires api_key"):
+        SecretClient()
+
+
+def test_rejects_http_base_url():
+    with pytest.raises(ValueError, match="HTTPS"):
+        SecretClient(api_key="t", base_url="http://insecure.example.com")
+
+
+@pytest.mark.asyncio
+async def test_oauth_construction_via_resolved_auth():
+    resolved = _OAuthAuth(
+        oauth=httpx.BasicAuth("u", "p"),  # stand-in httpx.Auth for the OAuth handler
+        mcp_url="https://memory.kagura-ai.com/mcp",
+        workspace_id="ws-uuid",
+    )
+    client = SecretClient._from_resolved_auth(resolved)
+    assert client.base_url == "https://memory.kagura-ai.com"
+    assert client._oauth is not None
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes():
+    async with SecretClient(api_key="t", base_url="https://test.com") as c:
+        assert c.base_url == "https://test.com"

--- a/tests/test_secrets_crypto.py
+++ b/tests/test_secrets_crypto.py
@@ -146,3 +146,29 @@ def test_encrypt_rejects_oversize_ciphertext(keypair):
     big = b"A" * crypto.MAX_CIPHERTEXT_BYTES
     with pytest.raises(KaguraCryptoError):
         crypto.encrypt(big, [recipient])
+
+
+def test_encrypt_rejects_regex_valid_but_invalid_recipient():
+    # Matches RECIPIENT_RE but is not a valid bech32 age key → pyrage RecipientError.
+    bogus = "age1" + "q" * 40
+    assert crypto.RECIPIENT_RE.match(bogus)
+    with pytest.raises(KaguraCryptoError):
+        crypto.encrypt(b"x", [bogus])
+
+
+def test_encrypt_wraps_pyrage_encrypt_error(monkeypatch, keypair):
+    _, recipient = keypair
+
+    def boom(_data, _recipients):
+        raise crypto.pyrage.EncryptError("synthetic encrypt failure")
+
+    monkeypatch.setattr(crypto.pyrage, "encrypt", boom)
+    with pytest.raises(KaguraCryptoError):
+        crypto.encrypt(b"x", [recipient])
+
+
+def test_decrypt_rejects_invalid_identity_string(keypair):
+    _, recipient = keypair
+    armored = crypto.encrypt(b"x", [recipient])
+    with pytest.raises(KaguraCryptoError):
+        crypto.decrypt(armored, "AGE-SECRET-KEY-1-NOT-A-REAL-IDENTITY")

--- a/tests/test_secrets_crypto.py
+++ b/tests/test_secrets_crypto.py
@@ -1,0 +1,148 @@
+"""Tests for kagura_memory.secrets.crypto — age wrap/unwrap, armor, fingerprint.
+
+The crypto layer is server-independent: it wraps the audited `pyrage` (Rust
+`age`/X25519) binding plus a pure-Python RFC 7468 armor codec. No home-grown
+crypto — only base64+PEM framing is ours.
+"""
+
+import hashlib
+
+import pytest
+
+from kagura_memory.exceptions import KaguraCryptoError
+from kagura_memory.secrets import crypto
+
+
+@pytest.fixture
+def keypair() -> tuple[str, str]:
+    """A fresh (identity, recipient) age keypair."""
+    return crypto.generate_keypair()
+
+
+# --- keygen + fingerprint ---------------------------------------------------
+
+
+def test_generate_keypair_returns_age_strings(keypair):
+    identity, recipient = keypair
+    assert crypto.RECIPIENT_RE.match(recipient), recipient
+    assert identity.startswith("AGE-SECRET-KEY-1")
+
+
+def test_fingerprint_is_sha256_hex_of_pubkey_string(keypair):
+    _, recipient = keypair
+    expected = hashlib.sha256(recipient.encode("utf-8")).hexdigest()
+    fp = crypto.fingerprint(recipient)
+    assert fp == expected
+    assert len(fp) == 64
+
+
+def test_recipient_from_identity_recovers_public_key(keypair):
+    identity, recipient = keypair
+    assert crypto.recipient_from_identity(identity) == recipient
+
+
+def test_recipient_from_identity_rejects_bad_identity():
+    with pytest.raises(KaguraCryptoError):
+        crypto.recipient_from_identity("not-an-identity")
+
+
+# --- armor codec ------------------------------------------------------------
+
+
+def test_armor_roundtrip_is_binary_equal():
+    binary = b"age-encryption.org/v1\n\x00\x01\x02\xff payload"
+    armored = crypto.armor_encode(binary)
+    assert armored.startswith("-----BEGIN AGE ENCRYPTED FILE-----")
+    assert "-----END AGE ENCRYPTED FILE-----" in armored
+    assert crypto.armor_decode(armored) == binary
+
+
+def test_armor_decode_is_crlf_tolerant():
+    binary = b"hello-age"
+    armored = crypto.armor_encode(binary).replace("\n", "\r\n")
+    assert crypto.armor_decode(armored) == binary
+
+
+def test_armor_decode_rejects_non_armored():
+    with pytest.raises(KaguraCryptoError):
+        crypto.armor_decode("just some random text, not PEM")
+
+
+def test_armor_decode_rejects_non_base64_body():
+    # `aGVs!!!@@@bG8=` would silently decode to b"hello" under validate=False
+    # (the non-alphabet chars are discarded); validate=True must reject it.
+    bad = "-----BEGIN AGE ENCRYPTED FILE-----\naGVs!!!@@@bG8=\n-----END AGE ENCRYPTED FILE-----\n"
+    with pytest.raises(KaguraCryptoError):
+        crypto.armor_decode(bad)
+
+
+def test_recipient_re_rejects_trailing_newline(keypair):
+    _, recipient = keypair
+    assert crypto.RECIPIENT_RE.match(recipient)
+    assert not crypto.RECIPIENT_RE.match(recipient + "\n")  # $ would have matched; \Z must not
+
+
+def test_decrypt_rejects_oversize_input(keypair):
+    identity, _ = keypair
+    huge = (
+        "-----BEGIN AGE ENCRYPTED FILE-----\n"
+        + "A" * crypto.MAX_CIPHERTEXT_BYTES
+        + "\n-----END AGE ENCRYPTED FILE-----\n"
+    )
+    # Must be rejected by the inbound size cap (before base64-decoding it all),
+    # not merely as a downstream age failure.
+    with pytest.raises(KaguraCryptoError, match="cap|exceed"):
+        crypto.decrypt(huge, identity)
+
+
+# --- encrypt / decrypt ------------------------------------------------------
+
+
+def test_encrypt_returns_armored_age(keypair):
+    _, recipient = keypair
+    armored = crypto.encrypt(b"db-password", [recipient])
+    assert armored.startswith("-----BEGIN AGE ENCRYPTED FILE-----")
+    # The armored body must decode to a real age file header.
+    assert crypto.armor_decode(armored).startswith(b"age-encryption.org/v1")
+
+
+def test_encrypt_decrypt_roundtrip(keypair):
+    identity, recipient = keypair
+    plaintext = b"super-secret-\xf0\x9f\x94\x91-value"
+    armored = crypto.encrypt(plaintext, [recipient])
+    assert crypto.decrypt(armored, identity) == plaintext
+
+
+def test_encrypt_multi_recipient_each_decrypts():
+    id1, r1 = crypto.generate_keypair()
+    id2, r2 = crypto.generate_keypair()
+    plaintext = b"shared-secret"
+    armored = crypto.encrypt(plaintext, [r1, r2])
+    assert crypto.decrypt(armored, id1) == plaintext
+    assert crypto.decrypt(armored, id2) == plaintext
+
+
+def test_encrypt_rejects_malformed_recipient():
+    with pytest.raises(KaguraCryptoError):
+        crypto.encrypt(b"x", ["not-an-age-recipient"])
+
+
+def test_encrypt_rejects_empty_recipients():
+    with pytest.raises(KaguraCryptoError):
+        crypto.encrypt(b"x", [])
+
+
+def test_decrypt_with_wrong_identity_raises(keypair):
+    _, recipient = keypair
+    other_identity, _ = crypto.generate_keypair()
+    armored = crypto.encrypt(b"secret", [recipient])
+    with pytest.raises(KaguraCryptoError):
+        crypto.decrypt(armored, other_identity)
+
+
+def test_encrypt_rejects_oversize_ciphertext(keypair):
+    _, recipient = keypair
+    # 256 KiB of plaintext armors well past the 262144-byte ciphertext cap.
+    big = b"A" * crypto.MAX_CIPHERTEXT_BYTES
+    with pytest.raises(KaguraCryptoError):
+        crypto.encrypt(big, [recipient])

--- a/tests/test_secrets_keymanager.py
+++ b/tests/test_secrets_keymanager.py
@@ -155,3 +155,17 @@ def test_keyringstore_roundtrip_with_usable_backend(monkeypatch):
     store.delete("identity:default")
     assert store.get("identity:default") is None
     store.delete("identity:default")  # idempotent: PasswordDeleteError swallowed
+
+
+def test_keyringstore_set_wraps_keyring_error(monkeypatch):
+    class _DummyBackend:  # usable backend (not keyring.backends.fail.Keyring)
+        pass
+
+    def boom(*_a, **_k):
+        raise keyring.errors.KeyringError("write failed")
+
+    monkeypatch.setattr(keyring, "get_keyring", lambda: _DummyBackend())
+    monkeypatch.setattr(keyring, "set_password", boom)
+    store = KeyringStore()
+    with pytest.raises(KaguraKeyCustodyError):
+        store.set("identity:default", "AGE-SECRET-KEY-1-x")

--- a/tests/test_secrets_keymanager.py
+++ b/tests/test_secrets_keymanager.py
@@ -5,6 +5,7 @@ touch the real OS keychain. The KeyringStore availability guard is tested by
 monkeypatching ``keyring.get_keyring`` to the fail backend.
 """
 
+import keyring
 import keyring.backends.fail
 import keyring.errors
 import pytest
@@ -56,9 +57,11 @@ def test_enroll_refuses_to_overwrite_existing_key():
     km.enroll()
     before = dict(store.data)
 
-    with pytest.raises(KaguraKeyCustodyError):
+    with pytest.raises(KaguraKeyCustodyError) as exc:
         km.enroll()
 
+    # Must not suggest `secret rotate` (that rotates a value, not the keypair).
+    assert "rotate" not in str(exc.value).lower()
     assert store.data == before  # original key untouched
 
 
@@ -120,3 +123,35 @@ def test_keyringstore_get_wraps_keyring_error(monkeypatch):
     store = KeyringStore()
     with pytest.raises(KaguraKeyCustodyError):
         store.get("identity:default")
+
+
+def test_keyringstore_roundtrip_with_usable_backend(monkeypatch):
+    """get/set/delete against a mocked usable backend (no real OS keychain)."""
+    backing: dict[tuple[str, str], str] = {}
+
+    class _DummyBackend:  # anything that is not keyring.backends.fail.Keyring
+        pass
+
+    def _set(service, name, value):
+        backing[(service, name)] = value
+
+    def _get(service, name):
+        return backing.get((service, name))
+
+    def _delete(service, name):
+        if (service, name) not in backing:
+            raise keyring.errors.PasswordDeleteError("not found")
+        del backing[(service, name)]
+
+    monkeypatch.setattr(keyring, "get_keyring", lambda: _DummyBackend())
+    monkeypatch.setattr(keyring, "set_password", _set)
+    monkeypatch.setattr(keyring, "get_password", _get)
+    monkeypatch.setattr(keyring, "delete_password", _delete)
+
+    store = KeyringStore()
+    assert store.get("identity:default") is None
+    store.set("identity:default", "AGE-SECRET-KEY-1-abc")
+    assert store.get("identity:default") == "AGE-SECRET-KEY-1-abc"
+    store.delete("identity:default")
+    assert store.get("identity:default") is None
+    store.delete("identity:default")  # idempotent: PasswordDeleteError swallowed

--- a/tests/test_secrets_keymanager.py
+++ b/tests/test_secrets_keymanager.py
@@ -1,0 +1,122 @@
+"""Tests for kagura_memory.secrets.keymanager — keygen + private-key custody.
+
+Custody is exercised through an injected in-memory ``KeyStore`` so tests never
+touch the real OS keychain. The KeyringStore availability guard is tested by
+monkeypatching ``keyring.get_keyring`` to the fail backend.
+"""
+
+import keyring.backends.fail
+import keyring.errors
+import pytest
+
+from kagura_memory.exceptions import KaguraKeyCustodyError
+from kagura_memory.secrets import crypto
+from kagura_memory.secrets.keymanager import KeyManager, KeyringStore
+
+
+class FakeStore:
+    """In-memory KeyStore for tests."""
+
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
+
+    def get(self, name: str) -> str | None:
+        return self.data.get(name)
+
+    def set(self, name: str, value: str) -> None:
+        self.data[name] = value
+
+    def delete(self, name: str) -> None:
+        self.data.pop(name, None)
+
+
+class UnavailableStore(FakeStore):
+    """Simulates a host with no usable keychain (fail-closed)."""
+
+    def set(self, name: str, value: str) -> None:
+        raise KaguraKeyCustodyError("no secure keychain available")
+
+
+def test_enroll_returns_recipient_and_fingerprint_and_stores_identity():
+    store = FakeStore()
+    km = KeyManager(profile="default", store=store)
+
+    recipient, fp = km.enroll()
+
+    assert crypto.RECIPIENT_RE.match(recipient)
+    assert fp == crypto.fingerprint(recipient)
+    assert km.has_key()
+    # The *private* key is what's in custody, not the public recipient.
+    assert next(iter(store.data.values())).startswith("AGE-SECRET-KEY-1")
+
+
+def test_enroll_refuses_to_overwrite_existing_key():
+    store = FakeStore()
+    km = KeyManager(profile="default", store=store)
+    km.enroll()
+    before = dict(store.data)
+
+    with pytest.raises(KaguraKeyCustodyError):
+        km.enroll()
+
+    assert store.data == before  # original key untouched
+
+
+def test_get_identity_raises_when_absent():
+    km = KeyManager(profile="default", store=FakeStore())
+    with pytest.raises(KaguraKeyCustodyError):
+        km.get_identity()
+
+
+def test_get_recipient_matches_enrolled_recipient():
+    km = KeyManager(profile="default", store=FakeStore())
+    recipient, _ = km.enroll()
+    assert km.get_recipient() == recipient
+
+
+def test_fingerprint_matches_enrolled():
+    km = KeyManager(profile="default", store=FakeStore())
+    recipient, fp = km.enroll()
+    assert km.fingerprint() == fp
+
+
+def test_delete_removes_key():
+    km = KeyManager(profile="default", store=FakeStore())
+    km.enroll()
+    km.delete()
+    assert not km.has_key()
+
+
+def test_profiles_are_isolated():
+    store = FakeStore()
+    a = KeyManager(profile="alice", store=store)
+    b = KeyManager(profile="bob", store=store)
+    ra, _ = a.enroll()
+    rb, _ = b.enroll()
+    assert ra != rb
+    assert a.get_recipient() == ra
+    assert b.get_recipient() == rb
+
+
+def test_enroll_fails_closed_when_no_keychain():
+    km = KeyManager(profile="default", store=UnavailableStore())
+    with pytest.raises(KaguraKeyCustodyError):
+        km.enroll()
+    assert not km.has_key()
+
+
+def test_keyringstore_set_refuses_fail_backend(monkeypatch):
+    monkeypatch.setattr(keyring, "get_keyring", lambda: keyring.backends.fail.Keyring())
+    store = KeyringStore()
+    with pytest.raises(KaguraKeyCustodyError):
+        store.set("identity:default", "AGE-SECRET-KEY-1-whatever")
+
+
+def test_keyringstore_get_wraps_keyring_error(monkeypatch):
+    def boom(*_a, **_k):
+        raise keyring.errors.KeyringError("keychain is locked")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    store = KeyringStore()
+    with pytest.raises(KaguraKeyCustodyError):
+        store.get("identity:default")

--- a/uv.lock
+++ b/uv.lock
@@ -167,6 +167,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -186,6 +195,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
 ]
 
 [[package]]
@@ -400,6 +454,54 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
 ]
 
 [[package]]
@@ -801,6 +903,51 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -996,6 +1143,10 @@ ingest-youtube = [
     { name = "pillow" },
     { name = "youtube-transcript-api" },
 ]
+secret = [
+    { name = "keyring" },
+    { name = "pyrage" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1012,6 +1163,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'ingest-html'", specifier = ">=4.12" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "httpx", specifier = ">=0.25.0" },
+    { name = "keyring", marker = "extra == 'secret'", specifier = ">=24.0" },
     { name = "litellm", specifier = ">=1.50,<1.82.7" },
     { name = "openpyxl", marker = "extra == 'ingest-all'", specifier = ">=3.1" },
     { name = "openpyxl", marker = "extra == 'ingest-xlsx'", specifier = ">=3.1" },
@@ -1032,6 +1184,7 @@ requires-dist = [
     { name = "pymupdf", marker = "extra == 'ingest-all'", specifier = ">=1.24" },
     { name = "pymupdf", marker = "extra == 'ingest-epub'", specifier = ">=1.24" },
     { name = "pymupdf", marker = "extra == 'ingest-pdf'", specifier = ">=1.24" },
+    { name = "pyrage", marker = "extra == 'secret'", specifier = ">=1.1" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
@@ -1045,7 +1198,7 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'ingest-all'", specifier = ">=1.0" },
     { name = "youtube-transcript-api", marker = "extra == 'ingest-youtube'", specifier = ">=1.0" },
 ]
-provides-extras = ["dev", "ingest", "ingest-all", "ingest-audio", "ingest-browser", "ingest-docx", "ingest-epub", "ingest-html", "ingest-pdf", "ingest-pptx", "ingest-xlsx", "ingest-youtube"]
+provides-extras = ["dev", "ingest", "ingest-all", "ingest-audio", "ingest-browser", "ingest-docx", "ingest-epub", "ingest-html", "ingest-pdf", "ingest-pptx", "ingest-xlsx", "ingest-youtube", "secret"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1054,6 +1207,24 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1274,6 +1445,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1669,6 +1849,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1823,6 +2012,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyrage"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/e8/918161376594d69b294e920bd6444f1d9997e6e6dd2aca18e15f1ef72463/pyrage-1.3.0.tar.gz", hash = "sha256:b283a2e3d688cbf68c707f57d93fdab3304ff57c7e2e6b710c0b4bc9096ad9da", size = 30120, upload-time = "2025-06-14T01:28:04.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6e/3095678ee12f0401e1de17f4d6993783b20a4b807daf69e23b170724e5f4/pyrage-1.3.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:907901ada8d63d674cc9005889150846c7349ef587ee8bf5e9278b79c54b4679", size = 1563258, upload-time = "2025-06-14T01:27:57.886Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e7/f515fbc972a5d83e9fa82d1c23a16f733f4dd6c2c6ae33d9054ca04a8d92/pyrage-1.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea452cb9c9c47083a96b309467dea5614d12530e1de4b6585f10aa04d3d19d1c", size = 785930, upload-time = "2025-06-14T01:27:59.755Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f3/e91bf604fd40c42c60e8f95075cddb0b85d0bdf452f736b533b1bad550e0/pyrage-1.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab066b22925c5a0ec5fead2e21e4586b21d5da730055c7e46caa978bd99de936", size = 847692, upload-time = "2025-06-14T01:28:01.042Z" },
+    { url = "https://files.pythonhosted.org/packages/88/59/15fd1945b02e6f93eff5a2ff352e67f85f51bf543769484f9bd960868c19/pyrage-1.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:3be314a9746809c2710bfd144a6acf0c54a40f43e306857b9778a9d871ad97b3", size = 767566, upload-time = "2025-06-14T01:28:02.597Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
@@ -1913,6 +2114,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -2247,6 +2457,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Client side of the **zero-knowledge secret store** (#216) — consumes
memory-cloud's `/api/v1/config/secrets` (server `#1128`, **v0.39.0**). Secrets are
encrypted to recipients' `age`/X25519 public keys and decrypted **locally**;
memory-cloud only ever stores armored ciphertext, never plaintext. All crypto is
delegated to the audited [`pyrage`](https://pypi.org/project/pyrage/) binding —
the only homegrown piece is the RFC 7468 armor (base64+PEM) transport codec.

Ships as a new opt-in `[secret]` extra (`pyrage`, `keyring`). The wire schema was
verified field-by-field against the **live v0.39.0 OpenAPI**, not guessed.

## What's included

- **`secrets/crypto.py`** — keygen, encrypt/decrypt, armor codec, sha256
  fingerprint; recipient-format + 256 KiB caps (inbound and outbound).
- **`secrets/keymanager.py`** — age private key in the OS keychain (`keyring`),
  **fail-closed** (refuse when no keychain backend), no-overwrite, profile isolation.
- **`secrets/client.py`** — `SecretClient` REST client; `put_secret_for_recipients`
  enforces the server's grant set-equality + fingerprint-integrity invariant
  client-side (fails fast before the 400).
- **`secrets/cli.py`** — `kagura secret keygen|approve|pubkeys|put|get|list|grant|revoke|rotate|audit-verify|exec`.
- **`skills/secret/SKILL.md`** — Claude Code plugin skill wrapping the CLI.

## Security / DX guards

- `get` **refuses to print a secret to a TTY** (pipe / `-o FILE` written `0600` / `--reveal`); no trailing newline on the piped value.
- `put`/`rotate` read the value from **stdin/`--from-file` only — never argv** (no `ps`/shell-history leak).
- `keygen` **never prints the private key**; idempotent (reuses an existing key, so a failed registration is retryable).
- `revoke` warns that **revoke ≠ cryptographic invalidation** → `rotate` + regenerate upstream.
- `exec` injects into a child env via `execvpe` (no disk/scrollback), **never mutates `os.environ`**; core dumps disabled before decrypt.
- All fallible SDK calls run inside a `ClickException`-mapping boundary so expected errors surface as clean messages, **never a traceback that could echo plaintext**.

## Testing

- **65 new tests** (crypto / keymanager / client / cli / plugin), full TDD.
- Quality gate green: `ruff` ✅, `ruff format` ✅, `pyright` 0 errors ✅, **1245 passed / 38 skipped**.
- Ran `/self-review` and `/code-review max` (multi-agent): one `[C]` (an `exec` non-UTF-8 traceback could echo plaintext) plus several hardening gaps — all fixed and covered by regression tests.

## Notes

- `__version__` is **not** bumped here — the `/release` flow bumps it to `0.33.0` (the assigned milestone) at release time; manifests stay synced to the current `__version__`.
- `MIN_SERVER_VERSION` is unchanged; only the secret surface requires server 0.39.0.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
