### PR TITLE
fix(files): canonicalize context_id via shared normalize_uuid

### DIFF
--- a/src/kagura_memory/files_client.py
+++ b/src/kagura_memory/files_client.py
@@ -23,7 +23,6 @@ import asyncio
 import base64
 import hashlib
 import mimetypes
-import uuid
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
@@ -41,6 +40,7 @@ from ._http import (
     SDK_VERSION,
     base_url_from_mcp,
     extract_detail,
+    normalize_uuid,
     sanitize_server_detail,
 )
 from ._rest_base import KaguraRestClient
@@ -363,12 +363,12 @@ class FilesClient(KaguraRestClient):
         confirmed = False
         try:
             # Pre-flight validators and source preparation can raise too
-            # (ValueError from _validate_context_id, FileNotFoundError /
+            # (ValueError from _normalize_context_id, FileNotFoundError /
             # ValueError from _prepare_source). They live INSIDE the try so
             # those failures also get a terminal kind=error event before
             # propagating — matching the contract documented in the logger
             # module's "terminal-event" docstring.
-            _validate_context_id(context_id)
+            context_id = _normalize_context_id(context_id)
             resolved_filename, body, sha256_hex = await _prepare_source(source, filename)
             size_bytes = len(body)
             resolved_content_type = _resolve_content_type(content_type, resolved_filename)
@@ -471,7 +471,7 @@ class FilesClient(KaguraRestClient):
                 read is reported as 404 (existence-hiding); a workspace mismatch
                 (wrong ``context_id``) surfaces as a 403 with an actionable hint.
         """
-        _validate_context_id(context_id)
+        context_id = _normalize_context_id(context_id)
         response = await self._request(
             "GET",
             f"/api/v1/files/{file_id}/download-url",
@@ -488,7 +488,7 @@ class FilesClient(KaguraRestClient):
                 v0.41.0); sent as ``workspace_id`` on the query. Omitting it
                 returns 422.
         """
-        _validate_context_id(context_id)
+        context_id = _normalize_context_id(context_id)
         await self._request(
             "DELETE",
             f"/api/v1/files/{file_id}",
@@ -519,7 +519,7 @@ class FilesClient(KaguraRestClient):
             ``next_cursor`` (always ``None`` against the current
             server).
         """
-        _validate_context_id(context_id)
+        context_id = _normalize_context_id(context_id)
         params: dict[str, Any] = {"workspace_id": context_id, "limit": limit}
         if cursor is not None:
             params["cursor"] = cursor
@@ -675,8 +675,8 @@ def _extract_existing_file(error: KaguraConnectionError) -> FileObject | None:
     return FileObject.model_validate(existing)
 
 
-def _validate_context_id(context_id: str) -> None:
-    """Fail fast on a non-UUID ``context_id``.
+def _normalize_context_id(context_id: str) -> str:
+    """Canonicalize ``context_id`` before URL/query interpolation.
 
     The server's ``/api/v1/files/*`` endpoints validate ``workspace_id``
     server-side and return 422, but the round-trip masks a class of
@@ -684,8 +684,17 @@ def _validate_context_id(context_id: str) -> None:
     through to the SDK without resolution. Raising locally turns that
     into a clear ``ValueError`` instead of a generic HTTP status.
 
+    Delegates to the shared :func:`~kagura_memory._http.normalize_uuid`
+    so tolerated non-canonical spellings (``{braces}``, ``urn:uuid:``
+    prefix, dashless 32-hex) are CANONICALIZED rather than sent raw —
+    raw spellings pass a validate-only check but surface server-side as
+    a misleading uniform 404 (#236).
+
     Args:
-        context_id: The workspace UUID to validate.
+        context_id: The workspace UUID to canonicalize.
+
+    Returns:
+        The canonical UUID string.
 
     Raises:
         ValueError: If ``context_id`` is not a parseable UUID. The
@@ -694,8 +703,8 @@ def _validate_context_id(context_id: str) -> None:
             two ways the SDK expects ``context_id`` to be sourced.
     """
     try:
-        uuid.UUID(context_id)
-    except (ValueError, TypeError, AttributeError) as e:
+        return normalize_uuid(context_id, label="context_id")
+    except ValueError as e:
         raise ValueError(
             f"context_id must be a UUID; got {context_id!r}. "
             "Use the OAuth profile's workspace_id, a UUID from "

--- a/tests/test_files_client.py
+++ b/tests/test_files_client.py
@@ -1318,6 +1318,27 @@ async def test_delete_rejects_non_uuid_context_id_locally():
 
 
 @pytest.mark.asyncio
+async def test_list_canonicalizes_noncanonical_context_id_spelling():
+    """Tolerated non-canonical UUID spellings ({braces}, dashless) are
+    CANONICALIZED before the wire, not sent raw (#236) — a validate-only
+    check let them through and they surfaced server-side as a misleading
+    uniform 404."""
+    client = FilesClient(api_key="test", base_url="https://example.com")
+    resp = _ok_response(200, [])
+    resp.json.return_value = []
+
+    with patch.object(client._client, "request", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = resp
+        await client.list(context_id=SAMPLE_CTX_ID.replace("-", ""))
+        await client.list(context_id="{" + SAMPLE_CTX_ID + "}")
+
+    for call in mock_req.call_args_list:
+        assert call[1]["params"]["workspace_id"] == SAMPLE_CTX_ID
+
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_list_with_legacy_bare_array_response():
     """Server v0.15.x returns bare list[FileObjectOut]; SDK wraps it."""
     client = FilesClient(api_key="test", base_url="https://example.com")


### PR DESCRIPTION
Closes #236. Supersedes #237 (auto-closed when its stacked base #232 merged; this is the same single commit rebased onto main).

## Summary

`files_client.py`'s `_validate_context_id` only VALIDATED the workspace UUID before interpolating it into URL paths/query params — `uuid.UUID`-tolerated spellings (`{braces}`, `urn:uuid:`, dashless 32-hex) passed the local check but reached the server RAW, surfacing as a misleading uniform 404. Now renamed `_normalize_context_id`, delegating to the shared `_http.normalize_uuid` (#231) while preserving the files-surface recovery hint. All four call sites (`upload`/`download_url`/`delete`/`list`) send the canonical spelling; `import uuid` dropped.

Behavior-preserving for canonical inputs and all rejection cases (existing `auto`/garbage/empty tests unchanged); canonicalizing for tolerated spellings (new wire-shape test).

## Test plan
- [x] tests/test_files_client.py + tests/test_cli_files.py: 96 passed
- [x] ruff clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)