### PR TITLE
fix(auth): skip the refresh call when a profile has no refresh token

### DIFF
--- a/src/kagura_memory/auth/credentials.py
+++ b/src/kagura_memory/auth/credentials.py
@@ -37,6 +37,8 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
+from ..exceptions import KaguraAuthExpiredError
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
@@ -641,6 +643,19 @@ class KaguraOAuth(httpx.Auth):
         # so resolve only at refresh time to avoid a cycle at import time.
         from .device_flow import make_oauth_client, refresh_access_token
 
+        # A profile stored without a refresh token cannot be refreshed.
+        # Going to the network only earns an ``invalid_grant``, whose
+        # message ("refresh token is no longer valid") describes a token
+        # that never existed — the grant never carried offline access.
+        # Fail here instead, naming that. Mirrors typescript-sdk#14.
+        if not base.refresh_token:
+            raise KaguraAuthExpiredError(
+                "This profile was stored without a refresh token, so it "
+                "cannot be refreshed — log in again to get one.\n"
+                "  Run: kagura auth login",
+                base.expires_at,
+            )
+
         async with make_oauth_client() as client:
             token = await refresh_access_token(
                 client,
@@ -657,7 +672,10 @@ class KaguraOAuth(httpx.Auth):
             access_token=token.access_token,
             refresh_token=token.refresh_token or None,
             expires_at=token.expires_at,
-            scope=token.scope,
+            # ``or None`` not the bare value: TokenResponse.scope defaults
+            # to "" when the server omits it, and with_refreshed falls back
+            # only on None — so an omitted scope blanked the stored grant.
+            scope=token.scope or None,
         )
         # We already hold the cross-process lock; write directly rather than via
         # update_profile (which would re-acquire the same lock on a second fd

--- a/tests/test_auth_credentials.py
+++ b/tests/test_auth_credentials.py
@@ -31,6 +31,7 @@ from kagura_memory.auth.credentials import (
     update_profile,
 )
 from kagura_memory.auth.device_flow import TokenResponse
+from kagura_memory.exceptions import KaguraAuthExpiredError
 
 # Gate POSIX-specific behaviour to non-Windows (CI runs Linux):
 #   - the cross-process refresh-dedup tests rely on fcntl serializing two
@@ -460,6 +461,109 @@ async def test_oauth_refreshes_when_within_skew(tmp_path: Path):
     # Persisted to disk too.
     on_disk = load_credentials_file(path).get_profile()
     assert on_disk.access_token == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_oauth_refuses_refresh_without_a_stored_refresh_token(tmp_path: Path):
