### PR TITLE
fix(secrets): tolerate null timestamps in SecretMetaResponse

### DIFF
--- a/src/kagura_memory/secrets/models.py
+++ b/src/kagura_memory/secrets/models.py
@@ -42,8 +42,11 @@ class SecretMetaResponse(BaseModel):
     rotation_needed: bool
     current_version: int | None = None
     grant_count: int
-    created_at: str
-    updated_at: str
+    # Timestamps are nullable: the live server returns null for these on some
+    # secrets (the OpenAPI marks them required but untyped). Tolerate null
+    # rather than failing deserialization.
+    created_at: str | None = None
+    updated_at: str | None = None
 
 
 class SecretValueResponse(BaseModel):

--- a/tests/test_secrets_client.py
+++ b/tests/test_secrets_client.py
@@ -186,6 +186,24 @@ async def test_put_secret_sends_contract_body():
     await client.close()
 
 
+def test_secret_meta_response_allows_null_timestamps():
+    # The live server returns updated_at/created_at as null for some secrets
+    # (caught by live E2E); the model must accept that, not 500 the SDK.
+    m = SecretMetaResponse.model_validate(
+        {
+            "name": "db",
+            "status": "active",
+            "rotation_needed": False,
+            "current_version": 1,
+            "grant_count": 1,
+            "created_at": None,
+            "updated_at": None,
+        }
+    )
+    assert m.created_at is None
+    assert m.updated_at is None
+
+
 @pytest.mark.asyncio
 async def test_list_secrets_returns_list():
     client = _client()


### PR DESCRIPTION
## Summary

Follow-up to #217, found by **live E2E** against memory-cloud v0.39.0.

`kagura secret list` / `SecretClient.list_secrets()` raised a pydantic
`ValidationError` because the server returns `updated_at` (and potentially
`created_at`) as **null** for some secrets, but `SecretMetaResponse` typed them
as required `str`. The OpenAPI marks these fields required-but-untyped, so the
mocked unit tests (which sent string timestamps) didn't catch it.

## Fix

`SecretMetaResponse.created_at` / `updated_at` → `str | None`. Added a
regression test for the null case.

## Verification

Ran the full flow end-to-end against the **live** server (throwaway pubkey +
secret, cleaned up afterward):

```
register_pubkey (pending) → approve (active) → put (v2) →
fetch+decrypt (roundtrip OK, alg=age) → list_secrets (OK) →
audit/verify (valid, 9 entries) → revoke_grant → revoke_pubkey
```

Quality gate green: ruff / pyright 0 / **1282 passed, 39 skipped**.

Closes the gap left by mocked-only tests for this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)