### PR TITLE
feat(client): get_agent_bootstrap() + AgentsClient REST companion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,14 @@
 
 ## Overview
 
-Python SDK for Kagura Memory Cloud. Six clients:
+Python SDK for Kagura Memory Cloud. Seven clients:
 - `KaguraClient` — MCP client for memory and context operations
 - `KaguraAgent` — LLM-powered session analysis with hooks/skills API
 - `ResourceClient` — REST client for resource token management and data ingestion
 - `FilesClient` — REST + presigned PUT client for file uploads with sha256 integrity binding (server v0.15.1+)
 - `SecretClient` — REST client for the zero-knowledge secret store (age recipient encryption, local decrypt; `[secret]` extra, server v0.39.0+)
 - `WorkspaceClient` — REST client for workspace member/invitation management (owner API key only, OAuth rejected; server v0.42.0+)
+- `AgentsClient` — REST companion for agent bootstrap (`POST /api/v1/agents/{agent_id}/bootstrap`; server v0.49.0+)
 
 ## Development Workflow
 
@@ -37,6 +38,7 @@ uv run pyright src/              # Type check
 - **Zero-knowledge secrets**: `SecretClient` + `kagura secret` — age recipient encryption, local decrypt; private key in OS keychain via `pyrage`/`keyring` (`[secret]` extra, server v0.39.0+). Owner-only hard delete via `SecretClient.delete_secret` / `kagura secret delete` (server v0.41.0+)
 - **Workspace member management**: `WorkspaceClient` + `kagura workspace member|invite` — owner-key-only (server v0.42.0+, memory-cloud#1164). Assignable roles member|admin|viewer (owner → 422); member/viewer invites require `allowed_context_ids`; `expires_in_days` presets 7/30/90/365; invitation ids are int with no status field; programmatic invite list nulls `token`/`invitation_url`
 - **Owner-provisioned member keys**: `WorkspaceClient.mint_member_key/list_member_keys/revoke_member_key` + `kagura auth create-key/list-keys/revoke-key` (server v0.42.0+, memory-cloud#1165). Member/viewer targets only, never self; `expires_days` 1-3650 required; plaintext returned once (force-hidden after); revoke is soft
+- **Agent bootstrap**: `KaguraClient.get_agent_bootstrap` (MCP) + `AgentsClient.bootstrap` (REST) — one-call session-start rehydration composing pinned + trusted recall + upcoming + state, fail-soft per component with top-level `degraded` (server v0.49.0+, RFC-0002 P0-3, memory-cloud#1276)
 - Agent hooks/skills: `@agent.hook("before_process")`, `@agent.skill("name")`
 - Ollama support: `model="ollama/qwen3:30b"` for local LLMs
 - CLI: `kagura doctor`, `kagura auth login/refresh/status/list/create-key/list-keys/revoke-key`, `kagura setup claude`, `kagura ingest <file|url>`, `kagura resource setup/import/stats/schema`, `kagura files upload/list/delete/download-url`, `kagura secret keygen/put/get/grant/rotate/delete/exec`, `kagura workspace member list/add/set-role/remove`, `kagura workspace invite create/list/revoke`, `kagura context search-config`, `kagura sleep history/report/rollback`

--- a/README.md
+++ b/README.md
@@ -241,6 +241,31 @@ async with KaguraClient(api_key="kagura_...", mcp_url="https://...") as client:
     state = await client.get_state(context_id="dev", key="step")  # omit key → all live entries
 ```
 
+#### Agent bootstrap — one-call session-start rehydration (v0.37.0, server v0.49.0+)
+
+`get_agent_bootstrap` composes the primitives above (context guide + pinned +
+trusted-only recall + upcoming time memories + agent state) into one envelope, so an
+agent starts a session with a single round-trip. Components are **fail-soft**: a failing
+component reports `status="error"` while the rest still return (top-level `degraded`
+flag). Also available over REST (`AgentsClient`) for API-key-only callers such as
+agent-bound member keys:
+
+```python
+from kagura_memory import AgentsClient, KaguraClient
+
+async with KaguraClient() as client:  # MCP surface
+    bootstrap = await client.get_agent_bootstrap(
+        "agent-uuid",                     # context_id omitted → default binding
+        session_id="run-42",              # echoed in the correlation block
+        query="current task",             # enables the trusted-only recall component
+        include=["pinned", "recall", "state"],
+    )
+    pinned = bootstrap.components["pinned"]  # {"status": "ok", "memories": [...], ...}
+
+async with AgentsClient.from_mcp_url() as agents:  # REST companion
+    bootstrap = await agents.bootstrap("agent-uuid", include=["pinned"])
+```
+
 > **⚠️ Error handling changed in v0.29.0 (breaking).** Every `KaguraClient` MCP tool
 > method now **raises** on a server domain error instead of returning an error dict:
 > a missing context/memory raises `KaguraNotFoundError`, any other domain error raises
@@ -385,6 +410,7 @@ The same client also provisions **member API keys** (memory-cloud [#1165](https:
 
 | SDK | Min memory-cloud | Notes |
 |---|---|---|
+| 0.37.0+ | 0.17.1 (0.49.0 for agent bootstrap) | **Agent bootstrap (RFC-0002 P0-3).** `KaguraClient.get_agent_bootstrap()` (MCP) and `AgentsClient.bootstrap()` (REST, `POST /api/v1/agents/{agent_id}/bootstrap`) need memory-cloud **0.49.0+** ([#1276](https://github.com/kagura-ai/memory-cloud/issues/1276)) and a registered agent (agent registry, [#1274](https://github.com/kagura-ai/memory-cloud/issues/1274)). Against an older server the MCP tool returns "tool not found" and the REST route 404s. `MIN_SERVER_VERSION` stays **0.17.1**. |
 | 0.36.0+ | 0.17.1 (0.42.0 for `kagura workspace` / `kagura auth create-key`) | **Workspace member management + owner-provisioned member keys (owner-key only).** `WorkspaceClient` / `kagura workspace member\|invite` and `mint_member_key`/`list_member_keys`/`revoke_member_key` / `kagura auth create-key\|list-keys\|revoke-key` need memory-cloud **0.42.0+** (owner-key programmatic access, [#1164](https://github.com/kagura-ai/memory-cloud/issues/1164) / [#1165](https://github.com/kagura-ai/memory-cloud/issues/1165)). Requires the workspace **owner's static API key** — OAuth tokens are rejected on this surface, and a deployment can disable it via `enable_owner_key_member_management=false`. Key minting is privilege-downgrade only: member/viewer targets, never self, `expires_days` required. `MIN_SERVER_VERSION` stays **0.17.1**. |
 | 0.35.0+ | 0.17.1 (0.41.0 for file uploads/downloads) | **FilesClient v0.41.0 compatibility (breaking).** memory-cloud 0.41.0 requires `workspace_id` on the query of the file-id endpoints (`confirm`/`download-url`/`delete`) and presigns R2 PUT without the checksum header — so pre-0.35.0 SDKs get 403/422 on every upload/download/delete against it. This SDK sends `workspace_id` on those endpoints (harmlessly ignored by older servers) and only binds the checksum when the presign signed it. **Breaking:** `FilesClient.download_url(file_id, *, context_id)` and `delete(file_id, *, context_id)` now require `context_id`; `kagura files download-url`/`delete` require `-c/--context-id` (or a profile/`.kagura.json` workspace). `MIN_SERVER_VERSION` stays **0.17.1**. |
 | 0.34.0+ | 0.17.1 (0.41.0 for secret delete + file context binding) | **Owner-only secret delete + file context binding.** `SecretClient.delete_secret` / `kagura secret delete` (`DELETE /api/v1/config/secrets/{name}`) and `FilesClient.upload(binding_context_id=…)` / `FileObject.context_id` (context-scoped file ACL) need memory-cloud **0.41.0+**. `MIN_SERVER_VERSION` stays **0.17.1** — only these surfaces require 0.41.0. |
@@ -617,6 +643,7 @@ follow-up.
 | Time Memory (recall_upcoming) | `KaguraClient` | MCP | API Key |
 | Retrieval feedback (feedback) | `KaguraClient` | MCP | API Key |
 | Agent session-state lane (set_state/get_state, TTL) | `KaguraClient` | MCP | API Key |
+| Agent bootstrap (get_agent_bootstrap — one-call session-start rehydration) | `KaguraClient` / `AgentsClient` | MCP + REST | API Key |
 | Context (create/update/list/delete/get_context_info) | `KaguraClient` | MCP | API Key |
 | Workspace (get_usage) | `KaguraClient` | MCP | API Key |
 | Search config (update_search_config) | `KaguraClient` | MCP | API Key |

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ uv run python examples/<script>.py
 | [`client_basics.py`](client_basics.py) | `KaguraClient` | remember / recall / explore / reference / forget |
 | [`client_advanced.py`](client_advanced.py) | `KaguraClient` | recall filters, cross-context recall, `list_tags`, `get_usage`, `get_memory_stats`, `find_duplicates`, `merge_contexts` |
 | [`agent_session.py`](agent_session.py) | `KaguraAgent` | AI-powered session analysis (remember/recall decided by the LLM) |
+| [`agent_bootstrap.py`](agent_bootstrap.py) | `KaguraClient` / `AgentsClient` | one-call agent session-start rehydration (`get_agent_bootstrap`, MCP + REST; server v0.49.0+) |
 | [`resource_tokens.py`](resource_tokens.py) | `ResourceClient` | resource setup, token lifecycle, single + batch event ingestion |
 | [`files_upload.py`](files_upload.py) | `FilesClient` | upload (bytes + dedup), `download_url`, `list`, `delete` |
 | [`ingest_pdf.py`](ingest_pdf.py) | `FileIngestor` | PDF → overview + section memories + R2 archive |

--- a/examples/agent_bootstrap.py
+++ b/examples/agent_bootstrap.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Agent bootstrap — one-call session-start rehydration (server v0.49.0+).
+
+``get_agent_bootstrap`` composes context guide + pinned memories +
+trusted-only recall (only when a query is supplied) + upcoming time
+memories + agent run-state into a single envelope, so an agent starts a
+session with one round-trip instead of five. Components are fail-soft:
+a failing component reports status="error" while the rest still return,
+with the top-level ``degraded`` flag set.
+
+Shown here over both surfaces:
+- ``KaguraClient.get_agent_bootstrap`` — the MCP tool
+- ``AgentsClient.bootstrap`` — the REST companion
+  (``POST /api/v1/agents/{agent_id}/bootstrap``), for API-key-only
+  callers such as agent-bound member keys
+
+Usage:
+    export KAGURA_API_KEY="kagura_..."
+    export KAGURA_MCP_URL="http://localhost:8080/mcp/w/{workspace_id}"
+    export KAGURA_AGENT_ID="<agent uuid from the registry>"
+    uv run python examples/agent_bootstrap.py
+"""
+
+import asyncio
+import os
+import sys
+
+from kagura_memory import AgentsClient, KaguraClient
+
+
+async def main():
+    agent_id = os.getenv("KAGURA_AGENT_ID")
+    if not agent_id:
+        print("Error: KAGURA_AGENT_ID required (register the agent first)")
+        sys.exit(1)
+
+    # --- MCP surface -----------------------------------------------------
+    async with KaguraClient() as client:
+        bootstrap = await client.get_agent_bootstrap(
+            agent_id,
+            # context_id omitted → the agent's default binding
+            session_id="example-session-001",
+            query="current task and recent decisions",  # enables the recall component
+            recall_k=5,
+        )
+
+        print(f"Agent:       {bootstrap.agent.name} ({bootstrap.agent.agent_id})")
+        if bootstrap.context:
+            print(f"Context:     {bootstrap.context.name}")
+        print(f"Degraded:    {bootstrap.degraded}")
+        for name, component in bootstrap.components.items():
+            print(f"  {name:<9} status={component.get('status')}")
+
+        pinned = bootstrap.components.get("pinned", {})
+        for memory in pinned.get("memories", []):
+            print(f"  pinned: {memory['summary']}")
+
+    # --- REST companion ----------------------------------------------------
+    # Same arguments, same envelope — for callers holding an API key but no
+    # MCP session (e.g. an agent-bound member key minted for a deployed agent).
+    async with AgentsClient.from_mcp_url() as agents:
+        bootstrap = await agents.bootstrap(
+            agent_id,
+            include=["pinned", "state"],  # cheap subset, no recall
+        )
+        print(f"REST bootstrap degraded={bootstrap.degraded}, "
+              f"components={sorted(bootstrap.components)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/agent_bootstrap.py
+++ b/examples/agent_bootstrap.py
@@ -63,8 +63,10 @@ async def main():
             agent_id,
             include=["pinned", "state"],  # cheap subset, no recall
         )
-        print(f"REST bootstrap degraded={bootstrap.degraded}, "
-              f"components={sorted(bootstrap.components)}")
+        print(
+            f"REST bootstrap degraded={bootstrap.degraded}, "
+            f"components={sorted(bootstrap.components)}"
+        )
 
 
 if __name__ == "__main__":

--- a/src/kagura_memory/__init__.py
+++ b/src/kagura_memory/__init__.py
@@ -1,6 +1,7 @@
 """Kagura Memory SDK - AI-driven memory management for Kagura Memory Cloud."""
 
 from .agent import KaguraAgent
+from .agents_client import AgentsClient
 from .client import MIN_SERVER_VERSION, KaguraClient
 from .exceptions import (
     KaguraAuthDeniedError,
@@ -20,6 +21,11 @@ from .exceptions import (
 from .files_client import FilesClient
 from .ingest import FileIngestor
 from .models import (
+    AgentBootstrapAgent,
+    AgentBootstrapBinding,
+    AgentBootstrapComponentName,
+    AgentBootstrapCorrelation,
+    AgentBootstrapResponse,
     Artifact,
     ContextDetail,
     ContextInfo,
@@ -104,6 +110,7 @@ __all__ = [
     "ResourceClient",
     "FilesClient",
     "WorkspaceClient",
+    "AgentsClient",
     "MIN_SERVER_VERSION",
     # Embedding models
     "EmbeddingModel",
@@ -181,6 +188,12 @@ __all__ = [
     "WorkspaceMember",
     "WorkspaceInvitation",
     "MemberAPIKey",
+    # Agent bootstrap (#231, server v0.49.0+)
+    "AgentBootstrapAgent",
+    "AgentBootstrapBinding",
+    "AgentBootstrapComponentName",
+    "AgentBootstrapCorrelation",
+    "AgentBootstrapResponse",
     # File ingestion (Issue #80)
     "FileIngestor",
     "IngestResult",

--- a/src/kagura_memory/_http.py
+++ b/src/kagura_memory/_http.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import uuid
 from importlib.metadata import version as _pkg_version
 from typing import Any, NoReturn
 
@@ -163,6 +164,29 @@ def _format_validation_errors(errors: list[Any]) -> str:
 # past the check (#189). Scheme matching stays case-sensitive to preserve prior
 # behavior; the trigger below is the lowercase ``http://`` literal.
 _LOCALHOST_HTTP_RE = re.compile(r"^http://(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:[/?#]|$)")
+
+
+def normalize_uuid(value: str, *, label: str) -> str:
+    """Return the canonical UUID string, rejecting non-UUIDs before URL use.
+
+    ``uuid.UUID`` tolerates non-canonical spellings (``{braces}``,
+    ``urn:uuid:`` prefix, dashless 32-hex); interpolating the RAW input
+    into a URL path would send those to the server and surface as a
+    misleading uniform 404 — normalize instead of just validating.
+
+    Args:
+        value: Candidate UUID string.
+        label: Parameter name used in the error message.
+
+    Raises:
+        ValueError: If ``value`` is not a parseable UUID. The ``str()``
+            coercion and ``TypeError`` catch keep the error uniform for
+            untyped runtime callers passing non-strings.
+    """
+    try:
+        return str(uuid.UUID(str(value)))
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"{label} must be a UUID, got {value!r}") from exc
 
 
 def validate_https_url(url: str, *, label: str = "URL") -> None:

--- a/src/kagura_memory/_http.py
+++ b/src/kagura_memory/_http.py
@@ -166,7 +166,7 @@ def _format_validation_errors(errors: list[Any]) -> str:
 _LOCALHOST_HTTP_RE = re.compile(r"^http://(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:[/?#]|$)")
 
 
-def normalize_uuid(value: str, *, label: str) -> str:
+def normalize_uuid(value: object, *, label: str) -> str:
     """Return the canonical UUID string, rejecting non-UUIDs before URL use.
 
     ``uuid.UUID`` tolerates non-canonical spellings (``{braces}``,
@@ -175,13 +175,14 @@ def normalize_uuid(value: str, *, label: str) -> str:
     misleading uniform 404 — normalize instead of just validating.
 
     Args:
-        value: Candidate UUID string.
+        value: Candidate UUID. Typed ``object`` because this is a runtime
+            guard at the public-parameter trust boundary: non-string
+            values from untyped callers are coerced via ``str()`` and
+            rejected with the same uniform ValueError.
         label: Parameter name used in the error message.
 
     Raises:
-        ValueError: If ``value`` is not a parseable UUID. The ``str()``
-            coercion and ``TypeError`` catch keep the error uniform for
-            untyped runtime callers passing non-strings.
+        ValueError: If ``value`` is not a parseable UUID.
     """
     try:
         return str(uuid.UUID(str(value)))

--- a/src/kagura_memory/agents_client.py
+++ b/src/kagura_memory/agents_client.py
@@ -15,25 +15,13 @@ mapping live in :class:`~kagura_memory._rest_base.KaguraRestClient`
 
 from __future__ import annotations
 
-import uuid
-from typing import Any
-
+from ._http import normalize_uuid
 from ._rest_base import KaguraRestClient
-from .models import AgentBootstrapComponentName, AgentBootstrapResponse
-
-
-def _normalize_agent_id(agent_id: str) -> str:
-    """Return the canonical UUID string, rejecting non-UUIDs before the URL.
-
-    ``uuid.UUID`` tolerates non-canonical spellings (``{braces}``,
-    ``urn:uuid:`` prefix, dashless 32-hex); interpolating the RAW input
-    would send those to the server and surface as a misleading uniform
-    404 — normalize instead of just validating.
-    """
-    try:
-        return str(uuid.UUID(str(agent_id)))
-    except (ValueError, TypeError) as exc:
-        raise ValueError(f"agent_id must be a UUID, got {agent_id!r}") from exc
+from .models import (
+    AgentBootstrapComponentName,
+    AgentBootstrapResponse,
+    _bootstrap_payload,
+)
 
 
 class AgentsClient(KaguraRestClient):
@@ -90,24 +78,18 @@ class AgentsClient(KaguraRestClient):
         Returns:
             :class:`AgentBootstrapResponse` — the composed envelope.
         """
-        body: dict[str, Any] = {}
-        if context_id is not None:
-            body["context_id"] = context_id
-        if session_id is not None:
-            body["session_id"] = session_id
-        if query is not None:
-            body["query"] = query
-        if recall_k is not None:
-            body["recall_k"] = recall_k
-        if pinned_cap is not None:
-            body["pinned_cap"] = pinned_cap
-        if upcoming_until is not None:
-            body["upcoming_until"] = upcoming_until
-        if include is not None:
-            body["include"] = include
+        body = _bootstrap_payload(
+            context_id=context_id,
+            session_id=session_id,
+            query=query,
+            recall_k=recall_k,
+            pinned_cap=pinned_cap,
+            upcoming_until=upcoming_until,
+            include=include,
+        )
         resp = await self._request(
             "POST",
-            f"/api/v1/agents/{_normalize_agent_id(agent_id)}/bootstrap",
+            f"/api/v1/agents/{normalize_uuid(agent_id, label='agent_id')}/bootstrap",
             json=body,
         )
         return AgentBootstrapResponse.model_validate(self._json(resp))

--- a/src/kagura_memory/agents_client.py
+++ b/src/kagura_memory/agents_client.py
@@ -1,0 +1,113 @@
+"""REST client for the agent surface (#231, server v0.49.0+).
+
+The ``get_agent_bootstrap`` MCP tool has a REST companion —
+``POST /api/v1/agents/{agent_id}/bootstrap`` (RFC-0002 P0-3,
+memory-cloud [#1276](https://github.com/kagura-ai/memory-cloud/issues/1276))
+— authenticated with ``APIKeyOrSessionUser``, so it accepts agent-bound
+member keys: a deployed agent can rehydrate its cognitive state without
+opening an MCP session. POST-for-read follows the server's
+``POST /api/v1/memory/pinned`` precedent.
+
+Construction, credential resolution, lifecycle, and the base error
+mapping live in :class:`~kagura_memory._rest_base.KaguraRestClient`
+(#229); this module keeps only the bootstrap wire call.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from ._rest_base import KaguraRestClient
+from .models import AgentBootstrapComponentName, AgentBootstrapResponse
+
+
+def _normalize_agent_id(agent_id: str) -> str:
+    """Return the canonical UUID string, rejecting non-UUIDs before the URL.
+
+    ``uuid.UUID`` tolerates non-canonical spellings (``{braces}``,
+    ``urn:uuid:`` prefix, dashless 32-hex); interpolating the RAW input
+    would send those to the server and surface as a misleading uniform
+    404 — normalize instead of just validating.
+    """
+    try:
+        return str(uuid.UUID(str(agent_id)))
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"agent_id must be a UUID, got {agent_id!r}") from exc
+
+
+class AgentsClient(KaguraRestClient):
+    """REST API client for agent bootstrap (memory-cloud v0.49.0+).
+
+    All methods may raise:
+        KaguraAuthError: Authentication failed (401)
+        KaguraConnectionError: Invalid arguments (400) or any other
+            HTTP/connection error
+        KaguraNotFoundError: Agent or context not found (404). The 404 is
+            uniform (CWE-639) — nonexistent and not-yours are
+            indistinguishable by design, so a 404 does NOT prove the
+            agent is absent.
+        KaguraQuotaError: Rate limit exceeded (429)
+    """
+
+    async def bootstrap(
+        self,
+        agent_id: str,
+        *,
+        context_id: str | None = None,
+        session_id: str | None = None,
+        query: str | None = None,
+        recall_k: int | None = None,
+        pinned_cap: int | None = None,
+        upcoming_until: str | None = None,
+        include: list[AgentBootstrapComponentName] | None = None,
+    ) -> AgentBootstrapResponse:
+        """Rehydrate an agent's cognitive state at session start.
+
+        REST companion to :meth:`KaguraClient.get_agent_bootstrap` — same
+        arguments, same composed envelope, same fail-soft component
+        semantics (see that method for the full contract). Use this
+        surface when the caller holds an API key but no MCP session,
+        e.g. an agent-bound member key minted for a deployed agent.
+
+        Args:
+            agent_id: Agent UUID from the registry (required; sent in the
+                URL path).
+            context_id: Target context UUID. Omit to use the agent's
+                default binding.
+            session_id: Opaque correlation id (max 128 chars,
+                ``[A-Za-z0-9._-]``).
+            query: Recall query (max 1024 chars). Supplying it enables the
+                trusted-only recall component; omit to skip recall.
+            recall_k: Number of recall results.
+            pinned_cap: Override for the pinned-set cap (clamped server-side
+                to [1, 1000]).
+            upcoming_until: ISO upper bound for upcoming time memories.
+            include: Component selector — a subset of ``"pinned"``,
+                ``"recall"``, ``"upcoming"``, ``"state"``, ``"policy"``.
+                Omit for all components.
+
+        Returns:
+            :class:`AgentBootstrapResponse` — the composed envelope.
+        """
+        body: dict[str, Any] = {}
+        if context_id is not None:
+            body["context_id"] = context_id
+        if session_id is not None:
+            body["session_id"] = session_id
+        if query is not None:
+            body["query"] = query
+        if recall_k is not None:
+            body["recall_k"] = recall_k
+        if pinned_cap is not None:
+            body["pinned_cap"] = pinned_cap
+        if upcoming_until is not None:
+            body["upcoming_until"] = upcoming_until
+        if include is not None:
+            body["include"] = include
+        resp = await self._request(
+            "POST",
+            f"/api/v1/agents/{_normalize_agent_id(agent_id)}/bootstrap",
+            json=body,
+        )
+        return AgentBootstrapResponse.model_validate(self._json(resp))

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -17,6 +17,8 @@ from .exceptions import (
     _exc_message,
 )
 from .models import (
+    AgentBootstrapComponentName,
+    AgentBootstrapResponse,
     ContextInfo,
     DuplicatesResponse,
     Edge,
@@ -673,6 +675,89 @@ class KaguraClient:
         if key is not None:
             arguments["key"] = key
         return await self._call_tool_checked("get_state", arguments)
+
+    async def get_agent_bootstrap(
+        self,
+        agent_id: str,
+        *,
+        context_id: str | None = None,
+        session_id: str | None = None,
+        query: str | None = None,
+        recall_k: int | None = None,
+        pinned_cap: int | None = None,
+        upcoming_until: str | None = None,
+        include: list[AgentBootstrapComponentName] | None = None,
+    ) -> AgentBootstrapResponse:
+        """Rehydrate an agent's cognitive state in one session-start call.
+
+        Calls the ``get_agent_bootstrap`` MCP tool (server v0.49.0+,
+        RFC-0002 P0-3). The server composes existing primitives — context
+        guide + pinned memories (:meth:`load_pinned`) + a trusted-only
+        :meth:`recall` (only when ``query`` is supplied) + upcoming time
+        memories (:meth:`recall_upcoming`) + the agent-state lane
+        (:meth:`get_state`) — with bounds, ordering, and trust filtering
+        inherited from those standalone tools, not re-specified.
+
+        Components are **fail-soft**: a failing component reports
+        ``{"status": "error", ...}`` under ``components`` while the rest
+        still return, with the top-level ``degraded`` flag set.
+        Identity/authorization failures are total and raise instead.
+
+        Requires memory-cloud v0.49.0+ — older servers return an MCP
+        "tool not found" error. ``MIN_SERVER_VERSION`` is deliberately not
+        bumped; only this method needs the newer server. The REST companion
+        (``POST /api/v1/agents/{agent_id}/bootstrap``) is available via
+        :class:`~kagura_memory.agents_client.AgentsClient` for
+        API-key-only callers such as agent-bound member keys.
+
+        Args:
+            agent_id: Agent UUID from the registry (required).
+            context_id: Target context UUID. Omit to use the agent's
+                default binding.
+            session_id: Opaque correlation id (max 128 chars,
+                ``[A-Za-z0-9._-]``); echoed in the ``correlation`` block.
+            query: Recall query (max 1024 chars). Supplying it enables the
+                trusted-only recall component; omit to skip recall — the
+                server never fabricates a query, so the component reports
+                ``status="skipped"`` even when ``include`` names it.
+            recall_k: Number of recall results; forwarded to recall's
+                ``k`` validation.
+            pinned_cap: Override for the pinned-set cap; clamped by
+                ``load_pinned`` to [1, 1000].
+            upcoming_until: ISO upper bound for upcoming time memories
+                (the lower bound is always now).
+            include: Component selector — a subset of ``"pinned"``,
+                ``"recall"``, ``"upcoming"``, ``"state"``, ``"policy"``.
+                Omit for all components.
+
+        Returns:
+            :class:`AgentBootstrapResponse` — the composed envelope with
+            ``agent`` (identity + resolved binding), ``context``,
+            ``instructions``, per-component payloads in ``components``,
+            the ``correlation`` block, and the ``degraded`` flag.
+
+        Raises:
+            KaguraNotFoundError: Agent or context not found (uniform 404 —
+                nonexistent and not-yours are indistinguishable by design).
+            KaguraError: Invalid arguments or other server-side error.
+        """
+        arguments: dict[str, Any] = {"agent_id": agent_id}
+        if context_id is not None:
+            arguments["context_id"] = context_id
+        if session_id is not None:
+            arguments["session_id"] = session_id
+        if query is not None:
+            arguments["query"] = query
+        if recall_k is not None:
+            arguments["recall_k"] = recall_k
+        if pinned_cap is not None:
+            arguments["pinned_cap"] = pinned_cap
+        if upcoming_until is not None:
+            arguments["upcoming_until"] = upcoming_until
+        if include is not None:
+            arguments["include"] = include
+        result = await self._call_tool_checked("get_agent_bootstrap", arguments)
+        return AgentBootstrapResponse.model_validate(result)
 
     async def list_contexts(self) -> dict[str, Any]:
         """
@@ -1597,7 +1682,7 @@ class KaguraClient:
             return
         code = result.get("error", "unknown")
         message = result.get("message", "Unknown error")
-        if code in ("report_not_found", "context_not_found", "memory_not_found"):
+        if code in ("report_not_found", "context_not_found", "memory_not_found", "agent_not_found"):
             raise KaguraNotFoundError(f"{operation}: {message}")
         raise KaguraError(f"{operation} failed ({code}): {message}")
 

--- a/src/kagura_memory/client.py
+++ b/src/kagura_memory/client.py
@@ -32,6 +32,7 @@ from .models import (
     SleepReport,
     SleepReportDetail,
     UsageInfo,
+    _bootstrap_payload,
 )
 
 _T = TypeVar("_T", bound=_BaseModel)
@@ -741,21 +742,18 @@ class KaguraClient:
                 nonexistent and not-yours are indistinguishable by design).
             KaguraError: Invalid arguments or other server-side error.
         """
-        arguments: dict[str, Any] = {"agent_id": agent_id}
-        if context_id is not None:
-            arguments["context_id"] = context_id
-        if session_id is not None:
-            arguments["session_id"] = session_id
-        if query is not None:
-            arguments["query"] = query
-        if recall_k is not None:
-            arguments["recall_k"] = recall_k
-        if pinned_cap is not None:
-            arguments["pinned_cap"] = pinned_cap
-        if upcoming_until is not None:
-            arguments["upcoming_until"] = upcoming_until
-        if include is not None:
-            arguments["include"] = include
+        arguments: dict[str, Any] = {
+            "agent_id": agent_id,
+            **_bootstrap_payload(
+                context_id=context_id,
+                session_id=session_id,
+                query=query,
+                recall_k=recall_k,
+                pinned_cap=pinned_cap,
+                upcoming_until=upcoming_until,
+                include=include,
+            ),
+        }
         result = await self._call_tool_checked("get_agent_bootstrap", arguments)
         return AgentBootstrapResponse.model_validate(result)
 

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -1000,3 +1000,85 @@ class MemberAPIKey(BaseModel):
     revoked_at: datetime | None = None
     expires_at: datetime | None = None
     bound_context_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent bootstrap (#231, server v0.49.0+, RFC-0002 P0-3)
+# ---------------------------------------------------------------------------
+
+
+AgentBootstrapComponentName = Literal["pinned", "recall", "upcoming", "state", "policy"]
+"""Valid values for ``get_agent_bootstrap``'s ``include`` component selector.
+
+Mirrors the server's closed component set; the server rejects unknown
+names with ``invalid_arguments``."""
+
+
+class AgentBootstrapBinding(BaseModel):
+    """The context binding a bootstrap resolved (``agent.binding``).
+
+    ``is_default`` is ``True`` when the context came from the agent's
+    default binding (no explicit ``context_id`` was passed).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    context_id: str
+    is_default: bool = False
+
+
+class AgentBootstrapAgent(BaseModel):
+    """Agent identity block in the bootstrap envelope."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    agent_id: str
+    name: str
+    binding: AgentBootstrapBinding | None = None
+
+
+class AgentBootstrapCorrelation(BaseModel):
+    """Correlation block (RFC-0002 P0-4) — session/run/trace identifiers.
+
+    ``session_id`` echoes the bootstrap argument when given, else the
+    server's baggage-derived session id. ``run_id``/``trace_id``/``span_id``
+    are populated from the per-request correlation context when present.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    agent_id: str | None = None
+    session_id: str | None = None
+    run_id: str | None = None
+    trace_id: str | None = None
+    span_id: str | None = None
+
+
+class AgentBootstrapResponse(BaseModel):
+    """Composed envelope from ``get_agent_bootstrap`` (server v0.49.0+).
+
+    One session-start call that rehydrates an agent's cognitive state by
+    composing existing primitives. Each entry in ``components`` is
+    **fail-soft** and carries its own ``status``: ``"ok"`` (payload
+    inherited from the standalone tool — ``load_pinned``, trusted-only
+    ``recall``, ``recall_upcoming``, ``get_state``), ``"skipped"`` (e.g.
+    recall without a ``query``, with a ``reason``), or ``"error"`` (that
+    component failed; the rest still return and the top-level ``degraded``
+    flag is set). Component payloads stay dicts because their shapes belong
+    to the standalone tools and evolve with them.
+
+    ``context`` reuses :class:`ContextDetail` — the server emits the block
+    byte-compatible with ``get_context_info`` (``search_config`` is not
+    included in bootstrap and keeps its client-side default).
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: str = "success"
+    degraded: bool = False
+    agent: AgentBootstrapAgent
+    context: ContextDetail | None = None
+    instructions: str | None = None
+    components: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    correlation: AgentBootstrapCorrelation | None = None
+    generated_at: datetime | None = None

--- a/src/kagura_memory/models.py
+++ b/src/kagura_memory/models.py
@@ -1014,6 +1014,43 @@ Mirrors the server's closed component set; the server rejects unknown
 names with ``invalid_arguments``."""
 
 
+def _bootstrap_payload(
+    *,
+    context_id: str | None,
+    session_id: str | None,
+    query: str | None,
+    recall_k: int | None,
+    pinned_cap: int | None,
+    upcoming_until: str | None,
+    include: list[AgentBootstrapComponentName] | None,
+) -> dict[str, Any]:
+    """Build the omit-when-None bootstrap payload shared by both surfaces.
+
+    ``KaguraClient.get_agent_bootstrap`` (MCP tool arguments) and
+    ``AgentsClient.bootstrap`` (REST JSON body) carry the same seven
+    optional keys; a single builder keeps the two surfaces in lockstep —
+    ``agent_id`` stays transport-specific (MCP argument vs URL path).
+    Lives beside the bootstrap models because it IS the request half of
+    this wire contract.
+    """
+    payload: dict[str, Any] = {}
+    if context_id is not None:
+        payload["context_id"] = context_id
+    if session_id is not None:
+        payload["session_id"] = session_id
+    if query is not None:
+        payload["query"] = query
+    if recall_k is not None:
+        payload["recall_k"] = recall_k
+    if pinned_cap is not None:
+        payload["pinned_cap"] = pinned_cap
+    if upcoming_until is not None:
+        payload["upcoming_until"] = upcoming_until
+    if include is not None:
+        payload["include"] = include
+    return payload
+
+
 class AgentBootstrapBinding(BaseModel):
     """The context binding a bootstrap resolved (``agent.binding``).
 

--- a/src/kagura_memory/workspace_client.py
+++ b/src/kagura_memory/workspace_client.py
@@ -14,7 +14,6 @@ the owner-key 403 hint and the detail-carrying 429 quota mapping.
 
 from __future__ import annotations
 
-import uuid
 from typing import Any
 from urllib.parse import quote
 
@@ -22,7 +21,7 @@ import httpx
 from pydantic import ValidationError
 
 from ._auth import _SOURCE_LABEL
-from ._http import _retry_after_seconds, extract_detail, sanitize_server_detail
+from ._http import _retry_after_seconds, extract_detail, normalize_uuid, sanitize_server_detail
 from ._rest_base import KaguraRestClient
 from .exceptions import KaguraConnectionError, KaguraError, KaguraQuotaError
 from .models import MemberAPIKey, WorkspaceInvitation, WorkspaceMember
@@ -44,17 +43,8 @@ _UNIFORM_403 = "Insufficient permissions"
 
 
 def _normalize_workspace_id(workspace_id: str) -> str:
-    """Return the canonical UUID string, rejecting non-UUIDs before the URL.
-
-    ``uuid.UUID`` tolerates non-canonical spellings (``{braces}``,
-    ``urn:uuid:`` prefix, dashless 32-hex); interpolating the RAW input
-    would send those to the server and surface as a misleading uniform
-    404 — normalize instead of just validating.
-    """
-    try:
-        return str(uuid.UUID(str(workspace_id)))
-    except (ValueError, TypeError) as exc:
-        raise ValueError(f"workspace_id must be a UUID, got {workspace_id!r}") from exc
+    """Canonicalize before URL interpolation — see :func:`normalize_uuid`."""
+    return normalize_uuid(workspace_id, label="workspace_id")
 
 
 def _require_int(value: object, label: str) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,63 @@ def sleep_report_summary_dict(report_id: str = "rid-1") -> dict:
     }
 
 
+def bootstrap_envelope_dict(
+    agent_id: str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    context_id: str = "11111111-2222-3333-4444-555555555555",
+) -> dict:
+    """Build a server-shaped ``get_agent_bootstrap`` envelope for tests.
+
+    Mirrors ``build_envelope`` in
+    ``memory-cloud/backend/src/services/agent_bootstrap_service.py``
+    (v0.49.0, RFC-0002 P0-3) so the MCP-surface tests (test_client.py) and
+    the REST-surface tests (test_agents_client.py) consume one wire
+    fixture instead of diverging copies. Per-case variants override only
+    what they assert, e.g. ``{**bootstrap_envelope_dict(),
+    "components": {...}}``.
+    """
+    return {
+        "status": "success",
+        "degraded": False,
+        "agent": {
+            "agent_id": agent_id,
+            "name": "ci-agent",
+            "binding": {"context_id": context_id, "is_default": True},
+        },
+        "context": {
+            "id": context_id,
+            "name": "dev",
+            "display_name": "Dev",
+            "summary": "Dev knowledge base",
+            "usage_guide": "Recall before acting.",
+            "is_private": True,
+            "is_locked": False,
+            "embedding_model": "text-embedding-3-small",
+            "embedding_dimensions": 1536,
+        },
+        "instructions": "Recall before acting.\n\nSTANDARD INSTRUCTIONS",
+        "components": {
+            "pinned": {
+                "status": "ok",
+                "memories": [{"memory_id": "m1", "summary": "Guardrail", "type": "note"}],
+                "total_available": 1,
+                "truncated": False,
+                "cap": 100,
+            },
+            "recall": {"status": "skipped", "reason": "no_query"},
+            "state": {"status": "ok", "entries": []},
+            "policy": {"status": "skipped", "reason": "no_policy_bundle"},
+        },
+        "correlation": {
+            "agent_id": agent_id,
+            "session_id": "run-42",
+            "run_id": None,
+            "trace_id": None,
+            "span_id": None,
+        },
+        "generated_at": "2026-07-16T00:00:00Z",
+    }
+
+
 @pytest.fixture
 def isolated_kagura_credentials(tmp_path, monkeypatch):
     """Isolate a test from real ``~/.kagura/credentials.json`` and env.

--- a/tests/test__http.py
+++ b/tests/test__http.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
-from kagura_memory._http import extract_detail, validate_https_url
+from kagura_memory._http import extract_detail, normalize_uuid, validate_https_url
 
 
 def _response_with_json(payload: object) -> MagicMock:
@@ -242,6 +242,35 @@ def test_retry_after_seconds_parses_digits_else_none():
     assert _retry_after_seconds(_Resp({"Retry-After": " 45 "})) == 45  # stripped
     assert _retry_after_seconds(_Resp({"Retry-After": "Wed, 21 Oct 2099 07:28:00 GMT"})) is None
     assert _retry_after_seconds(_Resp({})) is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_uuid — shared canonicalize-before-URL-interpolation guard
+# ---------------------------------------------------------------------------
+
+_CANONICAL = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        _CANONICAL,  # canonical passes through unchanged
+        "{" + _CANONICAL + "}",  # braces
+        _CANONICAL.replace("-", ""),  # dashless 32-hex
+        f"urn:uuid:{_CANONICAL}",  # urn prefix
+        _CANONICAL.upper(),  # uppercase → lowercased canonical
+    ],
+)
+def test_normalize_uuid_canonicalizes_tolerated_spellings(spelling: str):
+    """Every spelling ``uuid.UUID`` tolerates must come out canonical."""
+    assert normalize_uuid(spelling, label="agent_id") == _CANONICAL
+
+
+@pytest.mark.parametrize("bad", ["not-a-uuid", "", "../../admin", None, 42])
+def test_normalize_uuid_rejects_non_uuids_with_label(bad):
+    """Garbage (including non-str runtime values) raises with the caller's label."""
+    with pytest.raises(ValueError, match="workspace_id must be a UUID"):
+        normalize_uuid(bad, label="workspace_id")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agents_client.py
+++ b/tests/test_agents_client.py
@@ -1,0 +1,240 @@
+"""Tests for AgentsClient (#231) — the agent-bootstrap REST companion.
+
+Wire shapes assert the memory-cloud v0.49.0 contract verified against the
+server source (RFC-0002 P0-3, memory-cloud #1276): all-optional JSON body,
+``agent_id`` in the URL path, the composed envelope with fail-soft
+per-component statuses, and the uniform 404 (CWE-639) for agent/context.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from kagura_memory.agents_client import AgentsClient, _normalize_agent_id
+from kagura_memory.exceptions import (
+    KaguraAuthError,
+    KaguraConnectionError,
+    KaguraNotFoundError,
+)
+from kagura_memory.models import AgentBootstrapResponse
+
+AGENT = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+CTX = "11111111-2222-3333-4444-555555555555"
+
+ENVELOPE = {
+    "status": "success",
+    "degraded": False,
+    "agent": {
+        "agent_id": AGENT,
+        "name": "ci-agent",
+        "binding": {"context_id": CTX, "is_default": True},
+    },
+    "context": {
+        "id": CTX,
+        "name": "dev",
+        "display_name": "Dev",
+        "summary": "Dev knowledge base",
+        "usage_guide": "Recall before acting.",
+        "is_private": True,
+        "is_locked": False,
+        "embedding_model": "text-embedding-3-small",
+        "embedding_dimensions": 1536,
+    },
+    "instructions": "Recall before acting.\n\nSTANDARD INSTRUCTIONS",
+    "components": {
+        "pinned": {
+            "status": "ok",
+            "memories": [],
+            "total_available": 0,
+            "truncated": False,
+            "cap": 100,
+        },
+        "recall": {"status": "skipped", "reason": "no_query"},
+        "policy": {"status": "skipped", "reason": "no_policy_bundle"},
+    },
+    "correlation": {
+        "agent_id": AGENT,
+        "session_id": "run-42",
+        "run_id": None,
+        "trace_id": None,
+        "span_id": None,
+    },
+    "generated_at": "2026-07-16T00:00:00Z",
+}
+
+
+def make_client(handler) -> AgentsClient:
+    client = AgentsClient(api_key="kagura_test")
+    client._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer kagura_test"},
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_parses_and_ignores_unknown_fields():
+    payload = {**ENVELOPE, "some_future_field": "ignored"}
+    resp = AgentBootstrapResponse.model_validate(payload)
+    assert resp.agent.agent_id == AGENT
+    assert resp.agent.binding is not None and resp.agent.binding.context_id == CTX
+    assert resp.context is not None and resp.context.embedding_dimensions == 1536
+    # Component payloads survive verbatim as dicts.
+    assert resp.components["policy"] == {"status": "skipped", "reason": "no_policy_bundle"}
+    assert resp.generated_at is not None
+
+
+def test_envelope_minimal_shape():
+    # Only agent is required; a maximally degraded response must still parse.
+    resp = AgentBootstrapResponse.model_validate(
+        {"status": "success", "degraded": True, "agent": {"agent_id": AGENT, "name": "a"}}
+    )
+    assert resp.degraded is True
+    assert resp.context is None and resp.components == {}
+
+
+# ---------------------------------------------------------------------------
+# agent_id normalization
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_agent_id_canonical():
+    assert _normalize_agent_id(AGENT) == AGENT
+
+
+def test_normalize_agent_id_noncanonical_spellings():
+    assert _normalize_agent_id("{" + AGENT + "}") == AGENT
+    assert _normalize_agent_id(AGENT.replace("-", "")) == AGENT
+
+
+def test_normalize_agent_id_rejects_garbage():
+    with pytest.raises(ValueError, match="agent_id must be a UUID"):
+        _normalize_agent_id("not-a-uuid")
+
+
+# ---------------------------------------------------------------------------
+# bootstrap()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_minimal_sends_empty_body():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json=ENVELOPE)
+
+    async with make_client(handler) as client:
+        result = await client.bootstrap(AGENT)
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == f"/api/v1/agents/{AGENT}/bootstrap"
+    assert seen["body"] == {}  # all-optional body; server applies defaults
+    assert isinstance(result, AgentBootstrapResponse)
+    assert result.agent.name == "ci-agent"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_full_body():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json=ENVELOPE)
+
+    async with make_client(handler) as client:
+        await client.bootstrap(
+            AGENT,
+            context_id=CTX,
+            session_id="run-42",
+            query="current task",
+            recall_k=7,
+            pinned_cap=50,
+            upcoming_until="2026-08-01T00:00:00",
+            include=["pinned", "recall"],
+        )
+
+    assert seen["body"] == {
+        "context_id": CTX,
+        "session_id": "run-42",
+        "query": "current task",
+        "recall_k": 7,
+        "pinned_cap": 50,
+        "upcoming_until": "2026-08-01T00:00:00",
+        "include": ["pinned", "recall"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_normalizes_agent_id_in_path():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200, json=ENVELOPE)
+
+    async with make_client(handler) as client:
+        await client.bootstrap(AGENT.replace("-", ""))
+
+    assert seen["path"] == f"/api/v1/agents/{AGENT}/bootstrap"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_rejects_non_uuid_before_request():
+    async with make_client(lambda r: httpx.Response(200, json=ENVELOPE)) as client:
+        with pytest.raises(ValueError, match="agent_id must be a UUID"):
+            await client.bootstrap("../../admin")
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_404_raises_not_found():
+    # Uniform 404 — nonexistent and not-yours are indistinguishable (CWE-639).
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "Agent not found"})
+
+    async with make_client(handler) as client:
+        with pytest.raises(KaguraNotFoundError, match="Agent not found"):
+            await client.bootstrap(AGENT)
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_400_raises_connection_error_with_detail():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": "'session_id' allows only [A-Za-z0-9._-]."})
+
+    async with make_client(handler) as client:
+        with pytest.raises(KaguraConnectionError, match="session_id"):
+            await client.bootstrap(AGENT, session_id="bad session")
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_401_raises_auth_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "unauthorized"})
+
+    async with make_client(handler) as client:
+        with pytest.raises(KaguraAuthError):
+            await client.bootstrap(AGENT)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_requires_credentials():
+    with pytest.raises(ValueError, match="from_mcp_url"):
+        AgentsClient()
+
+
+def test_constructor_rejects_plain_http():
+    with pytest.raises(Exception, match="HTTPS"):
+        AgentsClient(api_key="k", base_url="http://memory.example.com")

--- a/tests/test_agents_client.py
+++ b/tests/test_agents_client.py
@@ -11,57 +11,19 @@ import json
 import httpx
 import pytest
 
-from kagura_memory.agents_client import AgentsClient, _normalize_agent_id
+from kagura_memory.agents_client import AgentsClient
 from kagura_memory.exceptions import (
     KaguraAuthError,
     KaguraConnectionError,
     KaguraNotFoundError,
 )
 from kagura_memory.models import AgentBootstrapResponse
+from tests.conftest import bootstrap_envelope_dict
 
 AGENT = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 CTX = "11111111-2222-3333-4444-555555555555"
 
-ENVELOPE = {
-    "status": "success",
-    "degraded": False,
-    "agent": {
-        "agent_id": AGENT,
-        "name": "ci-agent",
-        "binding": {"context_id": CTX, "is_default": True},
-    },
-    "context": {
-        "id": CTX,
-        "name": "dev",
-        "display_name": "Dev",
-        "summary": "Dev knowledge base",
-        "usage_guide": "Recall before acting.",
-        "is_private": True,
-        "is_locked": False,
-        "embedding_model": "text-embedding-3-small",
-        "embedding_dimensions": 1536,
-    },
-    "instructions": "Recall before acting.\n\nSTANDARD INSTRUCTIONS",
-    "components": {
-        "pinned": {
-            "status": "ok",
-            "memories": [],
-            "total_available": 0,
-            "truncated": False,
-            "cap": 100,
-        },
-        "recall": {"status": "skipped", "reason": "no_query"},
-        "policy": {"status": "skipped", "reason": "no_policy_bundle"},
-    },
-    "correlation": {
-        "agent_id": AGENT,
-        "session_id": "run-42",
-        "run_id": None,
-        "trace_id": None,
-        "span_id": None,
-    },
-    "generated_at": "2026-07-16T00:00:00Z",
-}
+ENVELOPE = bootstrap_envelope_dict(agent_id=AGENT, context_id=CTX)
 
 
 def make_client(handler) -> AgentsClient:
@@ -99,27 +61,12 @@ def test_envelope_minimal_shape():
 
 
 # ---------------------------------------------------------------------------
-# agent_id normalization
-# ---------------------------------------------------------------------------
-
-
-def test_normalize_agent_id_canonical():
-    assert _normalize_agent_id(AGENT) == AGENT
-
-
-def test_normalize_agent_id_noncanonical_spellings():
-    assert _normalize_agent_id("{" + AGENT + "}") == AGENT
-    assert _normalize_agent_id(AGENT.replace("-", "")) == AGENT
-
-
-def test_normalize_agent_id_rejects_garbage():
-    with pytest.raises(ValueError, match="agent_id must be a UUID"):
-        _normalize_agent_id("not-a-uuid")
-
-
-# ---------------------------------------------------------------------------
 # bootstrap()
 # ---------------------------------------------------------------------------
+# agent_id normalization/rejection is the shared normalize_uuid helper —
+# its spelling matrix is unit-tested once in tests/test__http.py; here only
+# the client-level behavior (path normalization, pre-request rejection) is
+# asserted.
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 
 from kagura_memory import (
     MIN_SERVER_VERSION,
+    AgentBootstrapResponse,
     ContextInfo,
     DuplicatesResponse,
     EmbeddingStatus,
@@ -3265,3 +3266,188 @@ async def test_list_tags_arg_validation(kwargs, match):
             await client.list_tags(context_id="ctx-1", **kwargs)
     finally:
         await client.close()
+
+
+# ============================================================================
+# get_agent_bootstrap (#231, server v0.49.0+)
+# ============================================================================
+
+_BOOTSTRAP_ENVELOPE = {
+    "status": "success",
+    "degraded": False,
+    "agent": {
+        "agent_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "name": "ci-agent",
+        "binding": {"context_id": "ctx-uuid", "is_default": True},
+    },
+    "context": {
+        "id": "ctx-uuid",
+        "name": "dev",
+        "display_name": "Dev",
+        "summary": "Dev knowledge base",
+        "usage_guide": "Recall before acting.",
+        "is_private": True,
+        "is_locked": False,
+        "embedding_model": "text-embedding-3-small",
+        "embedding_dimensions": 1536,
+    },
+    "instructions": "Recall before acting.\n\nSTANDARD INSTRUCTIONS",
+    "components": {
+        "pinned": {
+            "status": "ok",
+            "memories": [{"memory_id": "m1", "summary": "Guardrail", "type": "note"}],
+            "total_available": 1,
+            "truncated": False,
+            "cap": 100,
+        },
+        "recall": {"status": "skipped", "reason": "no_query"},
+        "state": {"status": "ok", "entries": []},
+    },
+    "correlation": {
+        "agent_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "session_id": "run-42",
+        "run_id": None,
+        "trace_id": None,
+        "span_id": None,
+    },
+    "generated_at": "2026-07-16T00:00:00Z",
+}
+
+
+@pytest.mark.asyncio
+async def test_get_agent_bootstrap_minimal():
+    """get_agent_bootstrap() sends agent_id only and parses the envelope."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = _BOOTSTRAP_ENVELOPE
+        result = await client.get_agent_bootstrap("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+        name, args = mock.call_args[0][0], mock.call_args[0][1]
+        assert name == "get_agent_bootstrap"
+        assert args == {"agent_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}
+
+    assert isinstance(result, AgentBootstrapResponse)
+    assert result.degraded is False
+    assert result.agent.name == "ci-agent"
+    assert result.agent.binding is not None and result.agent.binding.is_default is True
+    # The context block reuses ContextDetail (byte-compatible with get_context_info).
+    assert result.context is not None and result.context.name == "dev"
+    # Component payloads stay dicts — shapes belong to the standalone tools.
+    assert result.components["pinned"]["status"] == "ok"
+    assert result.components["recall"] == {"status": "skipped", "reason": "no_query"}
+    assert result.correlation is not None and result.correlation.session_id == "run-42"
+    assert result.generated_at is not None
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_bootstrap_full_args():
+    """get_agent_bootstrap() forwards every optional argument."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = _BOOTSTRAP_ENVELOPE
+        await client.get_agent_bootstrap(
+            "agent-uuid",
+            context_id="ctx-uuid",
+            session_id="run-42",
+            query="current task",
+            recall_k=7,
+            pinned_cap=50,
+            upcoming_until="2026-08-01T00:00:00",
+            include=["pinned", "recall"],
+        )
+        args = mock.call_args[0][1]
+        assert args == {
+            "agent_id": "agent-uuid",
+            "context_id": "ctx-uuid",
+            "session_id": "run-42",
+            "query": "current task",
+            "recall_k": 7,
+            "pinned_cap": 50,
+            "upcoming_until": "2026-08-01T00:00:00",
+            "include": ["pinned", "recall"],
+        }
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_bootstrap_optional_args_not_sent_when_none():
+    """Omitted optionals must not appear in the tool arguments (server defaults)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = _BOOTSTRAP_ENVELOPE
+        await client.get_agent_bootstrap("agent-uuid")
+        args = mock.call_args[0][1]
+        for key in (
+            "context_id",
+            "session_id",
+            "query",
+            "recall_k",
+            "pinned_cap",
+            "upcoming_until",
+            "include",
+        ):
+            assert key not in args
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_bootstrap_degraded_component():
+    """A failed component parses fail-soft: degraded=True, others intact."""
+    client = _make_initialized_client()
+    envelope = {
+        **_BOOTSTRAP_ENVELOPE,
+        "degraded": True,
+        "components": {
+            "pinned": {"status": "ok", "memories": [], "total_available": 0},
+            "state": {"status": "error", "error": "component_error"},
+        },
+    }
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = envelope
+        result = await client.get_agent_bootstrap("agent-uuid")
+        assert result.degraded is True
+        assert result.components["state"] == {"status": "error", "error": "component_error"}
+        assert result.components["pinned"]["status"] == "ok"
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_bootstrap_agent_not_found_raises():
+    """agent_not_found domain errors raise KaguraNotFoundError (uniform 404)."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "agent_not_found",
+            "message": "Agent not found.",
+        }
+        with pytest.raises(KaguraNotFoundError, match="Agent not found"):
+            await client.get_agent_bootstrap("agent-uuid")
+
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_bootstrap_invalid_arguments_raises():
+    """invalid_arguments domain errors raise the generic KaguraError."""
+    client = _make_initialized_client()
+
+    with patch.object(client, "_call_tool", new_callable=AsyncMock) as mock:
+        mock.return_value = {
+            "status": "error",
+            "error": "invalid_arguments",
+            "message": "'session_id' allows only [A-Za-z0-9._-].",
+        }
+        with pytest.raises(KaguraError, match="invalid_arguments"):
+            await client.get_agent_bootstrap("agent-uuid", session_id="bad session")
+
+    await client.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ from kagura_memory import (
     SleepReportDetail,
     UsageInfo,
 )
-from tests.conftest import sleep_report_summary_dict
+from tests.conftest import bootstrap_envelope_dict, sleep_report_summary_dict
 
 # ============================================================================
 # HTTPS enforcement (C-3)
@@ -3272,46 +3272,7 @@ async def test_list_tags_arg_validation(kwargs, match):
 # get_agent_bootstrap (#231, server v0.49.0+)
 # ============================================================================
 
-_BOOTSTRAP_ENVELOPE = {
-    "status": "success",
-    "degraded": False,
-    "agent": {
-        "agent_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-        "name": "ci-agent",
-        "binding": {"context_id": "ctx-uuid", "is_default": True},
-    },
-    "context": {
-        "id": "ctx-uuid",
-        "name": "dev",
-        "display_name": "Dev",
-        "summary": "Dev knowledge base",
-        "usage_guide": "Recall before acting.",
-        "is_private": True,
-        "is_locked": False,
-        "embedding_model": "text-embedding-3-small",
-        "embedding_dimensions": 1536,
-    },
-    "instructions": "Recall before acting.\n\nSTANDARD INSTRUCTIONS",
-    "components": {
-        "pinned": {
-            "status": "ok",
-            "memories": [{"memory_id": "m1", "summary": "Guardrail", "type": "note"}],
-            "total_available": 1,
-            "truncated": False,
-            "cap": 100,
-        },
-        "recall": {"status": "skipped", "reason": "no_query"},
-        "state": {"status": "ok", "entries": []},
-    },
-    "correlation": {
-        "agent_id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-        "session_id": "run-42",
-        "run_id": None,
-        "trace_id": None,
-        "span_id": None,
-    },
-    "generated_at": "2026-07-16T00:00:00Z",
-}
+_BOOTSTRAP_ENVELOPE = bootstrap_envelope_dict()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #231

## Summary

One-call agent session-start rehydration against memory-cloud **v0.49.0+** (RFC-0002 P0-3, kagura-ai/memory-cloud#1276):

- **`KaguraClient.get_agent_bootstrap()`** — routes the `get_agent_bootstrap` MCP tool through `_call_tool_checked` with all args (`context_id`, `session_id`, `query`, `recall_k`, `pinned_cap`, `upcoming_until`, `include`)
- **`AgentBootstrapResponse`** pydantic envelope — typed `agent`/`binding`/`correlation` blocks, `ContextDetail` reuse for the context block, fail-soft component payloads kept as dicts (their shapes belong to the standalone tools), top-level `degraded` flag
- **`AgentsClient(KaguraRestClient)`** — REST companion for `POST /api/v1/agents/{agent_id}/bootstrap`, for API-key-only callers such as agent-bound member keys (no MCP session needed)
- `agent_not_found` now maps to `KaguraNotFoundError` in `_raise_for_mcp_error`
- `examples/agent_bootstrap.py` (both surfaces) + README compat/coverage rows; `MIN_SERVER_VERSION` stays **0.17.1**

## /simplify follow-up (2nd commit)

- `normalize_uuid(value, label)` hoisted to `_http.py` — shared by `agents_client` and `workspace_client` (avoids the pre-#229 verbatim-copy drift pattern)
- `_bootstrap_payload` in `models.py` keeps the MCP and REST surfaces in lockstep
- `bootstrap_envelope_dict()` conftest builder replaces two divergent envelope fixtures

Wire contract verified against the memory-cloud v0.49.0 source (`agent_bootstrap_service.build_envelope`, `routes/agents.py`).

## Test plan

- [x] 6 MCP-surface tests (minimal/full/omit-None/degraded/agent_not_found/invalid_arguments)
- [x] 10 REST-surface tests (body marshaling, path normalization, pre-request UUID rejection, 400/401/404, constructor guards, model shapes)
- [x] `normalize_uuid` spelling matrix in `test__http.py`
- [x] Full suite: **1554 passed**, ruff clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)