+    """A profile with no refresh token must fail before any network call.
+
+    Posting ``refresh_token=""`` can only ever earn an ``invalid_grant``,
+    whose message ("refresh token is no longer valid") describes a token
+    that never existed. See typescript-sdk#14.
+    """
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    creds = _sample_creds(
+        refresh_token="",
+        expires_at=datetime.now(UTC) - timedelta(seconds=1),
+    )
+    cf = CredentialsFile()
+    cf.set_profile("default", creds)
+    save_credentials_file(cf, path)
+
+    auth = KaguraOAuth(get_shared_state(path))
+
+    refresh_mock = AsyncMock()
+    with (
+        patch("kagura_memory.auth.device_flow.refresh_access_token", new=refresh_mock),
+        patch(
+            "kagura_memory.auth.device_flow.make_oauth_client",
+            return_value=_AsyncContextStub(),
+        ),
+        pytest.raises(KaguraAuthExpiredError, match="without a refresh token"),
+    ):
+        request = httpx.Request("GET", "https://test/x")
+        flow = auth.async_auth_flow(request)
+        await flow.__anext__()
+
+    refresh_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oauth_force_refresh_refuses_without_a_stored_refresh_token(tmp_path: Path):
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    cf = CredentialsFile()
+    cf.set_profile("default", _sample_creds(refresh_token=""))
+    save_credentials_file(cf, path)
+
+    auth = KaguraOAuth(get_shared_state(path))
+
+    refresh_mock = AsyncMock()
+    with (
+        patch("kagura_memory.auth.device_flow.refresh_access_token", new=refresh_mock),
+        patch(
+            "kagura_memory.auth.device_flow.make_oauth_client",
+            return_value=_AsyncContextStub(),
+        ),
+        pytest.raises(KaguraAuthExpiredError),
+    ):
+        await auth.force_refresh()
+
+    refresh_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_oauth_refresh_keeps_stored_scope_when_server_omits_it(tmp_path: Path):
+    """``TokenResponse.scope`` defaults to "" — that must not blank the grant.
+
+    ``with_refreshed`` falls back only on ``None``, so passing the empty
+    string through overwrote a perfectly good stored scope.
+    """
+    reset_state_cache()
+    path = tmp_path / "creds.json"
+    near_expiry = datetime.now(UTC) + timedelta(seconds=60)
+    cf = CredentialsFile()
+    cf.set_profile(
+        "default",
+        _sample_creds(expires_at=near_expiry, scope="memory:read memory:write"),
+    )
+    save_credentials_file(cf, path)
+
+    auth = KaguraOAuth(get_shared_state(path))
+    refreshed = TokenResponse(
+        access_token="new-token",
+        refresh_token="new-rtok",
+        token_type="Bearer",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        scope="",
+    )
+
+    with (
+        patch(
+            "kagura_memory.auth.device_flow.refresh_access_token",
+            new=AsyncMock(return_value=refreshed),
+        ),
+        patch(
+            "kagura_memory.auth.device_flow.make_oauth_client",
+            return_value=_AsyncContextStub(),
+        ),
+    ):
+        request = httpx.Request("GET", "https://test/x")
+        flow = auth.async_auth_flow(request)
+        await flow.__anext__()
+
+    assert load_credentials_file(path).get_profile().scope == "memory:read memory:write"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Paired with kagura-ai/kagura-memory-typescript-sdk#14 — the two SDKs share
`~/.kagura/credentials.json` byte-for-byte and carried both of these
defects identically, so they are fixed together rather than one side
drifting from the other.

## 1. Refreshing a profile that has no refresh token

`_network_refresh_and_save` passed `base.refresh_token` through unchecked.
When a profile was stored without one — the token response omitted
`refresh_token`, which `kagura auth status` already models as
`refreshable: false` — the refresh still went to the network. Posting
`refresh_token=""` can only earn an `invalid_grant`, which surfaces as:

> Your login expired (refresh token is no longer valid).

That describes a token that never existed. The real cause — the grant
never carried offline access — was gone by the time the user saw
anything, and a round trip was spent to get there.

Now raises `KaguraAuthExpiredError` before the request, naming the actual
cause.

## 2. An omitted scope silently blanked the stored grant

Found while adding the guard above, on the same few lines:

```python
self._state.credentials = base.with_refreshed(
    ...
    refresh_token=token.refresh_token or None,   # correct
    scope=token.scope,                           # not
)
```

`with_refreshed` falls back with `scope if scope is not None else
self.scope`, and `TokenResponse.scope` defaults to `""` when the server
omits it. So `""` passed the `is not None` check and **overwrote a
perfectly good stored scope on every refresh where the server did not
repeat it** — one line below a comment explaining exactly this hazard for
`refresh_token`.

Now `token.scope or None`. The new test fails on `main` with
`assert '' == 'memory:read memory:write'`.

## Verification

- `pytest` — **1555 passed**, 33 skipped
- `ruff check` / `ruff format --check` — clean
- Three new tests: the guard on the auto-refresh path, the guard on
  `force_refresh()`, and the scope-preservation regression. Each asserts
  `refresh_access_token` is never awaited where that is the point.

Note for reviewers: `pytest` in this repo resolves `kagura_memory` from
site-packages unless `PYTHONPATH=src` is set, so a local run can silently
test the installed wheel instead of the working tree. That cost me a
confusing cycle here; the results above are with `PYTHONPATH=src`.
