### PR TITLE
fix(files): restore FilesClient compatibility with memory-cloud v0.41.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uv run pyright src/              # Type check
 - Search tuning: `update_search_config` (semantic/bm25 weights, reranking)
 - Resource ingestion: `setup_resource`, `ingest_event`, `ingest_events`
 - Resource stats/schema: `get_resource_impact`, `get_resource_schema`
-- **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+); optional `binding_context_id` binds a file to an owning context for ACL + nullable `FileObject.context_id` (server v0.41.0+)
+- **File uploads**: `FilesClient.upload/download_url/delete/list` with R2 sha256 binding (server v0.15.1+); optional `binding_context_id` binds a file to an owning context for ACL + nullable `FileObject.context_id` (server v0.41.0+). Against v0.41.0 the file-id endpoints require `workspace_id` on the query, so `download_url`/`delete` take a **required** `context_id` and the PUT sends the checksum header only when the presign signed it (#226)
 - **Zero-knowledge secrets**: `SecretClient` + `kagura secret` — age recipient encryption, local decrypt; private key in OS keychain via `pyrage`/`keyring` (`[secret]` extra, server v0.39.0+). Owner-only hard delete via `SecretClient.delete_secret` / `kagura secret delete` (server v0.41.0+)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ kagura ingest ./report.pdf
 
 ```bash
 kagura recall "report findings" -k 5        # search across sections
-kagura files download-url <file_id>          # short-lived GET on the original
+kagura files download-url <file_id> -c <context-id>   # short-lived GET on the original
 ```
 
 Ingestion extracts **text** — from PDFs, Office/HTML/EPUB documents, audio/video transcripts, and YouTube captions. Images embedded in a document are detected and counted (`IngestResult.skipped_images`) but not yet OCR'd: a vision provider (Gemini 2.5 Flash by default) is configured and validated, but the orchestrator does not currently invoke `Provider.describe_image()` — image-to-text memories are a planned follow-up. Pass `--no-vision` to skip provider configuration entirely, or `--dry-run` to see token / cost estimates without calling an LLM.
@@ -310,12 +310,13 @@ async with FilesClient.from_mcp_url(api_key="kagura_...", mcp_url="https://memor
     )
     print(f3.context_id)  # -> "owning-ctx-uuid"
 
-    # Short-lived presigned GET URL
-    url = await client.download_url(f.id)
+    # Short-lived presigned GET URL. download_url / delete require the owning
+    # context_id (workspace) — server v0.41.0 scopes file-id lookups to it.
+    url = await client.download_url(f.id, context_id="ctx-uuid")
 
     # List & delete
     page = await client.list(context_id="ctx-uuid", limit=50)
-    await client.delete(f.id)
+    await client.delete(f.id, context_id="ctx-uuid")
 ```
 
 Re-uploading bytes whose sha256 already exists in the workspace returns the **existing `FileObject`** (idempotent dedup happy-path) — no exception.
@@ -351,6 +352,7 @@ Most workflows use the CLI instead — see [`kagura secret`](#zero-knowledge-sec
 
 | SDK | Min memory-cloud | Notes |
 |---|---|---|
+| 0.35.0+ | 0.17.1 (0.41.0 for file uploads/downloads) | **FilesClient v0.41.0 compatibility (breaking).** memory-cloud 0.41.0 requires `workspace_id` on the query of the file-id endpoints (`confirm`/`download-url`/`delete`) and presigns R2 PUT without the checksum header — so pre-0.35.0 SDKs get 403/422 on every upload/download/delete against it. This SDK sends `workspace_id` on those endpoints (harmlessly ignored by older servers) and only binds the checksum when the presign signed it. **Breaking:** `FilesClient.download_url(file_id, *, context_id)` and `delete(file_id, *, context_id)` now require `context_id`; `kagura files download-url`/`delete` require `-c/--context-id` (or a profile/`.kagura.json` workspace). `MIN_SERVER_VERSION` stays **0.17.1**. |
 | 0.34.0+ | 0.17.1 (0.41.0 for secret delete + file context binding) | **Owner-only secret delete + file context binding.** `SecretClient.delete_secret` / `kagura secret delete` (`DELETE /api/v1/config/secrets/{name}`) and `FilesClient.upload(binding_context_id=…)` / `FileObject.context_id` (context-scoped file ACL) need memory-cloud **0.41.0+**. `MIN_SERVER_VERSION` stays **0.17.1** — only these surfaces require 0.41.0. |
 | 0.33.0+ | 0.17.1 (0.39.0 for `kagura secret`) | **Zero-knowledge secret store.** `SecretClient` / `kagura secret` need memory-cloud **0.39.0+** (the `/api/v1/config/secrets` endpoints). `MIN_SERVER_VERSION` is **not** bumped — the rest of the SDK still works on 0.17.1+; only the secret surface requires 0.39.0. Requires the `[secret]` extra. |
 | 0.27.0 – 0.31.x | 0.17.1 | **Agent memory substrate.** `load_pinned` + `delivery_mode` pin-on-write, `recall_upcoming`, `feedback`, `set_state`/`get_state`, and the `trust_tier` recall filter each need a memory-cloud carrying the matching [#885](https://github.com/kagura-ai/memory-cloud/issues/885) agent-substrate APIs (≈ v0.23.0+); against an older server those specific tools return an MCP "tool not found". `MIN_SERVER_VERSION` stays **0.17.1** — the rest of the SDK still works on 0.17.1+. **v0.29.0 also changed error handling (breaking): MCP tool methods now raise `KaguraNotFoundError`/`KaguraError` instead of returning `{"status":"error"}` dicts** (see the KaguraClient error-handling note above). |
@@ -456,8 +458,8 @@ kagura sleep rollback <context-id> <report-id> -y    # destructive: prompts unle
 kagura files upload ./report.pdf -c <context-id>
 kagura files upload ./plan.pdf -c <context-id> --binding-context-id <ctx>   # bind to an owning context for ACL (v0.41.0+)
 kagura files list -c <context-id> --limit 50
-kagura files download-url <file-id>
-kagura files delete <file-id>
+kagura files download-url <file-id> -c <context-id>   # -c required (server v0.41.0)
+kagura files delete <file-id> -c <context-id>         # -c required (server v0.41.0)
 
 # Config
 kagura config show

--- a/examples/files_upload.py
+++ b/examples/files_upload.py
@@ -69,8 +69,10 @@ async def main():
         )
         print(f"Dedup happy-path: same id? {dup.id == obj.id}")
 
-        # Short-lived presigned GET URL for the original bytes.
-        url = await files.download_url(obj.id)
+        # Short-lived presigned GET URL for the original bytes. download_url /
+        # delete require the owning context_id (workspace) — server v0.41.0
+        # scopes file-id lookups to it.
+        url = await files.download_url(obj.id, context_id=ctx)
         print(f"Download URL (expires shortly): {url[:60]}...")
 
         # List files in the context, newest first.
@@ -78,7 +80,7 @@ async def main():
         print(f"Files in context: {len(page.files)}")
 
         # Cleanup.
-        await files.delete(obj.id)
+        await files.delete(obj.id, context_id=ctx)
         print(f"Deleted: {obj.id}")
 
 

--- a/skills/files/SKILL.md
+++ b/skills/files/SKILL.md
@@ -21,8 +21,8 @@ binding). Thin wrapper around the installed `kagura` CLI.
 kagura files upload ./data.bin          # upload (sha256-bound presigned PUT)
 kagura files upload ./data.bin --binding-context-id <ctx>   # bind the file to an owning context for ACL (server v0.41.0+)
 kagura files list                       # list stored files
-kagura files download-url <file_id>     # short-lived GET URL
-kagura files delete <file_id>           # delete a file
+kagura files download-url <file_id> -c <ctx>   # short-lived GET URL (context required, server v0.41.0+)
+kagura files delete <file_id> -c <ctx>         # delete a file (context required, server v0.41.0+)
 ```
 
 ## Consume the result

--- a/src/kagura_memory/cli.py
+++ b/src/kagura_memory/cli.py
@@ -2099,35 +2099,43 @@ def files_upload(
 
 @files.command(name="download-url")
 @click.argument("file_id")
-def files_download_url(file_id: str):
+@click.option("--context-id", "-c", help="Context (workspace) UUID the file belongs to")
+def files_download_url(file_id: str, context_id: str | None):
     """
     Print a short-lived presigned GET URL for a file.
 
+    The owning context (workspace) is required (server v0.41.0): pass
+    ``--context-id`` or set it in your OAuth profile / .kagura.json.
+
     Example:
-      kagura files download-url <file_id>
+      kagura files download-url <file_id> -c <context-id>
     """
 
-    async def op(client: FilesClient, _ctx: str) -> str:
-        return await client.download_url(file_id)
+    async def op(client: FilesClient, ctx: str) -> str:
+        return await client.download_url(file_id, context_id=ctx)
 
-    _run_files_command(op, None, needs_context=False)
+    _run_files_command(op, context_id)
 
 
 @files.command(name="delete")
 @click.argument("file_id")
-def files_delete(file_id: str):
+@click.option("--context-id", "-c", help="Context (workspace) UUID the file belongs to")
+def files_delete(file_id: str, context_id: str | None):
     """
     Soft-delete a file by id.
 
+    The owning context (workspace) is required (server v0.41.0): pass
+    ``--context-id`` or set it in your OAuth profile / .kagura.json.
+
     Example:
-      kagura files delete <file_id>
+      kagura files delete <file_id> -c <context-id>
     """
 
-    async def op(client: FilesClient, _ctx: str) -> str:
-        await client.delete(file_id)
+    async def op(client: FilesClient, ctx: str) -> str:
+        await client.delete(file_id, context_id=ctx)
         return f"Deleted {file_id}"
 
-    _run_files_command(op, None, needs_context=False)
+    _run_files_command(op, context_id)
 
 
 @files.command(name="list")

--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -26,6 +26,7 @@ import mimetypes
 import uuid
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 
@@ -268,10 +269,12 @@ class FilesClient:
                 # targets workspace B). Surface the credential source and
                 # requested workspace prefix so the cause is visible without
                 # leaking the api_key value or Bearer header. The hint shape
-                # adapts to whether the failing request carries a workspace —
-                # file-id-based endpoints (download-url/delete) don't, so the
-                # "workspace not accessible / --context-id" language is
-                # suppressed for those to avoid misleading operators.
+                # adapts to whether the failing request carries a workspace. As
+                # of memory-cloud v0.41.0 every file endpoint (reserve / confirm
+                # / download-url / delete / list) puts workspace_id on the wire,
+                # so the workspace-mismatch heading is emitted for all of them;
+                # the generic "access denied" heading remains only as a
+                # defensive fallback for a request that carries no workspace.
                 raise KaguraConnectionError(
                     _format_workspace_403_hint(
                         auth_source=self._auth_source,
@@ -315,17 +318,20 @@ class FilesClient:
         the documented and observed common cause; parsing the
         S3-XML error body for finer discrimination is out of scope
         for v0.14.0.
+
+        The checksum header is sent **only when the presign signed it**
+        (``X-Amz-SignedHeaders`` contains ``x-amz-checksum-sha256``). A
+        server with R2 checksum binding OFF presigns without it, and
+        sending it anyway makes the SigV4 signature mismatch → R2 rejects
+        with 403 SignatureDoesNotMatch (#226). The sha256 is re-sent at
+        the confirm step regardless, so server-side verification still
+        holds when binding is off.
         """
-        checksum_b64 = base64.b64encode(bytes.fromhex(sha256_hex)).decode()
+        headers = {"Content-Type": content_type}
+        if _presign_signs_checksum(upload_url):
+            headers["x-amz-checksum-sha256"] = base64.b64encode(bytes.fromhex(sha256_hex)).decode()
         try:
-            response = await self._upload_client.put(
-                upload_url,
-                content=body,
-                headers={
-                    "Content-Type": content_type,
-                    "x-amz-checksum-sha256": checksum_b64,
-                },
-            )
+            response = await self._upload_client.put(upload_url, content=body, headers=headers)
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 400:
@@ -482,9 +488,13 @@ class FilesClient:
 
             log.action("Confirming upload", stage="confirm")
             confirm_started = True
+            # workspace_id is required on the confirm query string (memory-cloud
+            # v0.41.0); omitting it returns 422 VAL-001 and the upload never
+            # finalizes. context_id is the SDK's name for the workspace on the wire.
             confirm_resp = await self._request(
                 "POST",
                 f"/api/v1/files/{reserve.file_id}/confirm",
+                params={"workspace_id": context_id},
                 json={"sha256": sha256_hex},
             )
             result = FileObject.model_validate(confirm_resp.json())
@@ -514,14 +524,42 @@ class FilesClient:
             )
             raise
 
-    async def download_url(self, file_id: str) -> str:
-        """Return a short-lived presigned GET URL for ``file_id``."""
-        response = await self._request("GET", f"/api/v1/files/{file_id}/download-url")
+    async def download_url(self, file_id: str, *, context_id: str) -> str:
+        """Return a short-lived presigned GET URL for ``file_id``.
+
+        Args:
+            file_id: The file object id.
+            context_id: The owning workspace UUID. **Required** — memory-cloud
+                v0.41.0 scopes file-id lookups to the workspace and returns 422
+                without ``workspace_id`` on the query. Sent as ``workspace_id``
+                (the SDK's consistent ``context_id`` → ``workspace_id`` wire
+                mapping). A file bound to a private context the caller can't
+                read is reported as 404 (existence-hiding); a workspace mismatch
+                (wrong ``context_id``) surfaces as a 403 with an actionable hint.
+        """
+        _validate_context_id(context_id)
+        response = await self._request(
+            "GET",
+            f"/api/v1/files/{file_id}/download-url",
+            params={"workspace_id": context_id},
+        )
         return FileDownloadUrlResponse.model_validate(response.json()).download_url
 
-    async def delete(self, file_id: str) -> None:
-        """Soft-delete a file by id (server hard-deletes after retention)."""
-        await self._request("DELETE", f"/api/v1/files/{file_id}")
+    async def delete(self, file_id: str, *, context_id: str) -> None:
+        """Soft-delete a file by id (server hard-deletes after retention).
+
+        Args:
+            file_id: The file object id.
+            context_id: The owning workspace UUID. **Required** (memory-cloud
+                v0.41.0); sent as ``workspace_id`` on the query. Omitting it
+                returns 422.
+        """
+        _validate_context_id(context_id)
+        await self._request(
+            "DELETE",
+            f"/api/v1/files/{file_id}",
+            params={"workspace_id": context_id},
+        )
 
     async def list(
         self,
@@ -612,10 +650,11 @@ def _extract_requested_workspace(
 ) -> str | None:
     """Recover the ``workspace_id`` the failing request was targeting.
 
-    File endpoints carry workspace_id in either the JSON body (reserve)
-    or the query string (list). Returns ``None`` when the request was
-    file-id based (download-url / delete / confirm) and no workspace
-    information is on the wire.
+    File endpoints carry workspace_id in either the JSON body (reserve) or the
+    query string (confirm / download-url / delete / list, all of which put it
+    on the query as of memory-cloud v0.41.0). Returns ``None`` only as a
+    defensive fallback when neither the body nor the params carries a
+    ``workspace_id`` — no current file request hits that path.
     """
     if json is not None:
         ws = json.get("workspace_id")
@@ -760,6 +799,27 @@ def _validate_context_id(context_id: str) -> None:
             "Use the OAuth profile's workspace_id, a UUID from "
             "`kagura context list`, or run `kagura auth login` first."
         ) from e
+
+
+def _presign_signs_checksum(upload_url: str) -> bool:
+    """True if the presigned URL signed the sha256 checksum header.
+
+    Reads ``X-Amz-SignedHeaders`` from the presigned PUT URL's query and reports
+    whether it lists ``x-amz-checksum-sha256`` (case-insensitive). The SDK must
+    send the checksum header only when the server bound it into the presign (R2
+    checksum binding on). Sending it against a presign that did not sign it
+    invalidates the SigV4 signature and R2 rejects the PUT with 403
+    SignatureDoesNotMatch (#226).
+
+    Args:
+        upload_url: The presigned R2 PUT URL returned by ``/files/reserve``.
+
+    Returns:
+        ``True`` when ``x-amz-checksum-sha256`` is in the signed-headers set,
+        ``False`` otherwise (including when the URL has no query string).
+    """
+    signed = parse_qs(urlparse(upload_url).query).get("X-Amz-SignedHeaders", [""])[0]
+    return "x-amz-checksum-sha256" in signed.lower()
 
 
 def _resolve_content_type(content_type: str | None, filename: str) -> str:

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -421,11 +421,30 @@ def test_files_download_url(mock_client_cls, mock_config):
     _wire_files_client_mock(mock_client_cls, mock_client)
 
     runner = CliRunner()
-    result = runner.invoke(main, ["files", "download-url", SAMPLE_FILE_ID])
+    result = runner.invoke(main, ["files", "download-url", SAMPLE_FILE_ID, "-c", SAMPLE_CTX_ID])
 
     assert result.exit_code == 0, result.output
     assert "https://r2.example.com/get/key" in result.output
-    mock_client.download_url.assert_awaited_once_with(SAMPLE_FILE_ID)
+    mock_client.download_url.assert_awaited_once_with(SAMPLE_FILE_ID, context_id=SAMPLE_CTX_ID)
+
+
+@patch("kagura_memory.cli.load_config")
+def test_files_download_url_requires_context(mock_config, monkeypatch, tmp_path):
+    """`files download-url` now needs a resolvable workspace (v0.41.0 breaking change).
+
+    With no --context-id, no OAuth profile, and no .kagura.json context_id, the
+    command errors instead of hitting the server and getting a 422.
+    """
+    mock_config.return_value = {"api_key": "key", "mcp_url": "https://test.com/mcp"}
+    monkeypatch.delenv("KAGURA_PROFILE", raising=False)
+    monkeypatch.setattr(
+        "kagura_memory.auth.credentials.DEFAULT_CREDENTIALS_PATH",
+        tmp_path / "missing-credentials.json",
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["files", "download-url", SAMPLE_FILE_ID])
+    assert result.exit_code != 0
+    assert "context_id is missing" in result.output or "--context-id" in result.output
 
 
 @patch("kagura_memory.cli.load_config")
@@ -436,11 +455,11 @@ def test_files_delete(mock_client_cls, mock_config):
     _wire_files_client_mock(mock_client_cls, mock_client)
 
     runner = CliRunner()
-    result = runner.invoke(main, ["files", "delete", SAMPLE_FILE_ID])
+    result = runner.invoke(main, ["files", "delete", SAMPLE_FILE_ID, "-c", SAMPLE_CTX_ID])
 
     assert result.exit_code == 0, result.output
     assert f"Deleted {SAMPLE_FILE_ID}" in result.output
-    mock_client.delete.assert_awaited_once_with(SAMPLE_FILE_ID)
+    mock_client.delete.assert_awaited_once_with(SAMPLE_FILE_ID, context_id=SAMPLE_CTX_ID)
 
 
 @patch("kagura_memory.cli.load_config")

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -82,8 +82,25 @@ def _file_object_dict(file_id: str = SAMPLE_FILE_ID, status: str = "uploaded") -
 
 def _reserve_response_dict(
     file_id: str = SAMPLE_FILE_ID,
-    upload_url: str = "https://r2.example.com/bucket/key",
+    upload_url: str | None = None,
+    *,
+    sign_checksum: bool = True,
 ) -> dict:
+    """Build a reserve response with a SigV4-style presigned ``upload_url``.
+
+    ``sign_checksum`` controls whether ``X-Amz-SignedHeaders`` lists
+    ``x-amz-checksum-sha256`` — i.e. whether the server enabled R2 checksum
+    binding. The SDK must only send the checksum header when the presign
+    signed it, else R2 rejects the PUT with 403 SignatureDoesNotMatch (#226).
+    """
+    if upload_url is None:
+        signed = "content-length;content-type;host"
+        if sign_checksum:
+            signed += ";x-amz-checksum-sha256"
+        upload_url = (
+            f"https://r2.example.com/bucket/key?X-Amz-SignedHeaders={signed}"
+            "&X-Amz-Signature=deadbeef"
+        )
     return {
         "file_id": file_id,
         "upload_url": upload_url,
@@ -492,6 +509,110 @@ async def test_upload_sends_base64_raw_digest_header():
     await client.close()
 
 
+# ============================================================================
+# upload() — conditional checksum header (#226): only send it when the presign
+# signed it, else R2 rejects the PUT with 403 SignatureDoesNotMatch
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_upload_omits_checksum_header_when_presign_does_not_sign_it():
+    """If X-Amz-SignedHeaders omits the checksum header, the SDK must NOT send it.
+
+    Regression for the live 403: a server with R2 checksum binding OFF presigns
+    without ``x-amz-checksum-sha256`` in SignedHeaders; sending it anyway makes
+    the SigV4 signature mismatch and R2 returns 403 SignatureDoesNotMatch.
+    """
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict(sign_checksum=False))
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(context_id=SAMPLE_CTX_ID, source=SAMPLE_BODY, filename="hello.txt")
+
+    put_headers = mock_put.call_args.kwargs["headers"]
+    assert "x-amz-checksum-sha256" not in put_headers
+    # Content-Type is a signed header and must still be sent.
+    assert put_headers["Content-Type"] == "text/plain"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_upload_sends_checksum_header_when_presign_signs_it():
+    """When the presign DOES sign the checksum header, the SDK still sends it (binding on)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict(sign_checksum=True))
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(context_id=SAMPLE_CTX_ID, source=SAMPLE_BODY, filename="hello.txt")
+
+    put_headers = mock_put.call_args.kwargs["headers"]
+    assert put_headers["x-amz-checksum-sha256"] == SAMPLE_SHA256_B64
+    await client.close()
+
+
+def test_presign_signs_checksum_detects_signed_header():
+    """`_presign_signs_checksum` reads X-Amz-SignedHeaders case-insensitively."""
+    from kagura_memory.files_client import _presign_signs_checksum
+
+    on = "https://r2/key?X-Amz-SignedHeaders=content-length;content-type;host;x-amz-checksum-sha256"
+    off = "https://r2/key?X-Amz-SignedHeaders=content-length;content-type;host"
+    assert _presign_signs_checksum(on) is True
+    assert _presign_signs_checksum(off) is False
+    assert _presign_signs_checksum("https://r2/key") is False  # no query at all
+    # Case-insensitive: some SDKs upper-case the header token.
+    assert (
+        _presign_signs_checksum("https://r2/key?X-Amz-SignedHeaders=X-Amz-Checksum-Sha256") is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_upload_confirm_sends_workspace_id_query_param():
+    """The confirm step must carry workspace_id as a query param (#226).
+
+    memory-cloud v0.41.0 requires ``workspace_id`` on the query string of
+    ``POST /api/v1/files/{id}/confirm``; without it the server returns 422
+    (VAL-001, query.workspace_id Field required) and the upload never finalizes.
+    """
+    client = FilesClient(api_key="test", base_url="https://example.com")
+
+    reserve_resp = _ok_response(201, _reserve_response_dict())
+    confirm_resp = _ok_response(200, _file_object_dict())
+    put_resp = _ok_response(200, {})
+
+    with (
+        patch.object(client._client, "request", new_callable=AsyncMock) as mock_req,
+        patch.object(client._upload_client, "put", new_callable=AsyncMock) as mock_put,
+    ):
+        mock_req.side_effect = [reserve_resp, confirm_resp]
+        mock_put.return_value = put_resp
+
+        await client.upload(context_id=SAMPLE_CTX_ID, source=SAMPLE_BODY, filename="hello.txt")
+
+    confirm_call = mock_req.call_args_list[1]
+    assert f"/api/v1/files/{SAMPLE_FILE_ID}/confirm" in confirm_call[0][1]
+    assert confirm_call.kwargs["params"] == {"workspace_id": SAMPLE_CTX_ID}
+    assert confirm_call.kwargs["json"] == {"sha256": SAMPLE_SHA256_HEX}
+    await client.close()
+
+
 @pytest.mark.asyncio
 async def test_upload_from_path(tmp_path: Path):
     """Path source reads bytes from disk and uses path.name as filename."""
@@ -882,7 +1003,7 @@ async def test_request_401_raises_auth_error():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = err_resp
         with pytest.raises(KaguraAuthError):
-            await client.delete("some-file-id")
+            await client.delete("some-file-id", context_id=SAMPLE_CTX_ID)
     await client.close()
 
 
@@ -902,7 +1023,7 @@ async def test_request_403_without_source_includes_sanitized_detail():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = err_resp
         with pytest.raises(KaguraConnectionError) as exc_info:
-            await client.delete("some-file-id")
+            await client.delete("some-file-id", context_id=SAMPLE_CTX_ID)
         msg = str(exc_info.value)
     await client.close()
 
@@ -910,13 +1031,14 @@ async def test_request_403_without_source_includes_sanitized_detail():
 
 
 @pytest.mark.asyncio
-async def test_request_403_without_workspace_uses_generic_heading():
-    """File-id endpoints (no workspace_id on the wire) → generic 403 heading.
+async def test_request_403_delete_emits_workspace_hint():
+    """delete now carries workspace_id (v0.41.0), so its 403 uses the workspace hint.
 
-    download-url / delete don't accept ``--context-id``, so the
-    workspace-mismatch language and the ``--context-id`` recovery hint
-    are misleading for those commands. The hint adapts: keep the
-    source label, drop the workspace-specific lines.
+    Before v0.41.0 the file-id endpoints sent no workspace and got the generic
+    heading; now delete / download-url require ``workspace_id`` on the query
+    string, so a 403 surfaces the workspace-mismatch hint like upload / list.
+    (The generic-heading branch is still covered by the
+    ``_format_workspace_403_hint`` unit tests.)
     """
     client = FilesClient(
         api_key="test-key",
@@ -928,19 +1050,16 @@ async def test_request_403_without_workspace_uses_generic_heading():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = err_resp
         with pytest.raises(KaguraConnectionError) as exc_info:
-            await client.delete("some-file-id")
+            await client.delete("some-file-id", context_id="11111111-2222-3333-4444-555555555555")
         msg = str(exc_info.value)
     await client.close()
 
     assert "HTTP 403" in msg
-    assert "access denied" in msg
-    # workspace-specific language must NOT appear for file-id endpoints.
-    assert "workspace not accessible" not in msg
-    assert "workspace requested:" not in msg
-    assert "--context-id" not in msg
-    # The source provenance and server detail still surface.
+    assert "workspace not accessible" in msg
+    # Source provenance, bound + requested workspace prefixes, and detail surface.
     assert ".kagura.json" in msg
     assert "aaaaaaaa" in msg
+    assert "workspace requested: 11111111" in msg
     assert "insufficient_scope" in msg
 
 
@@ -1117,7 +1236,7 @@ async def test_request_404_raises_not_found():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = err_resp
         with pytest.raises(KaguraNotFoundError, match="file gone"):
-            await client.download_url("some-file-id")
+            await client.download_url("some-file-id", context_id=SAMPLE_CTX_ID)
     await client.close()
 
 
@@ -1129,7 +1248,7 @@ async def test_request_429_raises_quota_error_with_retry_after():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = err_resp
         with pytest.raises(KaguraQuotaError) as exc_info:
-            await client.delete("some-file-id")
+            await client.delete("some-file-id", context_id=SAMPLE_CTX_ID)
         assert exc_info.value.retry_after == 60
     await client.close()
 
@@ -1140,7 +1259,7 @@ async def test_request_network_error_raises_connection_error():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.side_effect = httpx.ConnectError("refused")
         with pytest.raises(KaguraConnectionError, match="Connection failed"):
-            await client.delete("some-file-id")
+            await client.delete("some-file-id", context_id=SAMPLE_CTX_ID)
     await client.close()
 
 
@@ -1155,11 +1274,13 @@ async def test_download_url_returns_string():
     resp = _ok_response(200, {"download_url": "https://r2.example.com/get/key?sig=..."})
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = resp
-        url = await client.download_url(SAMPLE_FILE_ID)
+        url = await client.download_url(SAMPLE_FILE_ID, context_id=SAMPLE_CTX_ID)
     assert url == "https://r2.example.com/get/key?sig=..."
     call = mock_req.call_args
     assert call[0][0] == "GET"
     assert f"/api/v1/files/{SAMPLE_FILE_ID}/download-url" in call[0][1]
+    # v0.41.0 requires workspace_id on the query string of file-id endpoints (#226).
+    assert call.kwargs["params"] == {"workspace_id": SAMPLE_CTX_ID}
     await client.close()
 
 
@@ -1169,11 +1290,30 @@ async def test_delete_returns_none():
     resp = _ok_response(204, {})
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = resp
-        result = await client.delete(SAMPLE_FILE_ID)
+        result = await client.delete(SAMPLE_FILE_ID, context_id=SAMPLE_CTX_ID)
     assert result is None
     call = mock_req.call_args
     assert call[0][0] == "DELETE"
     assert f"/api/v1/files/{SAMPLE_FILE_ID}" in call[0][1]
+    assert call.kwargs["params"] == {"workspace_id": SAMPLE_CTX_ID}
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_download_url_rejects_non_uuid_context_id_locally():
+    """download_url validates context_id before the wire (parity with upload/list)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with pytest.raises(ValueError, match="context_id must be a UUID"):
+        await client.download_url("some-file-id", context_id="auto")
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_non_uuid_context_id_locally():
+    """delete validates context_id before the wire (parity with upload/list)."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    with pytest.raises(ValueError, match="context_id must be a UUID"):
+        await client.delete("some-file-id", context_id="auto")
     await client.close()
 
 
@@ -1311,7 +1451,7 @@ async def test_request_500_with_non_dict_body_message():
     with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = err_resp
         with pytest.raises(KaguraConnectionError) as exc_info:
-            await client.delete("some-id")
+            await client.delete("some-id", context_id=SAMPLE_CTX_ID)
     # extract_detail returns "" for non-dict bodies; the message has no suffix.
     assert str(exc_info.value) == "HTTP 500"
     await client.close()

--- a/tests/test_files_integration.py
+++ b/tests/test_files_integration.py
@@ -52,8 +52,8 @@ async def test_upload_round_trip_against_live_backend():
         assert file_obj.size_bytes == len(body)
         assert file_obj.status in ("uploaded", "confirmed")
 
-        # Download URL
-        url = await client.download_url(file_obj.id)
+        # Download URL — context_id (workspace) required as of server v0.41.0.
+        url = await client.download_url(file_obj.id, context_id=INTEGRATION_CONTEXT_ID)
         assert url.startswith("http")
 
         # List — uploaded file should appear in the workspace
@@ -61,4 +61,4 @@ async def test_upload_round_trip_against_live_backend():
         assert any(f.id == file_obj.id for f in page.files)
 
         # Clean up
-        await client.delete(file_obj.id)
+        await client.delete(file_obj.id, context_id=INTEGRATION_CONTEXT_ID)


### PR DESCRIPTION
## Summary

Discovered while verifying storage after the v0.34.0 release: **`FilesClient` was fully broken against the current prod server (memory-cloud v0.41.0)** — every upload, download, and delete failed; only `list` worked. Two independent server-contract drifts, both reproduced live and fixed here.

### 1. R2 PUT `403 SignatureDoesNotMatch`
The server presigns the R2 PUT **without** `x-amz-checksum-sha256` in `X-Amz-SignedHeaders` (checksum binding off), but the SDK sent that header unconditionally — an unsigned `x-amz-*` header invalidates the SigV4 signature. Proof (same presigned URL): PUT with the header → 403; identical PUT without it → 200.

**Fix:** send `x-amz-checksum-sha256` only when the presign signed it (`_presign_signs_checksum`). Integrity is preserved when the server enables binding (header sent → R2 rejects tampered bodies with 400 BadDigest), and the sha256 is sent at `confirm` regardless.

### 2. File-id endpoints require `workspace_id` on the query
`confirm`, `download-url`, and `delete` all return `422 VAL-001 (query.workspace_id Field required)` without it:

| Endpoint | without `workspace_id` | with |
|---|---|---|
| `POST /files/{id}/confirm` | 422 | 200 |
| `GET /files/{id}/download-url` | 422 | 200 |
| `DELETE /files/{id}` | 422 | 204 |

**Fix:**
- `upload` confirm now sends `params={"workspace_id": context_id}`.
- **`FilesClient.download_url(file_id, *, context_id)` and `delete(file_id, *, context_id)` now require `context_id`** (sent as `workspace_id`). ⚠️ **Breaking.**
- CLI `kagura files download-url` / `delete` gain `-c/--context-id` (resolve the workspace from the flag, OAuth profile, or `.kagura.json`).

## Compatibility

Wire changes are backward-compatible with older servers (the extra `workspace_id` param is ignored; the checksum header still sent when the presign signs it). The breaking part is the **SDK API** (required `context_id` on `download_url`/`delete`) → ships as **v0.35.0 (minor)**. `MIN_SERVER_VERSION` stays `0.17.1`.

## Verification

- **Live end-to-end** against `memory.kagura-ai.com` (v0.41.0): upload → list → download (bytes + sha256 match) → delete all pass, self-cleaning.
- **Unit (TDD)**: conditional checksum header (presign signs / doesn't), `_presign_signs_checksum` edge cases, confirm/download-url/delete `workspace_id` param, local UUID validation, CLI `-c` forwarding + "requires context" error. Full suite **1442 passed, 29 skipped**; ruff + pyright clean.
- Docs updated: README (SDK sample, CLI blocks, 0.35.0 compat row), `skills/files/SKILL.md`, `CLAUDE.md`, `examples/files_upload.py`, and the gated `tests/test_files_integration.py`.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)