### PR TITLE
fix(secrets): clearer error on HTTP 403 from the secret store

### DIFF
--- a/src/kagura_memory/secrets/client.py
+++ b/src/kagura_memory/secrets/client.py
@@ -162,6 +162,18 @@ class SecretClient:
                 raise KaguraAuthError(f"Authentication failed. {hint}") from e
             if status == 404:
                 raise KaguraNotFoundError(extract_detail(e.response) or "Not found") from e
+            if status == 403:
+                # The server returns 403 (not 404) for a secret the caller can't
+                # read, to avoid leaking whether it exists. Give an actionable
+                # message rather than a bare "HTTP 403".
+                detail = extract_detail(e.response)
+                msg = (
+                    "Access denied (HTTP 403): you may not have a grant on this secret, "
+                    "it may not exist, or you lack permission for this operation."
+                )
+                if detail:
+                    msg = f"{msg} ({detail})"
+                raise KaguraConnectionError(msg) from e
             detail = extract_detail(e.response)
             msg = f"HTTP {status}: {detail}" if detail else f"HTTP {status}"
             raise KaguraConnectionError(msg) from e

--- a/tests/test_secrets_client.py
+++ b/tests/test_secrets_client.py
@@ -414,6 +414,16 @@ async def test_403_maps_to_clear_access_denied():
 
 
 @pytest.mark.asyncio
+async def test_403_appends_server_detail():
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(403, "no grant for caller")
+        with pytest.raises(KaguraConnectionError, match="no grant for caller"):
+            await client.fetch_secret("foo")
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_generic_http_error_maps_to_connection_error():
     client = _client()
     with patch.object(client._client, "request", new_callable=AsyncMock) as req:

--- a/tests/test_secrets_client.py
+++ b/tests/test_secrets_client.py
@@ -402,6 +402,18 @@ async def test_401_raises_auth_error():
 
 
 @pytest.mark.asyncio
+async def test_403_maps_to_clear_access_denied():
+    # The live server returns 403 (not 404) for a secret the caller can't read
+    # — hide existence. Surface an actionable message, not a bare "HTTP 403".
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(403, "")
+        with pytest.raises(KaguraConnectionError, match="(?i)access denied"):
+            await client.fetch_secret("foo")
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_generic_http_error_maps_to_connection_error():
     client = _client()
     with patch.object(client._client, "request", new_callable=AsyncMock) as req:


### PR DESCRIPTION
## Summary

Follow-up to #217, found during live verification against memory-cloud v0.39.0.

The server returns **403** (not 404) when the caller cannot read a secret — it
hides whether the secret exists. `SecretClient` surfaced this as a bare
`HTTP 403`, unhelpful for the most common real failure (you do not have a grant
on a secret).

## Fix

Map 403 in `_request` to an actionable message:

> Access denied (HTTP 403): you may not have a grant on this secret, it may not exist, or you lack permission for this operation.

Any server-supplied `detail` is appended. Added a regression test.

## Verification

Confirmed live: `kagura secret get <unreadable>` now prints the clear message
instead of `Error: HTTP 403`. Quality gate green: ruff / pyright 0 / **1283 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)