### PR TITLE
feat(secrets): owner-only secret delete + `kagura secret delete` CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,10 @@ uv run pyright src/              # Type check
 - Resource ingestion: `setup_resource`, `ingest_event`, `ingest_events`
 - Resource stats/schema: `get_resource_impact`, `get_resource_schema`
 - **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+)
-- **Zero-knowledge secrets**: `SecretClient` + `kagura secret` — age recipient encryption, local decrypt; private key in OS keychain via `pyrage`/`keyring` (`[secret]` extra, server v0.39.0+)
+- **Zero-knowledge secrets**: `SecretClient` + `kagura secret` — age recipient encryption, local decrypt; private key in OS keychain via `pyrage`/`keyring` (`[secret]` extra, server v0.39.0+). Owner-only hard delete via `SecretClient.delete_secret` / `kagura secret delete` (server v0.41.0+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs
-- CLI: `kagura doctor`, `kagura auth login/refresh/status/list`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura secret keygen/put/get/grant/rotate/exec`, `kagura context search-config`, `kagura sleep history/report/rollback`
+- CLI: `kagura doctor`, `kagura auth login/refresh/status/list`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura secret keygen/put/get/grant/rotate/delete/exec`, `kagura context search-config`, `kagura sleep history/report/rollback`
 
 ## Branch Strategy
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Most workflows use the CLI instead — see [`kagura secret`](#zero-knowledge-sec
 
 | SDK | Min memory-cloud | Notes |
 |---|---|---|
+| 0.34.0+ | 0.17.1 (0.41.0 for `kagura secret delete`) | **Owner-only secret delete.** `SecretClient.delete_secret` / `kagura secret delete` need memory-cloud **0.41.0+** (`DELETE /api/v1/config/secrets/{name}`). `MIN_SERVER_VERSION` stays **0.17.1** — only the delete surface requires 0.41.0. |
 | 0.33.0+ | 0.17.1 (0.39.0 for `kagura secret`) | **Zero-knowledge secret store.** `SecretClient` / `kagura secret` need memory-cloud **0.39.0+** (the `/api/v1/config/secrets` endpoints). `MIN_SERVER_VERSION` is **not** bumped — the rest of the SDK still works on 0.17.1+; only the secret surface requires 0.39.0. Requires the `[secret]` extra. |
 | 0.27.0 – 0.31.x | 0.17.1 | **Agent memory substrate.** `load_pinned` + `delivery_mode` pin-on-write, `recall_upcoming`, `feedback`, `set_state`/`get_state`, and the `trust_tier` recall filter each need a memory-cloud carrying the matching [#885](https://github.com/kagura-ai/memory-cloud/issues/885) agent-substrate APIs (≈ v0.23.0+); against an older server those specific tools return an MCP "tool not found". `MIN_SERVER_VERSION` stays **0.17.1** — the rest of the SDK still works on 0.17.1+. **v0.29.0 also changed error handling (breaking): MCP tool methods now raise `KaguraNotFoundError`/`KaguraError` instead of returning `{"status":"error"}` dicts** (see the KaguraClient error-handling note above). |
 | 0.15.0 – 0.20.x | 0.15.1 | `FilesClient` + R2 checksum binding. `list_tags()` additionally needs **0.15.4** — `MIN_SERVER_VERSION` is intentionally not bumped, only that one method requires the newer server. |
@@ -462,8 +463,11 @@ kagura secret grant db-prod --to <pubkey-id> # re-encrypt to the expanded recipi
 kagura secret revoke db-prod --to <pubkey-id># revoke a grant (then `rotate` — revoke ≠ invalidation)
 kagura secret rotate db-prod                 # encrypt a NEW value to the remaining recipients
 kagura secret list                           # secret metadata (never the values)
+kagura secret delete db-prod                 # owner-only hard delete (cleanup, not invalidation — rotate first)
 kagura secret audit-verify                   # verify the tamper-evident audit chain
 ```
+
+> **`delete` is cleanup, not a security control.** It removes the stored ciphertext (all versions + grants) but does **not** un-share a value a recipient already fetched, nor rotate the live upstream credential. To contain a leak, rotate the upstream credential first, then delete. Owner-only; needs memory-cloud 0.41.0+.
 
 ### Document ingestion (`kagura ingest`)
 
@@ -562,7 +566,7 @@ follow-up.
 | Resource Schema | `ResourceClient` | REST API | API Key |
 | File upload / download-url / delete / list | `FilesClient` | REST + presigned PUT | API Key |
 | Secret pubkey registry (register/list/me/approve/revoke) | `SecretClient` | REST API | API Key / OAuth |
-| Secret put / fetch / list / revoke-grant / audit-verify | `SecretClient` | REST API (age, local decrypt) | API Key / OAuth |
+| Secret put / fetch / list / revoke-grant / delete / audit-verify | `SecretClient` | REST API (age, local decrypt) | API Key / OAuth |
 | Account erasure (GDPR Art.17 / APPI) | — | Web UI only | Session |
 
 Context deletion is a **soft delete** available via `KaguraClient.delete_context()` and `kagura context delete` (the CLI prompts for confirmation). Account erasure (GDPR Art.17 / APPI) is intentionally Web UI only — it is irreversible and requires session authentication and confirmation. `kagura sleep rollback` runs over the MCP API Key but is itself destructive (reverses edge creation, merges, importance updates, promotions, and archives) and the CLI requires `--yes` to skip the interactive confirmation. The server commits per-action without a Saga, so a 5xx response after partial success means SOME actions may have been reversed before the error surfaced — re-run `kagura sleep report` to inspect the post-failure state.

--- a/skills/secret/SKILL.md
+++ b/skills/secret/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: secret
-description: Store and retrieve zero-knowledge secrets with the `kagura secret` CLI — age recipient encryption, local decrypt (memory-cloud never sees plaintext). Use for keygen/enroll, put/get, grant/revoke/rotate, exec-with-injected-env, and audit verification.
+description: Store and retrieve zero-knowledge secrets with the `kagura secret` CLI — age recipient encryption, local decrypt (memory-cloud never sees plaintext). Use for keygen/enroll, put/get, grant/revoke/rotate, owner-only delete, exec-with-injected-env, and audit verification.
 ---
 
 # kagura secret — zero-knowledge secret store
@@ -32,6 +32,7 @@ kagura secret grant db-prod --to <pubkey-id> # re-encrypt to the expanded recipi
 kagura secret revoke db-prod --to <pubkey-id># revoke a grant — then rotate
 kagura secret rotate db-prod                 # encrypt a NEW value to the remaining recipients
 kagura secret list                           # secret metadata (never the values)
+kagura secret delete db-prod                 # owner-only hard delete (cleanup, not invalidation — rotate first; needs memory-cloud 0.41.0+)
 kagura secret audit-verify                   # verify the tamper-evident audit chain
 ```
 
@@ -47,5 +48,11 @@ kagura secret audit-verify                   # verify the tamper-evident audit c
 - **revoke ≠ cryptographic invalidation.** A revoked recipient may still hold a
   fetched copy — after `revoke`, run `kagura secret rotate` *and* regenerate the
   upstream provider credential to actually contain a leak.
+- **delete ≠ invalidation either.** `kagura secret delete` is owner-only cleanup:
+  it removes the stored ciphertext + all versions + grants, but does **not**
+  un-share a value a recipient already fetched, nor rotate the live upstream
+  credential. Confirm with the user before deleting, and steer them to rotate the
+  upstream credential **first**, then delete — never delete on their behalf
+  without that warning.
 - On `keygen`/`approve`, surface the **fingerprint** so the user can verify it
   out-of-band (TOFU) before trusting the key.

--- a/src/kagura_memory/secrets/cli.py
+++ b/src/kagura_memory/secrets/cli.py
@@ -476,6 +476,32 @@ def rotate(name: str, from_file: str | None, profile: str) -> None:
     click.echo("  Remember to regenerate the upstream provider credential (the real token).")
 
 
+@secret.command()
+@click.argument("name")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
+def delete(name: str, yes: bool) -> None:
+    """Hard-delete a secret and all its versions + grants (owner only).
+
+    Delete is CLEANUP, not a security control: it removes the stored ciphertext
+    but does NOT un-share a value a recipient already fetched, nor rotate the
+    live upstream credential. Rotate the upstream credential first, then delete.
+    """
+    if not yes:
+        click.echo(f"About to permanently delete secret '{name}' (all versions + grants).")
+        click.echo("  ⚠ Delete is CLEANUP, not a security control. It removes stored")
+        click.echo("    ciphertext but does NOT un-share a value already fetched, nor")
+        click.echo("    rotate the live upstream credential.")
+        click.echo("    To contain a leak, rotate the upstream credential FIRST, then delete.")
+        click.confirm("Proceed?", abort=True)
+
+    async def _delete() -> None:
+        async with _get_secret_client() as c:
+            await c.delete_secret(name)
+
+    _run(_delete())
+    click.echo(f"✓ deleted secret '{name}'.")
+
+
 @secret.command(name="audit-verify")
 def audit_verify() -> None:
     """Verify the tamper-evident audit chain (owner/admin)."""

--- a/src/kagura_memory/secrets/client.py
+++ b/src/kagura_memory/secrets/client.py
@@ -12,6 +12,7 @@ share one shape.
 from __future__ import annotations
 
 from typing import Any, Literal
+from urllib.parse import quote
 
 import httpx
 
@@ -260,6 +261,35 @@ class SecretClient:
         body = {"name": name, "recipient_pubkey_id": recipient_pubkey_id}
         response = await self._request("POST", f"{_BASE}/revoke-grant", json=body)
         return SecretMetaResponse.model_validate(response.json())
+
+    async def delete_secret(self, name: str) -> None:
+        """Hard-delete a secret and all its versions + grants (owner only).
+
+        Wraps ``DELETE /api/v1/config/secrets/{name}`` (memory-cloud v0.41.0).
+        The server appends a ``delete`` entry to the tamper-evident audit chain
+        **before** removal, so :meth:`verify_audit` still passes afterwards.
+
+        **Cleanup, NOT a security control.** Removing the stored ciphertext does
+        not un-share a value a recipient already fetched, nor rotate the live
+        upstream credential. To contain a leak, rotate the upstream credential
+        first, then delete.
+
+        Args:
+            name: Secret name. Slash-containing names (e.g.
+                ``cloudflare/api-token``) are addressable — each path segment is
+                percent-encoded individually so the ``/`` separators stay
+                structural in the URL.
+
+        Raises:
+            KaguraNotFoundError: No such secret (404).
+            KaguraConnectionError: Caller is not the workspace owner (403, the
+                delete is owner-only) or another HTTP/network error.
+        """
+        # Encode each segment but keep the '/' separators so a name like
+        # ``cloudflare/api token`` maps to ``cloudflare/api%20token`` and the
+        # server's ``{name:path}`` converter still routes on the slashes.
+        encoded = "/".join(quote(segment, safe="") for segment in name.split("/"))
+        await self._request("DELETE", f"{_BASE}/{encoded}")
 
     async def verify_audit(self) -> AuditVerifyResponse:
         """Verify the tamper-evident audit chain (owner/admin)."""

--- a/tests/test_secrets_cli.py
+++ b/tests/test_secrets_cli.py
@@ -131,6 +131,9 @@ class FakeSecretClient:
     async def list_secrets(self):
         return self.secrets
 
+    async def delete_secret(self, name):
+        self.calls["delete"] = name
+
 
 @pytest.fixture
 def km():
@@ -346,6 +349,36 @@ def test_revoke_warns_revoke_is_not_invalidation(wired):
     low = result.output.lower()
     assert "rotate" in low
     assert "not" in low and "invalidate" in low
+
+
+# --- delete: owner-only hard delete, with the rotate-first warning ----------
+
+
+def test_delete_with_yes_skips_confirmation(wired):
+    fake, _ = wired
+    result = CliRunner().invoke(secret, ["delete", "db", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert fake.calls["delete"] == "db"
+    assert "deleted secret 'db'" in result.output.lower()
+
+
+def test_delete_prompts_and_warns_rotate_first(wired):
+    fake, _ = wired
+    result = CliRunner().invoke(secret, ["delete", "db"], input="y\n")
+    assert result.exit_code == 0, result.output
+    assert fake.calls["delete"] == "db"
+    low = result.output.lower()
+    # The confirmation must steer the user to rotate the upstream credential
+    # first and make clear delete is cleanup, not a security control.
+    assert "rotate" in low
+    assert "cleanup" in low and "not a security control" in low
+
+
+def test_delete_abort_does_not_call_server(wired):
+    fake, _ = wired
+    result = CliRunner().invoke(secret, ["delete", "db"], input="n\n")
+    assert result.exit_code != 0  # click.confirm(abort=True) → non-zero exit
+    assert "delete" not in fake.calls  # never reached the server
 
 
 # --- exec: env injection without mutating os.environ ------------------------

--- a/tests/test_secrets_client.py
+++ b/tests/test_secrets_client.py
@@ -306,6 +306,56 @@ async def test_revoke_grant():
 
 
 @pytest.mark.asyncio
+async def test_delete_secret_success():
+    client = _client()
+    resp = _mock_response(204, None)
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        result = await client.delete_secret("db")
+    assert result is None
+    method, url = req.call_args[0][0], req.call_args[0][1]
+    assert method == "DELETE"
+    assert url.endswith("/api/v1/config/secrets/db")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_secret_encodes_slash_name_segmentwise():
+    # Slash-containing names must stay addressable: the '/' separators are
+    # structural (the server uses a {name:path} converter), but each segment
+    # is percent-encoded, so a space inside a segment becomes %20.
+    client = _client()
+    resp = _mock_response(204, None)
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = resp
+        await client.delete_secret("cloudflare/api token")
+    url = req.call_args[0][1]
+    assert url.endswith("/api/v1/config/secrets/cloudflare/api%20token")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_secret_missing_raises_not_found():
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(404, "secret not found")
+        with pytest.raises(KaguraNotFoundError):
+            await client.delete_secret("nope")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_secret_non_owner_raises_access_denied():
+    # The delete is owner-only: a non-owner (incl. a non-owner admin) gets 403.
+    client = _client()
+    with patch.object(client._client, "request", new_callable=AsyncMock) as req:
+        req.return_value = _error_response(403, "owner only")
+        with pytest.raises(KaguraConnectionError, match="(?i)access denied"):
+            await client.delete_secret("db")
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_verify_audit():
     client = _client()
     resp = _mock_response(


### PR DESCRIPTION
## Summary

Wraps memory-cloud v0.41.0's **owner-only hard delete** (#1153) for the zero-knowledge secret store, completing the secret client's lifecycle surface (register/put/get/list/grant/revoke/rotate → **delete**).

Additive and backward-compatible — nothing in the current SDK breaks.

- **`SecretClient.delete_secret(name)`** → `DELETE /api/v1/config/secrets/{name}`. The name is encoded **per path segment** (`name.split('/')` → percent-encode each → join with `/`) so slash-containing names like `cloudflare/api-token` stay addressable against the server's `{name:path}` route. 204 → success, 404 → `KaguraNotFoundError`, 403 → owner-only access-denied (`KaguraConnectionError`), via the existing `_request` mapping.
- **`kagura secret delete <name>`** with a confirmation prompt that warns **delete is cleanup, not a security control** — rotate the upstream credential first. `--yes`/`-y` skips the prompt for scripts.
- **Docs/skills**: README command list + capability table + a 0.41.0 compat row; `skills/secret/SKILL.md` (description, command block, and a `delete ≠ invalidation` agent guardrail); `CLAUDE.md` CLI enumeration + capability bullet.

## Tests (TDD)

`tests/test_secrets_client.py`: success (204), slash-name segment-wise encoding round-trip (`cloudflare/api token` → `…/cloudflare/api%20token`), 404 → not-found, 403 → access-denied. `tests/test_secrets_cli.py`: `--yes` skips confirm, prompt warns rotate-first + "cleanup, not a security control", abort (`n`) never calls the server.

Full suite: **1427 passed, 29 skipped**; ruff + pyright clean.

## Design note

The method is named **`delete_secret`** (not the issue's literal `SecretClient.delete(name)`) to match the class's established `*_secret`/`_grant`/`_pubkey` suffix convention (`put_secret`, `list_secrets`, `fetch_secret`, `revoke_grant`) — a bare `delete()` would be the lone outlier and read ambiguously next to `close`/`verify_audit`.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)