### PR TITLE
docs: post-v0.37.0 sync — CONTRIBUTING client table + example config

### DIFF
--- a/.kagura.json.example
+++ b/.kagura.json.example
@@ -1,6 +1,5 @@
 {
   "api_key": "kagura_your_api_key",
   "mcp_url": "http://localhost:8080/mcp/w/{workspace_id}",
-  "model": "gpt-5.4-nano",
   "context_id": "auto"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,4 +84,6 @@ All PRs must pass codecov/patch — every changed line needs a test.
 | `ResourceClient` | REST API | Resource token management + data ingestion |
 | `FilesClient` | REST + presigned PUT | File uploads with R2 sha256 checksum binding |
 | `SecretClient` | REST + age crypto | Zero-knowledge secrets — age recipient encryption, local decrypt (server stores only ciphertext) |
+| `WorkspaceClient` | REST API | Workspace member / invitation management + owner-provisioned member keys (owner API key only) |
+| `AgentsClient` | REST API | Agent control plane — bootstrap, registry CRUD, context bindings (server v0.49.0+) |
 | `FileIngestor` | CLI + SDK | Document ingestion (PDF → memory graph + R2 archive) |


### PR DESCRIPTION
Post-release doc audit follow-up (v0.37.0):

- **CONTRIBUTING.md** SDK Architecture table was missing `WorkspaceClient` and `AgentsClient` rows — the same completeness gap Copilot flagged on the README intro table in #234, which only fixed the README copy.
- **.kagura.json.example** still carried the dead `"model"` key — it configured only the removed `KaguraAgent` / `kagura process` (#233); the README's copy of this example already dropped it.

Audited and clean: README (the two remaining `KaguraAgent` mentions are the intentional migration note + compat row), CLAUDE.md, examples/README.md, skills/, .claude-plugin/.

Docs-only; no code paths touched (config/CLI tests re-run green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)