### PR TITLE
feat(files): optional context_id binding in FilesClient + FileObject.context_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uv run pyright src/              # Type check
 - Search tuning: `update_search_config` (semantic/bm25 weights, reranking)
 - Resource ingestion: `setup_resource`, `ingest_event`, `ingest_events`
 - Resource stats/schema: `get_resource_impact`, `get_resource_schema`
-- **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+)
+- **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+); optional `binding_context_id` binds a file to an owning context for ACL + nullable `FileObject.context_id` (server v0.41.0+)
 - **Zero-knowledge secrets**: `SecretClient` + `kagura secret` — age recipient encryption, local decrypt; private key in OS keychain via `pyrage`/`keyring` (`[secret]` extra, server v0.39.0+). Owner-only hard delete via `SecretClient.delete_secret` / `kagura secret delete` (server v0.41.0+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This SDK connects your Python code to [Kagura Memory Cloud](https://github.com/k
 | **`KaguraAgent`** | MCP + LLM | AI-powered — auto-decides what to remember/recall from conversations |
 | **`KaguraClient`** | MCP (JSON-RPC) | Direct memory ops — remember, recall, explore, reference, forget |
 | **`ResourceClient`** | REST API | External data ingestion — push data from Slack, CI/CD, CRM into Kagura |
-| **`FilesClient`** | REST + presigned PUT | File uploads with sha256 integrity binding (R2) |
+| **`FilesClient`** | REST + presigned PUT | File uploads with sha256 integrity binding (R2); optional per-file context binding for ACL |
 | **`SecretClient`** | REST + age crypto | Zero-knowledge secrets — age recipient encryption, **local decryption** (the server only ever stores armored ciphertext) |
 | **`FileIngestor`** | CLI + SDK | Document ingestion — PDF/Office/HTML/EPUB, audio & YouTube transcripts → memory graph + R2 archive |
 
@@ -299,6 +299,17 @@ async with FilesClient.from_mcp_url(api_key="kagura_...", mcp_url="https://memor
     # Upload from bytes — filename is required (server enforces non-empty)
     f2 = await client.upload(context_id="ctx-uuid", source=b"...", filename="payload.bin")
 
+    # Optionally bind a file to an owning context for access control (server
+    # v0.41.0+). binding_context_id is the wire `context_id` — distinct from the
+    # `context_id` arg, which is the workspace. Omit it for a workspace-scoped
+    # (NULL-context) file. FileObject.context_id reflects the binding (or None).
+    f3 = await client.upload(
+        context_id="ctx-uuid",
+        source=Path("./plan.pdf"),
+        binding_context_id="owning-ctx-uuid",
+    )
+    print(f3.context_id)  # -> "owning-ctx-uuid"
+
     # Short-lived presigned GET URL
     url = await client.download_url(f.id)
 
@@ -308,6 +319,8 @@ async with FilesClient.from_mcp_url(api_key="kagura_...", mcp_url="https://memor
 ```
 
 Re-uploading bytes whose sha256 already exists in the workspace returns the **existing `FileObject`** (idempotent dedup happy-path) — no exception.
+
+A file bound via `binding_context_id` routes read/write/list/delete through that context's ACL (server v0.41.0+): you need write (EDITOR+) access to the context, and it must belong to the upload's workspace (else `403` / `422`). A denied **download** surfaces as a `404` (existence-hiding), not a `403`. Unbound uploads stay workspace-scoped and fully listable.
 
 Runnable: [`examples/files_upload.py`](examples/files_upload.py).
 
@@ -338,7 +351,7 @@ Most workflows use the CLI instead — see [`kagura secret`](#zero-knowledge-sec
 
 | SDK | Min memory-cloud | Notes |
 |---|---|---|
-| 0.34.0+ | 0.17.1 (0.41.0 for `kagura secret delete`) | **Owner-only secret delete.** `SecretClient.delete_secret` / `kagura secret delete` need memory-cloud **0.41.0+** (`DELETE /api/v1/config/secrets/{name}`). `MIN_SERVER_VERSION` stays **0.17.1** — only the delete surface requires 0.41.0. |
+| 0.34.0+ | 0.17.1 (0.41.0 for secret delete + file context binding) | **Owner-only secret delete + file context binding.** `SecretClient.delete_secret` / `kagura secret delete` (`DELETE /api/v1/config/secrets/{name}`) and `FilesClient.upload(binding_context_id=…)` / `FileObject.context_id` (context-scoped file ACL) need memory-cloud **0.41.0+**. `MIN_SERVER_VERSION` stays **0.17.1** — only these surfaces require 0.41.0. |
 | 0.33.0+ | 0.17.1 (0.39.0 for `kagura secret`) | **Zero-knowledge secret store.** `SecretClient` / `kagura secret` need memory-cloud **0.39.0+** (the `/api/v1/config/secrets` endpoints). `MIN_SERVER_VERSION` is **not** bumped — the rest of the SDK still works on 0.17.1+; only the secret surface requires 0.39.0. Requires the `[secret]` extra. |
 | 0.27.0 – 0.31.x | 0.17.1 | **Agent memory substrate.** `load_pinned` + `delivery_mode` pin-on-write, `recall_upcoming`, `feedback`, `set_state`/`get_state`, and the `trust_tier` recall filter each need a memory-cloud carrying the matching [#885](https://github.com/kagura-ai/memory-cloud/issues/885) agent-substrate APIs (≈ v0.23.0+); against an older server those specific tools return an MCP "tool not found". `MIN_SERVER_VERSION` stays **0.17.1** — the rest of the SDK still works on 0.17.1+. **v0.29.0 also changed error handling (breaking): MCP tool methods now raise `KaguraNotFoundError`/`KaguraError` instead of returning `{"status":"error"}` dicts** (see the KaguraClient error-handling note above). |
 | 0.15.0 – 0.20.x | 0.15.1 | `FilesClient` + R2 checksum binding. `list_tags()` additionally needs **0.15.4** — `MIN_SERVER_VERSION` is intentionally not bumped, only that one method requires the newer server. |
@@ -441,6 +454,7 @@ kagura sleep rollback <context-id> <report-id> -y    # destructive: prompts unle
 
 # File uploads (R2 checksum binding)
 kagura files upload ./report.pdf -c <context-id>
+kagura files upload ./plan.pdf -c <context-id> --binding-context-id <ctx>   # bind to an owning context for ACL (v0.41.0+)
 kagura files list -c <context-id> --limit 50
 kagura files download-url <file-id>
 kagura files delete <file-id>
@@ -564,7 +578,7 @@ follow-up.
 | Resource Event ingestion | `ResourceClient` | REST API | Resource Token |
 | Resource Impact (stats) | `ResourceClient` | REST API | API Key |
 | Resource Schema | `ResourceClient` | REST API | API Key |
-| File upload / download-url / delete / list | `FilesClient` | REST + presigned PUT | API Key |
+| File upload (optional context binding) / download-url / delete / list | `FilesClient` | REST + presigned PUT | API Key |
 | Secret pubkey registry (register/list/me/approve/revoke) | `SecretClient` | REST API | API Key / OAuth |
 | Secret put / fetch / list / revoke-grant / delete / audit-verify | `SecretClient` | REST API (age, local decrypt) | API Key / OAuth |
 | Account erasure (GDPR Art.17 / APPI) | — | Web UI only | Session |

--- a/examples/files_upload.py
+++ b/examples/files_upload.py
@@ -44,6 +44,22 @@ async def main():
             filename="example.txt",
         )
         print(f"Uploaded: id={obj.id} sha256={obj.sha256[:12]}... size={obj.size_bytes}B")
+        # Unbound upload → context_id is None (workspace-scoped, fully listable).
+        print(f"Binding context: {obj.context_id}")
+
+        # Optional: bind a file to an owning context for access control
+        # (server v0.41.0+). binding_context_id is the wire `context_id` —
+        # distinct from `context_id` above (the workspace). The bound context
+        # must be a write-accessible context within the workspace (else
+        # 403 / 422), so this is shown as a snippet rather than executed:
+        #
+        #   bound = await files.upload(
+        #       context_id=ctx,
+        #       source=b"...",
+        #       filename="bound.txt",
+        #       binding_context_id="<owning-context-uuid>",
+        #   )
+        #   print(bound.context_id)  # -> "<owning-context-uuid>"
 
         # Re-uploading identical bytes is idempotent — returns the existing object.
         dup = await files.upload(

--- a/skills/files/SKILL.md
+++ b/skills/files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: files
-description: Upload, list, delete, and get download URLs for files in Kagura Memory's R2 storage (sha256 integrity-bound). Use when the user wants to attach or manage raw files in their workspace.
+description: Upload, list, delete, and get download URLs for files in Kagura Memory's R2 storage (sha256 integrity-bound; an upload can optionally be bound to an owning context for access control). Use when the user wants to attach or manage raw files in their workspace.
 ---
 
 # kagura files — R2 file storage
@@ -19,6 +19,7 @@ binding). Thin wrapper around the installed `kagura` CLI.
 
 ```bash
 kagura files upload ./data.bin          # upload (sha256-bound presigned PUT)
+kagura files upload ./data.bin --binding-context-id <ctx>   # bind the file to an owning context for ACL (server v0.41.0+)
 kagura files list                       # list stored files
 kagura files download-url <file_id>     # short-lived GET URL
 kagura files delete <file_id>           # delete a file
@@ -28,3 +29,7 @@ kagura files delete <file_id>           # delete a file
 
 - Relay the returned file id and download URL. **Download URLs are short-lived**
   — do not cache them; re-run `download-url` when one expires.
+- `--binding-context-id` (the file's owning context for ACL) is **distinct from**
+  `--context-id` (the workspace). Bound files route read/write/list/delete through
+  that context's ACL; an unbound upload stays workspace-scoped. A denied download
+  is reported as a 404 (existence-hiding), not a 403.

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -1984,6 +1984,16 @@ async def _remember_file_object(
 @click.option("--context-id", "-c", help="Target context (workspace) UUID")
 @click.option("--content-type", "-t", help="MIME type override (default: sniffed)")
 @click.option(
+    "--binding-context-id",
+    "binding_context_id",
+    default=None,
+    help=(
+        "Optional owning context UUID to bind the file to for access control "
+        "(server v0.41.0+). Distinct from --context-id (the workspace). Must be a "
+        "write-accessible context within the workspace. Omit for a workspace-scoped file."
+    ),
+)
+@click.option(
     "--remember",
     is_flag=True,
     default=False,
@@ -2028,6 +2038,7 @@ def files_upload(
     path: Path,
     context_id: str | None,
     content_type: str | None,
+    binding_context_id: str | None,
     remember: bool,
     summary: str | None,
     memory_type: str,
@@ -2060,6 +2071,7 @@ def files_upload(
             context_id=ctx,
             source=path,
             content_type=content_type,
+            binding_context_id=binding_context_id,
             logger=logger,
         )
         if not remember:

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -354,6 +354,7 @@ class FilesClient:
         source: Path | bytes,
         filename: str | None = None,
         content_type: str | None = None,
+        binding_context_id: str | None = None,
         logger: VerboseLogger | None = None,
     ) -> FileObject:
         """Upload a file to Kagura Memory Cloud.
@@ -384,6 +385,15 @@ class FilesClient:
             content_type: MIME type. When omitted, falls back to
                 :func:`mimetypes.guess_type` and then to
                 ``application/octet-stream``.
+            binding_context_id: Optional owning context to bind the file
+                to for access control (server v0.41.0+). It is sent as the
+                wire ``context_id`` field — **distinct** from the
+                ``context_id`` parameter above, which maps to
+                ``workspace_id``. The caller must have write (EDITOR+)
+                access to this context and it must belong to the upload's
+                workspace, else the server returns 403 / 422 respectively.
+                When omitted the file is NULL-context (workspace-scoped,
+                legacy behaviour) and stays fully listable.
 
         Returns:
             FileObject with the finalized file metadata. When the file
@@ -428,13 +438,18 @@ class FilesClient:
                 f"{resolved_filename} ({size_bytes} bytes)",
                 stage="reserve",
             )
-            reserve_body = {
+            reserve_body: dict[str, Any] = {
                 "workspace_id": context_id,
                 "filename": resolved_filename,
                 "content_type": resolved_content_type,
                 "size_bytes": size_bytes,
                 "sha256": sha256_hex,
             }
+            # Only send context_id when a binding was requested — omitting it
+            # keeps the upload NULL-context (workspace-scoped, legacy behaviour),
+            # which is exactly what the server expects for an unbound file.
+            if binding_context_id is not None:
+                reserve_body["context_id"] = binding_context_id
 
             try:
                 reserve_resp = await self._request(

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -765,7 +765,19 @@ class FileObject(BaseModel):
     ``status`` is typed as ``str`` (not a ``Literal``) because the server
     may add new lifecycle states over time. Known values today:
     ``reserved``, ``uploaded``, ``confirmed``.
+
+    ``context_id`` is the owning context a file is bound to for access
+    control (server v0.41.0+). It is ``None`` for legacy/workspace-scoped
+    files that were uploaded with no binding context — those stay fully
+    listable and accessible to the workspace.
+
+    ``extra="ignore"`` is explicit (matching the other wire-shape response
+    models): a strict model would 500 the SDK the moment the server adds a
+    field, so forward-compat tolerance is a deliberate contract, not an
+    accident of the pydantic default.
     """
+
+    model_config = ConfigDict(extra="ignore")
 
     id: str
     workspace_id: str
@@ -776,6 +788,7 @@ class FileObject(BaseModel):
     status: str
     created_at: datetime
     uploaded_at: datetime | None = None
+    context_id: str | None = None
 
 
 class FileReserveResponse(BaseModel):

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -39,6 +39,7 @@ def _isolate_oauth_state(tmp_path, monkeypatch):
 
 SAMPLE_CTX_ID = "00000000-0000-0000-0000-000000000001"
 SAMPLE_FILE_ID = "10000000-0000-0000-0000-000000000002"
+SAMPLE_BINDING_CTX_ID = "00000000-0000-0000-0000-0000000000bb"
 
 
 def _file_object() -> FileObject:
@@ -105,6 +106,50 @@ def test_files_upload(mock_client_cls, mock_config, tmp_path):
     call = mock_client.upload.call_args
     assert call.kwargs["context_id"] == SAMPLE_CTX_ID
     assert call.kwargs["source"] == p
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_forwards_binding_context_id(mock_client_cls, mock_config, tmp_path):
+    """`files upload --binding-context-id <ctx>` threads binding_context_id to upload()."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_client = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_client_cls, mock_client)
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["files", "upload", str(p), "--binding-context-id", SAMPLE_BINDING_CTX_ID]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert mock_client.upload.call_args.kwargs["binding_context_id"] == SAMPLE_BINDING_CTX_ID
+
+
+@patch("kagura_memory.cli.load_config")
+@patch("kagura_memory.cli.FilesClient")
+def test_files_upload_without_binding_flag_passes_none(mock_client_cls, mock_config, tmp_path):
+    """Without --binding-context-id, the CLI passes binding_context_id=None (NULL-context)."""
+    mock_config.return_value = {
+        "api_key": "key",
+        "mcp_url": "https://test.com/mcp",
+        "context_id": SAMPLE_CTX_ID,
+    }
+    mock_client = _mock_files_client("upload", _file_object())
+    _wire_files_client_mock(mock_client_cls, mock_client)
+
+    p = tmp_path / "hello.txt"
+    p.write_text("hi")
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "upload", str(p)])
+
+    assert result.exit_code == 0, result.output
+    assert mock_client.upload.call_args.kwargs["binding_context_id"] is None
 
 
 def _mock_kagura_client(mock_client_cls: MagicMock) -> MagicMock:

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -37,6 +37,7 @@ SAMPLE_SHA256_HEX = hashlib.sha256(SAMPLE_BODY).hexdigest()
 SAMPLE_SHA256_B64 = base64.b64encode(hashlib.sha256(SAMPLE_BODY).digest()).decode()
 SAMPLE_CTX_ID = "00000000-0000-0000-0000-000000000001"
 SAMPLE_FILE_ID = "10000000-0000-0000-0000-000000000002"
+SAMPLE_BINDING_CTX_ID = "00000000-0000-0000-0000-0000000000bb"
 
 
 def _ok_response(
@@ -88,6 +89,35 @@ def _reserve_response_dict(
         "upload_url": upload_url,
         "expires_at": "2026-05-11T00:05:00Z",
     }
+
+
+# ============================================================================
+# FileObject model — optional context_id binding (#222, server v0.41.0)
+# ============================================================================
+
+
+def test_file_object_reads_context_id_and_ignores_unknown_fields():
+    """FileObject exposes the new nullable context_id and tolerates unknown fields.
+
+    The server's FileObjectOut gained a nullable context_id (the owning context
+    for ACL). The SDK model must surface it AND stay lenient about other future
+    server fields — a strict (extra='forbid') model would 500 the SDK the moment
+    the server adds context_id. This pins both halves of the contract.
+    """
+    fo = FileObject.model_validate(
+        {
+            **_file_object_dict(),
+            "context_id": SAMPLE_BINDING_CTX_ID,
+            "some_future_field": "ignored",  # forward-compat: must not raise
+        }
+    )
+    assert fo.context_id == SAMPLE_BINDING_CTX_ID
+
+
+def test_file_object_context_id_defaults_none_when_absent():
+    """A legacy (NULL-context) file has no context_id key → defaults to None."""
+    fo = FileObject.model_validate(_file_object_dict())
+    assert fo.context_id is None
 
 
 # ============================================================================
@@ -580,6 +610,110 @@ async def test_upload_bytes_requires_filename():
     mock_req.assert_not_called()
     mock_put.assert_not_called()
     await client.close()
+
+
+# ============================================================================
+# upload() — optional context_id binding (#222, server v0.41.0)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_upload_forwards_binding_context_id_to_reserve():
+    """binding_context_id rides the reserve body as the wire field `context_id`.
+
+    The wire `context_id` is the server's owning-context ACL binding — distinct
+    from the SDK's `context_id` param, which maps to `workspace_id`. Both travel
+    on the same reserve body when a binding is requested.
+    """
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(
+            context_id=SAMPLE_CTX_ID,
+            source=SAMPLE_BODY,
+            filename="hello.txt",
+            binding_context_id=SAMPLE_BINDING_CTX_ID,
+        )
+
+    reserve_body = mock_req.call_args_list[0][1]["json"]
+    assert reserve_body["workspace_id"] == SAMPLE_CTX_ID
+    assert reserve_body["context_id"] == SAMPLE_BINDING_CTX_ID
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_without_binding_context_id_omits_context_id():
+    """Legacy path: no binding → no `context_id` key in the reserve body (NULL-context)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(context_id=SAMPLE_CTX_ID, source=SAMPLE_BODY, filename="hello.txt")
+
+    reserve_body = mock_req.call_args_list[0][1]["json"]
+    assert "context_id" not in reserve_body
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_422_binding_context_not_in_workspace_surfaces_detail():
+    """A binding context outside the workspace → 422; the server detail must surface."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    reserve_422 = _error_response(422, {"detail": "context does not belong to this workspace"})
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = reserve_422
+        with pytest.raises(KaguraConnectionError, match="does not belong to this workspace"):
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+                binding_context_id=SAMPLE_BINDING_CTX_ID,
+            )
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_403_binding_context_denied_surfaces_detail():
+    """Write-denied on the binding context → 403; the server's reason must surface."""
+    client = FilesClient(
+        api_key="test",
+        base_url="https://example.com",
+        _auth_source="config",
+        _workspace_id_hint="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    )
+    reserve_403 = _error_response(403, {"detail": "context write denied"})
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = reserve_403
+        with pytest.raises(KaguraConnectionError) as exc_info:
+            await client.upload(
+                context_id=SAMPLE_CTX_ID,
+                source=SAMPLE_BODY,
+                filename="hello.txt",
+                binding_context_id=SAMPLE_BINDING_CTX_ID,
+            )
+        msg = str(exc_info.value)
+    await client.close()
+
+    assert "context write denied" in msg
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Wraps memory-cloud v0.41.0's **context-scoped file ACL** (#1136): a file can be bound to an owning `context_id`, and read/write/list/delete then route through that context's ACL. Binding is **optional** — an unbound upload stays workspace-scoped (legacy behaviour).

**Backward-compatible** — existing `FilesClient.upload(context_id=...)` callers are unaffected; the legacy reserve body is byte-for-byte unchanged when no binding is requested.

- **`FileObject.context_id: str | None`** — the owning context (None for legacy/workspace-scoped files). `model_config = ConfigDict(extra="ignore")` is now **explicit** (matching the other wire-shape response models) so forward-compat tolerance is a deliberate contract, not an accident of the pydantic default — exactly the "verify it's lenient, not `forbid`" acceptance criterion.
- **`FilesClient.upload(binding_context_id=...)`** → sent as the wire `context_id` on `POST /files/reserve`. **Distinct** from the SDK's `context_id` param, which maps to `workspace_id`; the two never collide (separate dict keys, added only when a binding is requested). `403` (write denied) / `422` (context not in workspace) surface the server detail via the existing `_request` mapping; the 409 dedup path does not swallow them.
- **`kagura files upload --binding-context-id <ctx>`** CLI flag, threaded as a distinct kwarg (default `None`).
- **Docs**: README (client overview, FilesClient section + sample, CLI block, coverage matrix, a 0.41.0 compat row), `CLAUDE.md`, `skills/files/SKILL.md`, and the cited `examples/files_upload.py`.

## Naming

The new parameter is **`binding_context_id`** (not a second `context_id`) because the SDK's existing `context_id` is taken — it maps to `workspace_id`. Confirmed with the maintainer. The wire field it forwards to is the server's `context_id`.

## Tests (strict TDD)

Each behaviour was driven RED→GREEN. `tests/test_files_client.py`: `FileObject.context_id` exposed + unknown-field tolerance, defaults `None` when absent; `upload` forwards `binding_context_id` as wire `context_id`, omits it on the legacy path, and surfaces 403/422 server detail. `tests/test_cli_files.py`: `--binding-context-id` forwards through, and absence passes `None`.

Full suite: **1435 passed, 29 skipped**; ruff + pyright clean.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)